### PR TITLE
Add the rhiza release workflow and pin CI to its uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,13 @@ jobs:
       #
       # This step is also what replaces `install-uv`. bootstrap.mk curls the uv installer
       # into ./bin because make cannot assume uv exists; a workflow can just say so.
+      #
+      # `version` pins the uv binary itself, not just the action, to the same uv that
+      # rhiza_release.yml builds and publishes with. A gate that passes here on one uv and
+      # a release built on another is a resolver difference nothing would catch.
       - uses: astral-sh/setup-uv@v10.0.1
         with:
+          version: "0.11.16"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
@@ -52,6 +57,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v10.0.1
         with:
+          version: "0.11.16"
           enable-cache: true
 
       # Dogfooding, and not for its own sake: `all` is the aggregate consumers run, so a

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -1,0 +1,528 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# ⚠️  WHY THIS WORKFLOW CANNOT USE A STUB
+#
+# Rhiza normally distributes workflows as thin stubs that delegate to a reusable
+# workflow in this repository via `workflow_call`. That pattern cannot be used here
+# because PyPI Trusted Publishing (OIDC) validates the *exact* workflow file path
+# and repository that invokes `pypa/gh-action-pypi-publish`. When a stub delegates
+# to a reusable workflow in jebel-quant/rhiza, PyPI sees rhiza's repository as the
+# publisher — not the downstream project's — and rejects the OIDC token. This file
+# must therefore be synced directly into each downstream project so that the publish
+# step runs under the correct repository identity.
+#
+# Release Workflow for Python Packages
+#
+# This workflow implements a secure, maintainable release pipeline with distinct phases:
+#
+# 📋 Pipeline Phases:
+#   1. 🔍 Validate Tag - Check tag format and ensure release doesn't already exist
+#   2. 🏗️ Build - Build Python package with Hatch (if [build-system] is defined in pyproject.toml)
+#   3. 📦 Generate SBOM - Create Software Bill of Materials (CycloneDX format)
+#   4. 📝 Draft Release - Create draft GitHub release with build artifacts and SBOM
+#   5. 🚀 Publish to PyPI - Publish package using OIDC or custom feed
+#   6. ✅ Finalize Release - Publish the GitHub release with links
+#
+# 📄 CHANGELOG: not updated here. The release process (rhiza-claude `/release`)
+# folds a freshly generated CHANGELOG.md into the version-bump commit before the
+# tag is pushed, so the tagged commit already carries the changelog — no separate
+# post-tag commit.
+#
+# 📦 SBOM Generation:
+#   - Generated using CycloneDX format (industry standard for software supply chain security)
+#   - Creates both JSON and XML formats for maximum compatibility
+#   - SBOM attestations are created and stored (public repos only)
+#   - Attached to GitHub releases for transparency and compliance
+#   - Skipped if pyproject.toml doesn't exist
+#
+# 🚀 PyPI Publishing:
+#   - Skipped if no dist/ artifacts exist
+#   - Skipped if pyproject.toml contains "Private :: Do Not Upload"
+#   - Uses Trusted Publishing (OIDC) for PyPI (no stored credentials)
+#   - For custom feeds, use PYPI_REPOSITORY_URL and PYPI_TOKEN secrets
+#   - Adds PyPI/custom feed link to GitHub release notes
+#
+# 🔐 Security:
+#   - No PyPI credentials stored; relies on Trusted Publishing via GitHub OIDC
+#   - For custom feeds, PYPI_TOKEN secret is used with default username __token__
+#   - SLSA provenance attestations generated for build artifacts (public repos only)
+#   - SBOM attestations generated for supply chain transparency (public repos only)
+#
+# 📄 Requirements:
+#   - pyproject.toml with top-level version field (for Python packages)
+#   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
+#
+# ✅ To Trigger:
+#   Create and push a version tag:
+#     git tag v1.2.3
+#     git push origin v1.2.3
+#
+# 🎯 For repos without Python packages:
+#   The workflow gracefully skips Python-related steps if pyproject.toml doesn't exist.
+
+
+name: (RHIZA) RELEASE
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Version tag to release (e.g. v1.2.3). Required when called via workflow_call.'
+        required: true
+        type: string
+    secrets:
+      GH_PAT:
+        required: false
+      UV_EXTRA_INDEX_URL:
+        required: false
+      PYPI_TOKEN:
+        required: false
+
+# Queue runs instead of cancelling: a release or sync must never be
+# interrupted mid-publish or mid-push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# Least-privilege default: every job below re-declares exactly the write
+# scopes it needs (Scorecard Token-Permissions). Top-level stays read-only.
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Validation only: reads tags and release state
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Set Tag Variable
+        id: set_tag
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.set_tag.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            DRAFT_STATUS=$(gh release view "$TAG" --json isDraft --jq '.isDraft')
+            if [ "$DRAFT_STATUS" != "true" ]; then
+              echo "::error::Release '$TAG' already exists and is not a draft. Please use a new tag."
+              exit 1
+            else
+              echo "::warning::Release '$TAG' exists as a draft. Will proceed to update it."
+            fi
+          fi
+
+      - name: Ensure the tagged commit is reachable from a branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.set_tag.outputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # Backstop for issue #1454: a release cut on a branch that is then
+          # squash-merged leaves the tag on the pre-squash commit, and the squash
+          # puts the same content on the default branch under a new SHA. The tag is
+          # then permanently orphaned — no branch contains it, `git describe` skips
+          # the release, and a git-cliff regeneration silently deletes that version's
+          # CHANGELOG section because it cannot place a boundary at an unreachable
+          # tag. Publishing from such a tag is never intended, so refuse it.
+          # The checkout above uses fetch-depth: 0; this fetch only adds the remote
+          # branch refs, which a tag-push checkout does not need otherwise.
+          git fetch --no-tags --quiet origin '+refs/heads/*:refs/remotes/origin/*'
+
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+          fi
+          if ! git rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null; then
+            echo "::error::Cannot resolve the default branch 'origin/$DEFAULT_BRANCH' — refusing to release without a reachability check."
+            exit 1
+          fi
+
+          COMMIT=$(git rev-parse "$TAG^{commit}")
+          if git merge-base --is-ancestor "$COMMIT" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "✅ $TAG ($COMMIT) is an ancestor of $DEFAULT_BRANCH"
+            exit 0
+          fi
+
+          # Reachable from some other branch: a maintenance/hotfix release. Legitimate,
+          # but a changelog regenerated from the default branch still cannot see it.
+          BRANCHES=$(git branch -r --contains "$COMMIT" --format='%(refname:short)')
+          if [ -n "$BRANCHES" ]; then
+            echo "::warning::Tag $TAG is not an ancestor of $DEFAULT_BRANCH; it is contained in: $(echo "$BRANCHES" | tr '\n' ' '). A CHANGELOG regenerated from $DEFAULT_BRANCH will not include this release."
+            exit 0
+          fi
+
+          echo "::error::Tag $TAG points at $COMMIT, which no branch contains. It is most likely a pre-squash commit from a squash-merged release branch: re-tag the merged commit on $DEFAULT_BRANCH and delete this tag (issue #1454)."
+          exit 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+
+      - name: Ensure release version is newer than latest published
+        env:
+          TAG: ${{ steps.set_tag.outputs.tag }}
+        run: |
+          # Backstop for issue #1126: refuse a tag that is not strictly newer than the
+          # highest version already released. A diverged branch with a stale pyproject.toml
+          # can otherwise publish an older version (e.g. v0.3.3 after v0.4.0). The bump
+          # tooling enforces the same rule; this guards manually-pushed tags too.
+          git tag -l 'v*' | uv run --with packaging --no-project python3 -c '
+          import sys
+          from packaging.version import Version, InvalidVersion
+
+          new = sys.argv[1].lstrip("v")
+          try:
+              new_v = Version(new)
+          except InvalidVersion:
+              print(f"::error::Tag {sys.argv[1]} is not a valid version")
+              sys.exit(1)
+
+          latest = None
+          for line in sys.stdin:
+              tag = line.strip().lstrip("v")
+              if not tag:
+                  continue
+              try:
+                  candidate = Version(tag)
+              except InvalidVersion:
+                  continue
+              if candidate == new_v:
+                  continue
+              if latest is None or candidate > latest:
+                  latest = candidate
+
+          if latest is not None and new_v <= latest:
+              print(
+                  f"::error::Refusing to release v{new_v}: it is not newer than the latest "
+                  f"released version v{latest} (issue #1126). Sync with the default branch and bump again."
+              )
+              sys.exit(1)
+          print(f"v{new_v} is newer than the latest released version v{latest}" if latest
+                else f"v{new_v} is the first release")
+          ' "$TAG"
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: tag
+    permissions:
+      contents: read
+      id-token: write       # OIDC for attestation signing
+      attestations: write   # SLSA provenance + SBOM attestations (public repos only)
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: Configure git auth for private packages
+        uses: jebel-quant/actions/configure-git-auth@6d52725ca371d609489c5b50236965ad70bbe528 # v1
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Verify version matches tag
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          TAG_VERSION="${{ needs.tag.outputs.tag }}"
+          TAG_VERSION=${TAG_VERSION#v}
+          PROJECT_VERSION=$(uv version --short)
+
+          # Normalize tag version to PEP 440 format for comparison.
+          # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
+          # returns PEP 440 normalized format (e.g., 0.11.1b1).
+          NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
+
+          if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
+            echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
+            exit 1
+          fi
+          echo "Version verified: $PROJECT_VERSION matches tag (normalized: $NORMALIZED_TAG)"
+
+      - name: Detect buildable Python package
+        id: buildable
+        run: |
+          if [[ -f pyproject.toml ]] && grep -q '^\[build-system\]' pyproject.toml; then
+            echo "buildable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "buildable=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.buildable.outputs.buildable == 'true'
+        run: |
+          printf "[INFO] Building package...\n"
+          uv build
+
+      - name: Install Python for SBOM generation
+        if: hashFiles('pyproject.toml') != ''
+        uses: actions/setup-python@v6.3.0
+        with:
+          python-version-file: .python-version
+
+      - name: Sync environment for SBOM generation
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          export UV_EXTRA_INDEX_URL="${{ secrets.UV_EXTRA_INDEX_URL }}"
+          uv sync --all-extras --all-groups --frozen
+
+      - name: Generate SBOM (CycloneDX)
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          printf "[INFO] Generating SBOM in CycloneDX format...\n"
+          # Note: uvx caches the tool environment, so the second call is fast
+          uvx --from 'cyclonedx-bom>=7.0.0' cyclonedx-py environment --pyproject pyproject.toml --of JSON -o sbom.cdx.json
+          uvx --from 'cyclonedx-bom>=7.0.0' cyclonedx-py environment --pyproject pyproject.toml --of XML -o sbom.cdx.xml
+          printf "[INFO] SBOM generation complete\n"
+          printf "Generated files:\n"
+          ls -lh sbom.cdx.*
+
+      - name: Attest SBOM
+        # Attest only the JSON format as it's the canonical machine-readable format.
+        # The XML format is provided for compatibility but doesn't need separate attestation.
+        id: attest-sbom
+        if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: sbom.cdx.json
+          sbom-path: sbom.cdx.json
+
+      - name: Stage SBOM attestation for the GitHub release
+        # Attach the SBOM's Sigstore attestation bundle to the release as a
+        # recognised signature asset (*.sigstore.json). Non-buildable repos
+        # (no [build-system], so no dist/*.intoto.jsonl provenance) would
+        # otherwise ship releases without any signature asset, which fails
+        # OpenSSF Scorecard's Signed-Releases check.
+        if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
+        run: cp "${{ steps.attest-sbom.outputs.bundle-path }}" sbom.cdx.json.sigstore.json
+
+      - name: Upload SBOM artifacts
+        if: hashFiles('pyproject.toml') != ''
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sbom
+          path: |
+            sbom.cdx.json
+            sbom.cdx.xml
+            sbom.cdx.json.sigstore.json
+
+      - name: Generate SLSA provenance attestations
+        id: provenance
+        if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
+        uses: actions/attest-build-provenance@v4.2.2
+        with:
+          subject-path: dist/*
+
+      - name: Stage provenance bundle for the GitHub release
+        # Attach the SLSA provenance bundle to the release as a recognised
+        # signature asset (*.intoto.jsonl) so consumers — and OpenSSF
+        # Scorecard's Signed-Releases check — can verify the artifacts.
+        if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
+        run: cp "${{ steps.provenance.outputs.bundle-path }}" dist/provenance.intoto.jsonl
+
+      - name: Upload dist artifact
+        if: steps.buildable.outputs.buildable == 'true'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dist
+          path: dist
+
+  # Don't try to upload artifacts to GitHub Release at all
+  draft-release:
+    name: Draft GitHub Release
+    runs-on: ubuntu-latest
+    needs: [tag, build]
+    permissions:
+      contents: write   # Needed to create the GitHub release and upload artifacts
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+
+      - name: Generate release notes with git-cliff
+        run: uvx git-cliff --latest --output RELEASE_NOTES.md
+
+      - name: Download SBOM artifact
+        # Downloads sbom.cdx.json and sbom.cdx.xml into sbom/ directory
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+          path: sbom
+        continue-on-error: true
+
+      - name: Download dist artifact
+        # Brings in provenance.intoto.jsonl (and the built distributions) staged
+        # by the build job, so the SLSA provenance ships as a release asset.
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist
+        continue-on-error: true
+
+      - name: Create GitHub Release with artifacts
+        uses: ncipollo/release-action@v1.21.0
+        with:
+          tag: ${{ needs.tag.outputs.tag }}
+          name: ${{ needs.tag.outputs.tag }}
+          bodyFile: RELEASE_NOTES.md
+          draft: true
+          allowUpdates: true
+          artifacts: "sbom/*,dist/provenance.intoto.jsonl"
+
+  # Decide at step-level whether to publish
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [tag, build, draft-release]
+    permissions:
+      contents: read
+      id-token: write   # OIDC Trusted Publishing to PyPI (no stored credentials)
+    outputs:
+      should_publish: ${{ steps.check_dist.outputs.should_publish }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist
+        # Continue if dist folder is not found. Don't fail the job.
+        continue-on-error: true
+
+      - name: Check if dist contains artifacts and not marked as private
+        id: check_dist
+        run: |
+          if [[ ! -d dist ]]; then
+            echo "::warning::No folder dist/. Skipping PyPI publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            if grep -R "Private :: Do Not Upload" pyproject.toml; then
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          cat "$GITHUB_OUTPUT"
+
+      - name: Remove non-distribution files before publish
+        # The dist artifact also carries the SLSA provenance bundle (staged for
+        # the GitHub release). twine/pypi-publish rejects it as an unknown
+        # distribution format, so strip it here before publishing.
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        run: rm -f dist/*.intoto.jsonl
+
+      # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
+      # repository-url and password only used for custom feeds, not for PyPI with OIDC
+      - name: Publish to PyPI
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        uses: pypa/gh-action-pypi-publish@v1.14.2
+        with:
+          packages-dir: dist/
+          skip-existing: true
+          repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+          password: ${{ secrets.PYPI_TOKEN }}
+
+
+  finalise-release:
+    name: Finalise Release
+    runs-on: ubuntu-latest
+    needs: [tag, pypi]
+    if: needs.pypi.result == 'success'
+    permissions:
+      contents: write   # Needed to undraft/publish the GitHub release
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7.6.0
+        with:
+          version: "0.11.16"
+
+      - name: "Sync the virtual environment for ${{ github.repository }}"
+        shell: bash
+        run: |
+          export UV_EXTRA_INDEX_URL="${{ secrets.uv_extra_index_url }}"
+          # will just use .python-version?
+          uv sync --all-extras --all-groups --frozen
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.3.0
+
+      - name: Generate PyPI Link
+        id: pypi_link
+        if: needs.pypi.outputs.should_publish == 'true' && needs.pypi.result == 'success'
+        run: |
+          PACKAGE_NAME=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
+          VERSION="${{ needs.tag.outputs.tag }}"
+          VERSION=${VERSION#v}
+
+          REPO_URL="${{ vars.PYPI_REPOSITORY_URL || '' }}"
+          if [ -z "$REPO_URL" ]; then
+             LINK="https://pypi.org/project/$PACKAGE_NAME/$VERSION/"
+             NAME="PyPI Package"
+          else
+             LINK="$REPO_URL"
+             NAME="Custom Feed Package"
+          fi
+
+          {
+            echo "message<<EOF"
+            echo "### $NAME"
+            echo ""
+            echo "[$PACKAGE_NAME]($LINK)"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.tag.outputs.tag }}
+          PYPI_MSG: ${{ steps.pypi_link.outputs.message }}
+        run: |
+          # Get existing auto-generated release notes (gracefully handle missing release)
+          EXISTING=$(gh release view "$TAG" --json body --jq '.body // ""' 2>/dev/null || echo "")
+
+          # Append links to release body
+          {
+            printf '%s' "$EXISTING"
+            [ -n "$PYPI_MSG" ] && printf '\n\n%s' "$PYPI_MSG"
+          } > /tmp/notes.md
+
+          gh release edit "$TAG" --draft=false --notes-file /tmp/notes.md


### PR DESCRIPTION
## What

- Adds `.github/workflows/rhiza_release.yml`, copied **verbatim** from `jebel-quant/pytest-rhiza` (byte-identical).
- Pins the uv binary to `0.11.16` in both `setup-uv` steps of `ci.yml`.

## Why the release workflow is synced, not stubbed

Its own header explains it: PyPI Trusted Publishing (OIDC) validates the *exact* workflow file path and repository that invokes `pypa/gh-action-pypi-publish`. A thin stub delegating to a reusable workflow in `jebel-quant/rhiza` would make PyPI see rhiza as the publisher rather than this repo, and reject the token. The file has to live here.

## Why the uv pin, and in this direction

The release workflow builds and publishes with uv `0.11.16`; CI took whatever uv `setup-uv` happened to install. The binary is what resolves dependencies and runs the gates, so a gate passing here on one resolver while the release builds on another is the skew that can actually bite.

`setup-uv` stays at `@v10.0.1`. Aligning the *action* instead would mean downgrading to the release workflow's `@v7.6.0` — a regression the existing comment on that step argues against.

## Prerequisites checked in this repo

| Requirement | State |
|---|---|
| `.python-version` (SBOM setup-python step) | present — `3.11` |
| `[build-system]` + top-level `version` | present, so build/SBOM/publish all run |
| `uv.lock` for `uv sync --frozen` | present |
| `[tool.bumpversion]` for the `/release` bump | present |

## ⚠️ Before pushing a `v*` tag

This repo carries **no** `Private :: Do Not Upload` classifier, so `should_publish=true` and the workflow will attempt a real publish. That needs:

1. `rhiza-task` registered on PyPI as a Trusted Publisher for `Jebel-Quant/rhiza-task`, workflow `rhiza_release.yml`, environment `release`.
2. A `release` environment on the repo.

Without both, the `pypi` job fails and `finalise-release` never undrafts the GitHub release.

## Known loose ends, deliberately not touched here

- `rhiza_release.yml` is internally inconsistent upstream: its `build` and `finalise-release` jobs pin uv `0.11.16`, but `tag` and `draft-release` use unpinned `setup-uv@v7.6.0`. Fixing that belongs in `jebel-quant/rhiza` — a local edit would be reverted by the next `/rhiza:update`.
- `0.11.16` is now hardcoded in two files. A uv bump needs both; worth a grep in the release checklist.
- No `cliff.toml` here, so `uvx git-cliff --latest` falls back to its built-in config for release notes — same as pytest-rhiza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)