### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.2] - 2026-08-18
+
+### 🐛 Bug Fixes
+
+- *(config)* Treat an empty setting as unset, and floor the CI OS matrix
+
 ## [0.1.1] - 2026-08-18
 
 ## [0.1.0] - unreleased

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.1.1"
+version = "0.1.2"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.1.1 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@0.1.2 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -9,7 +9,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.1.1
+RHIZA_TASK ?= rhiza-task@0.1.2
 
 .DEFAULT_GOAL := help
 

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Release **v0.1.1 → v0.1.2** (patch: one `fix`, no features, no breaking changes).

## Version locations updated

`bump-my-version` rewrote every location the repo declares in `[tool.bumpversion]`:

| File | Change |
| --- | --- |
| `pyproject.toml` | `[project] version` → `0.1.2` (PEP 621 location, auto-detected) |
| `src/rhiza_task/__init__.py` | `__version__` → `0.1.2`, plus the `uvx rhiza-task@…` example in the module docstring |
| `src/rhiza_task/templates/Makefile` | `RHIZA_TASK ?= rhiza-task@0.1.2` — the shim's default pin, so a consumer generating a Makefile from this release gets this release |
| `uv.lock` | own package entry refreshed via `uv lock` (self-version line only) |

No hand-edits: every version location came from config.

## Changelog

One section prepended under the `# Changelog` title, leaving existing sections untouched:

```markdown
## [0.1.2] - 2026-08-18

### 🐛 Bug Fixes

- *(config)* Treat an empty setting as unset, and floor the CI OS matrix
```

## Merging this PR does not publish the release

There is **no tag yet**, deliberately. A tag has to point at a commit that exists on
`main`, and a squash-merge replaces this branch's commit with a new one — so the tag is
cut *after* the merge, from the merged commit, by a second `/rhiza:release` run. Until
then nothing is published.
