### PR TITLE
fix(config): split a string reaching a tuple field

### DIFF
--- a/src/rhiza_task/cli.py
+++ b/src/rhiza_task/cli.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__, runner
-from .config import DEFAULT_CI_OS_MATRIX, Config
+from .config import DEFAULT_CI_OS_MATRIX, Config, _key
 from .runner import Status
 from .spec import REGISTRY
 
@@ -76,7 +76,7 @@ def print_setting(name: str) -> None:
         typer.Exit: With status 2 when the setting does not exist.
     """
     cfg = Config.load()
-    field = name.removeprefix("RHIZA_").lower().replace("-", "_")
+    field = _key(name)
     if not hasattr(cfg, field):
         err.print(f"[red]unknown setting: {name}[/red]")
         raise typer.Exit(2)

--- a/src/rhiza_task/cli.py
+++ b/src/rhiza_task/cli.py
@@ -81,7 +81,15 @@ def print_setting(name: str) -> None:
         err.print(f"[red]unknown setting: {name}[/red]")
         raise typer.Exit(2)
     value = getattr(cfg, field)
-    console.print(" ".join(map(str, value)) if isinstance(value, tuple) else str(value))
+    # markup=False, highlight=False: ``print`` is the command you reach for when a setting
+    # is not doing what you expect, so it must show the stored value and nothing else.
+    # ``mkdocs_extra_packages = ("mkdocstrings[python]",)`` printed as ``mkdocstrings``
+    # otherwise, rich having read ``[python]`` as a style tag.
+    console.print(
+        " ".join(map(str, value)) if isinstance(value, tuple) else str(value),
+        markup=False,
+        highlight=False,
+    )
 
 
 @app.command("ci-os-matrix")

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -107,12 +107,34 @@ class Config:
     root: Path = field(default_factory=Path.cwd)
 
     def __post_init__(self) -> None:
-        """Validate the enumerated and numeric fields.
+        """Normalise the list fields, then validate the enumerated and numeric ones.
+
+        :func:`_coerce` sees a string without knowing which field it is destined for, so
+        it can only recognise the two shapes that announce themselves -- a JSON array and
+        a ``;``-separated list. Everything else it leaves as a ``str``, and a ``str``
+        reaching a ``tuple[str, ...]`` field is splatted one *character* per argument at
+        the call site: ``UV_SYNC_ARGS="--group test"`` became ``uv sync - - g r o u p``.
+
+        The field's type is known here and nowhere lower, so this is where a string
+        becomes a tuple. Splitting on whitespace is the make layer's own format --
+        python.mk documented ``LICENSE_IGNORE_PACKAGES`` as space-separated and
+        ``RHIZA_CHECKS`` accumulated space-separated module names -- so a ``.rhiza/.env``
+        written for make keeps working, as does the ``UV_SYNC_ARGS`` that rhiza's synced
+        ``.devcontainer/bootstrap.sh`` exports.
 
         Raises:
             ValueError: When ``typechecker`` is not one of ty, mypy, both, or
                 ``coverage_fail_under`` is outside 0-100.
         """
+        for f in fields(self):
+            if str(f.type).replace(" ", "") != "tuple[str,...]":
+                continue
+            value = getattr(self, f.name)
+            if isinstance(value, str):
+                object.__setattr__(self, f.name, tuple(value.split()))
+            elif isinstance(value, list):
+                object.__setattr__(self, f.name, tuple(value))
+
         if self.typechecker not in TYPECHECKERS:
             msg = f"typechecker must be one of {', '.join(TYPECHECKERS)} (got {self.typechecker!r})"
             raise ValueError(msg)

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -192,6 +192,10 @@ class Config:
         return cls(root=root, **{k: v for k, v in raw.items() if k in known})
 
 
+_FIELD_NAMES = frozenset(f.name for f in fields(Config))
+"""Every field name, for :func:`_key`. Built once rather than per environment variable."""
+
+
 def _from_env_file(path: Path) -> dict[str, Any]:
     """Read ``.rhiza/.env``.
 
@@ -255,20 +259,32 @@ def _from_environ(environ: Mapping[str, str]) -> dict[str, Any]:
         Parsed settings.
 
     """
