### PR TITLE
fix(config): treat an empty setting as unset, and floor the CI OS matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Five layers, lowest precedence first: dataclass defaults → `.rhiza/.env` (kept
 → `[tool.rhiza-task]` in `pyproject.toml` → `RHIZA_*` or bare make-style environment
 variables → command-line flags.
 
+An **empty value is unset** in the two string-valued layers: `RHIZA_CI_OS_MATRIX=` in
+`.rhiza/.env`, or an exported empty string, leaves the layer below it alone rather than
+resolving to `""`. That is make's `$(or ...)` rule, and the reusable workflows depend on
+it — `rhiza_ci.yml` exports one `RHIZA_CI_OS_MATRIX` for every caller and deliberately
+leaves it empty for consumers, whose own `.rhiza/.env` is meant to answer.
+
 ```toml
 [tool.rhiza-task]
 source_folder = "src"

--- a/src/rhiza_task/cli.py
+++ b/src/rhiza_task/cli.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__, runner
-from .config import Config
+from .config import DEFAULT_CI_OS_MATRIX, Config
 from .runner import Status
 from .spec import REGISTRY
 
@@ -86,8 +86,16 @@ def print_setting(name: str) -> None:
 
 @app.command("ci-os-matrix")
 def ci_os_matrix() -> None:
-    """Emit the CI OS matrix as a JSON array, for a GitHub Actions matrix input."""
-    print(json.dumps(list(Config.load().ci_os_matrix)))
+    """Emit the CI OS matrix as a JSON array, for a GitHub Actions matrix input.
+
+    Never emits ``[]``. A GitHub matrix with no OS in it does not fail the workflow -- it
+    expands to zero jobs, so the ``test`` job disappears and CI goes green having run
+    nothing. The retired make recipe guarded that with ``$(or $(RHIZA_CI_OS_MATRIX),
+    ["ubuntu-latest"])`` and this is the same floor: after :func:`~rhiza_task.config`
+    resolution an empty value can only come from an explicit ``RHIZA_CI_OS_MATRIX=[]``,
+    which is a mistake in every case a caller has ever meant.
+    """
+    print(json.dumps(list(Config.load().ci_os_matrix) or list(DEFAULT_CI_OS_MATRIX)))
 
 
 @app.command("shim")

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -54,6 +54,15 @@ layer had nowhere else to put it.
 """
 
 
+DEFAULT_CI_OS_MATRIX = ("ubuntu-latest",)
+"""The OS every consumer gets unless it asks for more.
+
+Named rather than inlined because two callers need the same value: the field default
+below, and the floor in ``rhiza-task ci-os-matrix`` that stops an explicitly empty
+setting reaching GitHub as a zero-job matrix.
+"""
+
+
 @dataclass
 class Config:
     """Resolved settings for one repository.
@@ -84,7 +93,7 @@ class Config:
     mkdocs_extra_packages: tuple[str, ...] = ()
     zensical_version: str = ">=0.0.36"
     uv_sync_args: tuple[str, ...] = ("--all-extras", "--all-groups")
-    ci_os_matrix: tuple[str, ...] = ("ubuntu-latest",)
+    ci_os_matrix: tuple[str, ...] = DEFAULT_CI_OS_MATRIX
 
     # Pinned to a tag rather than a branch: a gate that moves under you is not a gate.
     pytest_rhiza: str = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0"
@@ -164,6 +173,11 @@ class Config:
 def _from_env_file(path: Path) -> dict[str, Any]:
     """Read ``.rhiza/.env``.
 
+    An empty assignment (``RHIZA_CI_OS_MATRIX=``) is dropped rather than carried as an
+    empty string, for the reason given in :func:`_from_environ`: no field's type has a
+    meaningful empty value, so the only thing an empty setting can sensibly mean is
+    "leave the lower layer alone".
+
     Args:
         path: Path to the dotenv file.
 
@@ -172,7 +186,7 @@ def _from_env_file(path: Path) -> dict[str, Any]:
     """
     if not path.is_file():
         return {}
-    return {_key(k): _coerce(v) for k, v in dotenv_values(path).items() if v is not None}
+    return {_key(k): _coerce(v) for k, v in dotenv_values(path).items() if v and v.strip()}
 
 
 def _from_pyproject(path: Path) -> dict[str, Any]:
@@ -200,6 +214,18 @@ def _from_environ(environ: Mapping[str, str]) -> dict[str, Any]:
     reusable workflows currently pass bare make-style names on the command line and those
     jobs must keep working through the transition.
 
+    **An empty value counts as unset.** This is not a nicety, it is the make semantics
+    this layer replaces. rhiza_ci.yml's ``generate-matrix`` job exports
+
+        RHIZA_CI_OS_MATRIX: ${{ github.repository == 'jebel-quant/rhiza'
+                               && '["ubuntu-latest","macos-latest"]' || '' }}
+
+    -- one variable, set for the mother repo and *deliberately empty* for every consumer,
+    whose own ``.rhiza/.env`` is then meant to answer. make's ``?=`` treats an exported
+    empty string as set, which is why the retired ``ci-os-matrix`` recipe resolved through
+    ``$(or ...)``; dropping empties here is the same rule, applied one layer earlier so
+    every setting gets it rather than only the one whose recipe remembered to ask.
+
     Args:
         environ: The environment mapping.
 
@@ -208,7 +234,7 @@ def _from_environ(environ: Mapping[str, str]) -> dict[str, Any]:
 
     """
     known = {f.name for f in fields(Config)}
-    return {_key(k): _coerce(v) for k, v in environ.items() if _key(k) in known}
+    return {_key(k): _coerce(v) for k, v in environ.items() if _key(k) in known and v.strip()}
 
 
 def _key(name: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,42 @@ def test_ci_os_matrix_emits_json(repo: Path, monkeypatch: pytest.MonkeyPatch) ->
     assert json.loads(result.stdout) == ["ubuntu-latest", "windows-latest"]
 
 
+def test_ci_os_matrix_never_emits_an_empty_array(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicitly empty setting floors to the default rather than to zero jobs.
+
+    GitHub does not fail a workflow over an empty matrix; it expands it to no jobs at all,
+    so the gate goes green having tested nothing.
+
+    Args:
+        repo: The throwaway repository.
+        monkeypatch: pytest's patcher.
+    """
+    (repo / ".rhiza").mkdir()
+    (repo / ".rhiza" / ".env").write_text("RHIZA_CI_OS_MATRIX=[]\n")
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli.app, ["ci-os-matrix"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == ["ubuntu-latest"]
+
+
+def test_ci_os_matrix_ignores_an_empty_environment_override(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The consumer's ``.rhiza/.env`` still answers when the workflow exports an empty var.
+
+    This is the contract rhiza_ci.yml's ``generate-matrix`` job depends on once it calls
+    the CLI instead of ``make -f .rhiza/rhiza.mk -s ci-os-matrix``.
+
+    Args:
+        repo: The throwaway repository.
+        monkeypatch: pytest's patcher.
+    """
+    (repo / ".rhiza").mkdir()
+    (repo / ".rhiza" / ".env").write_text('RHIZA_CI_OS_MATRIX=["macos-latest"]\n')
+    monkeypatch.setenv("RHIZA_CI_OS_MATRIX", "")
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli.app, ["ci-os-matrix"])
+    assert json.loads(result.stdout) == ["macos-latest"]
+
+
 def test_shim_prints_a_usable_makefile() -> None:
     """``shim`` emits the catch-all Makefile, pinned to this version."""
     from rhiza_task import __version__

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,40 @@ def test_environ_beats_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     assert Config.load(root=tmp_path).source_folder == "from-env"
 
 
+def test_empty_environ_value_is_not_an_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exported empty string leaves the lower layer alone.
+
+    rhiza_ci.yml's ``generate-matrix`` job exports ``RHIZA_CI_OS_MATRIX`` unconditionally
+    and sets it to ``''`` for every repository that is not the template's own, expecting
+    the consumer's ``.rhiza/.env`` to answer instead. Honouring that empty string would
+    hand GitHub a zero-OS matrix and silently delete the test job.
+
+    Args:
+        tmp_path: The repository root.
+        monkeypatch: pytest's patcher.
+    """
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text('RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest"]\n')
+    monkeypatch.setenv("RHIZA_CI_OS_MATRIX", "")
+    assert Config.load(root=tmp_path).ci_os_matrix == ("ubuntu-latest", "macos-latest")
+
+    monkeypatch.setenv("RHIZA_CI_OS_MATRIX", "   ")
+    assert Config.load(root=tmp_path).ci_os_matrix == ("ubuntu-latest", "macos-latest")
+
+
+def test_empty_env_file_value_is_not_an_override(tmp_path: Path) -> None:
+    """An empty assignment in ``.rhiza/.env`` does not shadow the default either.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text("SOURCE_FOLDER=\nTYPECHECKER=mypy\n")
+    cfg = Config.load(root=tmp_path)
+    assert cfg.source_folder == "src"
+    assert cfg.typechecker == "mypy"
+
+
 def test_overrides_beat_everything(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A command-line override is the last word, and ``None`` is not an override.
 


### PR DESCRIPTION
## Why

`rhiza-task ci-os-matrix` already exists and already reads `RHIZA_CI_OS_MATRIX` out of `.rhiza/.env` — which means the reusable `rhiza_ci.yml` could stop calling

```
make -f .rhiza/rhiza.mk -s ci-os-matrix
```

That call is the *only* thing keeping a make file alive in a repo that has migrated to this CLI: jointview's `.rhiza/rhiza.mk` is four repo-owned lines whose entire job is to answer it. Two gaps had to close first, both of them make semantics this layer had not carried over.

## Empty means unset

`generate-matrix` exports the variable unconditionally:

```yaml
env:
  RHIZA_CI_OS_MATRIX: >-
    ${{ github.repository == 'jebel-quant/rhiza'
        && '["ubuntu-latest","macos-latest"]' || '' }}
```

Set for the mother repo, deliberately empty for every consumer, whose own `.rhiza/.env` is meant to answer. make's `?=` treats an exported empty string as set, which is exactly why the retired recipe resolved through `$(or ...)`. `_from_environ` did not:

```console
$ RHIZA_CI_OS_MATRIX='' uvx rhiza-task@0.1.1 ci-os-matrix
[]
```

Empty values are now dropped in both string-valued layers (`.rhiza/.env` and the environment), one layer earlier than the old recipe's guard, so every setting gets the rule rather than only the one whose recipe remembered to ask. No field's type has a meaningful empty value, so the only thing an empty setting can mean is "leave the layer below alone".

## The floor

GitHub does not fail a workflow over an empty matrix — it expands to zero jobs, the `test` job disappears, and CI goes green having run nothing. `ci-os-matrix` now emits `DEFAULT_CI_OS_MATRIX` rather than `[]`, which is the guard `$(or $(RHIZA_CI_OS_MATRIX),["ubuntu-latest"])` provided. After the change above, an empty tuple can only come from an explicit `RHIZA_CI_OS_MATRIX=[]`.

## Verification

- `uv run pytest` — 125 passed, up from 121 on `main` (four new: two in `test_config.py`, two in `test_cli.py`)
- `uv run rhiza-task all` — every gate `ok`, `fmt` skipped as it is in CI (no `.pre-commit-config.yaml` here)
- `uvx ruff format --check` / `ruff check` — clean

## Follow-ups this unblocks

1. A release, so the workflow can pin it.
2. `jebel-quant/rhiza`: `generate-matrix` gets `setup-uv` and calls `uvx rhiza-task@<version> ci-os-matrix`.
3. Consumers delete `.rhiza/rhiza.mk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
