### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [0.1.1] - 2026-08-18
+
 ## [0.1.0] - unreleased
 
 Initial extraction. Replaces `.rhiza/rhiza.mk` and `.rhiza/make.d/*.mk` (1023 synced

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.1.0"
+version = "0.1.1"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.1.0 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@0.1.1 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -9,7 +9,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.1.0
+RHIZA_TASK ?= rhiza-task@0.1.1
 
 .DEFAULT_GOAL := help
 

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
## chore: release v0.1.1

Version bump `0.1.0` → `0.1.1`, the **first** release of this package — no tags exist yet.

⚠️ **Merging this PR does not publish the release.** No tag is created here. The tag is cut afterwards, from the merged commit, by a second `/rhiza:release` run — a tag made before the merge would name a SHA that a squash-merge discards.

### Files the bump touched

| File | Change | How it's declared |
|---|---|---|
| `pyproject.toml` | `[project] version` → `0.1.1` | bump-my-version PEP-621 support (no `[[files]]` entry needed) |
| `src/rhiza_task/__init__.py` | `__version__` → `0.1.1`, plus the `uvx rhiza-task@0.1.1` docstring example | `[[tool.bumpversion.files]]` |
| `src/rhiza_task/templates/Makefile` | `RHIZA_TASK ?= rhiza-task@0.1.1` | `[[tool.bumpversion.files]]` with an explicit search/replace |
| `uv.lock` | `rhiza-task` `0.1.0` → `0.1.1` | `uv lock` — see below |
| `CHANGELOG.md` | new `## [0.1.1]` section | `git-cliff --unreleased --tag` |

`[tool.bumpversion]` carries no `current_version` key; bump-my-version derived `0.1.0` from `[project].version`, so nothing needed hand-editing.

### Why `uv.lock` is in this commit

The lockfile pinned `rhiza-task 0.1.0`, and the bump made it stale — `uv lock --check` failed. The release workflow's `build` job runs `uv sync --all-extras --all-groups --frozen`, which refuses a stale lockfile, so without this the release would have died before building the package or generating the SBOM. One line changed; no dependency moved.

### Two changelog caveats for the reviewer

1. **The `[0.1.1]` section is empty.** None of the 6 commits in this repo are conventional-commit shaped, so `git-cliff` skipped all of them as parse errors. There is no `cliff.toml`, so it ran on the default config.
2. **`## [0.1.0] - unreleased` is now misleading.** That hand-written section describes the initial extraction — which is exactly what `v0.1.1` will ship, since `0.1.0` was never tagged and never will be. Consider folding it into the `[0.1.1]` heading before merging; I left it untouched rather than rewriting hand-authored prose.

Also note `git-cliff --prepend` placed the new heading *above* the `# Changelog` H1 (a consequence of running without a `cliff.toml`). I reverted that and placed the section below the H1; the diff shows only the added heading.

### Version guard

`v0.1.1` strictly increases past the floor `v0.1.0` (`current 0.1.0`, highest tag: none). Verified by `check_version_bump.py` before anything was written.

### After merge

Re-run `/rhiza:release`. It will detect phase B (declared version ahead of the highest tag), re-run the guard against the merged history, then create and push `v0.1.1` — which triggers `rhiza_release.yml` and the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