-    known = {f.name for f in fields(Config)}
-    return {_key(k): _coerce(v) for k, v in environ.items() if _key(k) in known and v.strip()}
+    settings = ((_key(k), v) for k, v in environ.items())
+    return {k: _coerce(v) for k, v in settings if k in _FIELD_NAMES and v.strip()}
 
 
 def _key(name: str) -> str:
     """Normalise a make-style variable name to a field name.
 
+    The ``RHIZA_`` prefix is optional, so it is stripped -- but only when what remains is
+    actually a field. Stripping unconditionally made ``RHIZA_CHECKS`` resolve to the
+    unknown field ``checks``, so the setting was silently dropped and ``rhiza_checks`` was
+    reachable from the environment only as ``RHIZA_RHIZA_CHECKS``. Trying the whole name
+    as a fallback fixes that without disturbing the fields whose prefix *is* redundant:
+    ``RHIZA_CI_OS_MATRIX`` still resolves to ``ci_os_matrix``, and the doubled spelling
+    keeps working for anyone who found it.
+
     Args:
-        name: e.g. ``RHIZA_CI_OS_MATRIX`` or ``SOURCE_FOLDER``.
+        name: e.g. ``RHIZA_CI_OS_MATRIX``, ``SOURCE_FOLDER`` or ``rhiza-checks``.
 
     Returns:
-        e.g. ``ci_os_matrix``, ``source_folder``.
+        e.g. ``ci_os_matrix``, ``source_folder``, ``rhiza_checks``.
     """
-    return name.removeprefix("RHIZA_").lower()
+    lowered = name.lower().replace("-", "_")
+    stripped = lowered.removeprefix("rhiza_")
+    if stripped in _FIELD_NAMES or lowered not in _FIELD_NAMES:
+        return stripped
+    return lowered
 
 
 def _coerce(value: str) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,8 @@ def test_print_resolves_either_spelling(repo: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.chdir(repo)
     assert "src" in runner.invoke(cli.app, ["print", "SOURCE_FOLDER"]).stdout
     assert "src" in runner.invoke(cli.app, ["print", "source_folder"]).stdout
+    # RHIZA_CHECKS is the one name where the prefix is part of the field, not a prefix.
+    assert "pytest_rhiza" in runner.invoke(cli.app, ["print", "RHIZA_CHECKS"]).stdout
 
 
 def test_print_rejects_an_unknown_setting(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,3 +183,63 @@ def test_folders_and_path_resolve(tmp_path: Path) -> None:
     cfg = Config.load(root=tmp_path)
     assert set(cfg.folders) == {"source_folder", "tests_folder", "marimo_folder"}
     assert cfg.path("source_folder") == tmp_path / "src"
+
+
+@pytest.mark.parametrize(
+    ("var", "field", "raw", "expected"),
+    [
+        ("UV_SYNC_ARGS", "uv_sync_args", "--group test", ("--group", "test")),
+        ("LICENSE_IGNORE_PACKAGES", "license_ignore_packages", "docutils chardet", ("docutils", "chardet")),
+        ("DEPTRY_IGNORE", "deptry_ignore", "--ignore DEP004", ("--ignore", "DEP004")),
+        ("MKDOCS_EXTRA_PACKAGES", "mkdocs_extra_packages", "mkdocstrings[python]", ("mkdocstrings[python]",)),
+        # RHIZA_RHIZA_CHECKS, not RHIZA_CHECKS: ``_key`` strips one ``RHIZA_`` prefix, so
+        # the short spelling resolves to the unknown field ``checks`` and is dropped.
+        ("RHIZA_RHIZA_CHECKS", "rhiza_checks", "pkg.a  pkg.b", ("pkg.a", "pkg.b")),
+        ("LICENSE_FAIL_ON", "license_fail_on", "GPL;LGPL;AGPL", ("GPL", "LGPL", "AGPL")),
+        ("RHIZA_CI_OS_MATRIX", "ci_os_matrix", '["ubuntu-latest","macos-latest"]', ("ubuntu-latest", "macos-latest")),
+    ],
+)
+def test_space_separated_list_settings_do_not_splat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    var: str,
+    field: str,
+    raw: str,
+    expected: tuple[str, ...],
+) -> None:
+    """A ``tuple[str, ...]`` field never holds a ``str``, whatever shape the layer used.
+
+    ``_coerce`` recognises only a JSON array and a ``;``-separated list, so every other
+    string used to reach the field as a ``str`` and be splatted one character per argument
+    at the call site -- ``uv sync - - g r o u p``. See issue #6.
+
+    Args:
+        tmp_path: The repository root.
+        monkeypatch: To set the environment variable.
+        var: The environment variable a consumer exports.
+        field: The config field under test.
+        raw: The value as a consumer writes it.
+        expected: The tuple the field must hold.
+    """
+    monkeypatch.setenv(var, raw)
+    assert getattr(Config.load(root=tmp_path), field) == expected
+
+
+def test_env_file_and_pyproject_strings_are_tupled_too(tmp_path: Path) -> None:
+    """Layer 2 and a TOML string in layer 3 get the same normalisation as the environment.
+
+    A ``.rhiza/.env`` written for the retired make layer spelled
+    ``LICENSE_IGNORE_PACKAGES`` space-separated, and ``[tool.rhiza-task]`` lets a list
+    field be written as a plain string.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text("LICENSE_IGNORE_PACKAGES=docutils chardet\n")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "d"\nversion = "0"\n\n[tool.rhiza-task]\nuv_sync_args = "--group test"\n'
+    )
+    cfg = Config.load(root=tmp_path)
+    assert cfg.license_ignore_packages == ("docutils", "chardet")
+    assert cfg.uv_sync_args == ("--group", "test")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from rhiza_task.config import Config, _coerce
+from rhiza_task.config import Config, _coerce, _key
 
 
 def test_defaults_need_no_files(tmp_path: Path) -> None:
@@ -192,9 +192,7 @@ def test_folders_and_path_resolve(tmp_path: Path) -> None:
         ("LICENSE_IGNORE_PACKAGES", "license_ignore_packages", "docutils chardet", ("docutils", "chardet")),
         ("DEPTRY_IGNORE", "deptry_ignore", "--ignore DEP004", ("--ignore", "DEP004")),
         ("MKDOCS_EXTRA_PACKAGES", "mkdocs_extra_packages", "mkdocstrings[python]", ("mkdocstrings[python]",)),
-        # RHIZA_RHIZA_CHECKS, not RHIZA_CHECKS: ``_key`` strips one ``RHIZA_`` prefix, so
-        # the short spelling resolves to the unknown field ``checks`` and is dropped.
-        ("RHIZA_RHIZA_CHECKS", "rhiza_checks", "pkg.a  pkg.b", ("pkg.a", "pkg.b")),
+        ("RHIZA_CHECKS", "rhiza_checks", "pkg.a  pkg.b", ("pkg.a", "pkg.b")),
         ("LICENSE_FAIL_ON", "license_fail_on", "GPL;LGPL;AGPL", ("GPL", "LGPL", "AGPL")),
         ("RHIZA_CI_OS_MATRIX", "ci_os_matrix", '["ubuntu-latest","macos-latest"]', ("ubuntu-latest", "macos-latest")),
     ],
@@ -243,3 +241,41 @@ def test_env_file_and_pyproject_strings_are_tupled_too(tmp_path: Path) -> None:
     cfg = Config.load(root=tmp_path)
     assert cfg.license_ignore_packages == ("docutils", "chardet")
     assert cfg.uv_sync_args == ("--group", "test")
+
+
+@pytest.mark.parametrize(
+    ("var", "expected"),
+    [
+        ("RHIZA_CHECKS", "rhiza_checks"),
+        ("RHIZA_RHIZA_CHECKS", "rhiza_checks"),
+        ("rhiza_checks", "rhiza_checks"),
+        ("rhiza-checks", "rhiza_checks"),
+        ("RHIZA_CI_OS_MATRIX", "ci_os_matrix"),
+        ("CI_OS_MATRIX", "ci_os_matrix"),
+        ("SOURCE_FOLDER", "source_folder"),
+        ("NONSENSE", "nonsense"),
+    ],
+)
+def test_key_strips_the_prefix_only_when_a_field_remains(var: str, expected: str) -> None:
+    """``RHIZA_CHECKS`` names the ``rhiza_checks`` field, not the unknown ``checks``.
+
+    The prefix is optional, and stripping it unconditionally meant the one field whose own
+    name starts with ``rhiza_`` could not be set from the environment at all -- the value
+    resolved to a name no field has and was dropped without a word.
+
+    Args:
+        var: The variable name as a consumer spells it.
+        expected: The field it must resolve to.
+    """
+    assert _key(var) == expected
+
+
+def test_rhiza_checks_is_settable_from_the_env_file(tmp_path: Path) -> None:
+    """The short spelling reaches the field through layer 2 as well.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text("RHIZA_CHECKS=pkg.a pkg.b\n")
+    assert Config.load(root=tmp_path).rhiza_checks == ("pkg.a", "pkg.b")


### PR DESCRIPTION
Closes #6.

## The bug

`_coerce` sees a string without knowing which field it is for, so it recognises only the two shapes that announce themselves: a JSON array and a `;`-separated list. Everything else stayed a `str`, and every call site splats these fields with `*`:

```
UV_SYNC_ARGS="--group test"  ->  ['uv', 'sync', '-', '-', 'g', 'r', 'o', 'u', 'p', ' ', 't', 'e', 's', 't']
```

No error, just a subprocess invoked with dozens of one-character arguments. rhiza's synced `.devcontainer/bootstrap.sh` exports exactly this variable, so opening a devcontainer on a migrated repo fails.

## The fix

The field's type is known in `Config.__post_init__` and nowhere lower, so that is where a `str` reaching a `tuple[str, ...]` field becomes a tuple, split on whitespace. This covers all four affected layers at once (`.rhiza/.env`, a TOML string in `[tool.rhiza-task]`, the environment, and CLI overrides), keeps the JSON and `;` branches of `_coerce` untouched, and leaves the `str` fields (`typechecker`, `source_folder`, a `book_output` with a space in it) alone.

Whitespace is the make layer's own format — `python.mk` documented `LICENSE_IGNORE_PACKAGES` as space-separated and `RHIZA_CHECKS` was a `+=` accumulator of space-separated module names — so a `.rhiza/.env` written for make now migrates rather than breaking silently.

## `RHIZA_CHECKS` could not reach its field

Found while testing the above, and fixed in the second commit. `_key` stripped the optional `RHIZA_` prefix unconditionally, so `RHIZA_CHECKS` resolved to `checks` — a field no `Config` has — and was dropped without a word. `rhiza_checks` was the one setting unreachable from the environment or `.rhiza/.env` under its documented name; it worked only as `RHIZA_RHIZA_CHECKS`.

The prefix is now stripped only when what remains is actually a field, with the whole name as a fallback. `RHIZA_CI_OS_MATRIX` still resolves to `ci_os_matrix`, and the doubled spelling keeps working for anyone who found it. `_key` also folds `-` to `_`, so `rhiza-task print` shares it instead of repeating a slightly different copy of the same rule — which means `rhiza-task print RHIZA_CHECKS` now prints the checks rather than `unknown setting`.

## Also in here

The minor `print` issue from the same report: `rhiza-task print mkdocs_extra_packages` printed `mkdocstrings` for `("mkdocstrings[python]",)`, rich having read `[python]` as a style tag. `print` is the command you reach for when a setting is not doing what you expect, so it now passes `markup=False, highlight=False`.

## Tests

18 new cases: every `tuple[str, ...]` field from the environment in its documented shape, the same through `.rhiza/.env` and a `[tool.rhiza-task]` string, and every spelling `_key` has to resolve. `142 passed`, ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)