### PR TITLE
feat(config): add rhiza.toml, and read the table from Cargo.toml too

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ recipes that genuinely are not:
 | module | what |
 |---|---|
 | `spec.py` | `Task`, `Guard`, `Skip`/`Failed`, the `@task` registry |
-| `config.py` | five-layer resolution, replacing `?=` and `+=` |
+| `config.py` | six-layer resolution, replacing `?=` and `+=` |
 | `uv.py` | the three ways rhiza reaches a tool |
 | `runner.py` | prerequisite dedup, guards, outcome bookkeeping |
 | `cli.py` | Typer app, generated from the registry |
@@ -86,9 +86,25 @@ recipes that genuinely are not:
 
 ### Configuration
 
-Five layers, lowest precedence first: dataclass defaults → `.rhiza/.env` (kept unchanged)
-→ `[tool.rhiza-task]` in `pyproject.toml` → `RHIZA_*` or bare make-style environment
-variables → command-line flags.
+Six layers, lowest precedence first: dataclass defaults → `.rhiza/.env` (kept unchanged)
+→ `rhiza.toml` → `[tool.rhiza-task]` in the language manifest (`Cargo.toml`, then
+`pyproject.toml`) → `RHIZA_*` or bare make-style environment variables → command-line
+flags.
+
+`rhiza.toml` is the language-neutral file, and the only committed settings surface a Go
+module can have — it has no manifest to hide a table in, and `.rhiza/.env` is now
+developer-local, since rhiza ships neither it nor the `.rhiza/.gitignore` whose entire
+content was the `!.env` negation that kept it tracked. Settings sit at the top level
+there; a `[tool.rhiza-task]` table is honoured too, and wins when both are present. It
+ranks *below* the manifest so that adding it to a Python repo cannot silently outrank the
+table already there.
+
+```toml
+# rhiza.toml — a Go module or a Rust crate, or any repo that would rather not
+# thread settings through a manifest
+source_folder = "cmd"
+coverage_fail_under = 95
+```
 
 An **empty value is unset** in the two string-valued layers: `RHIZA_CI_OS_MATRIX=` in
 `.rhiza/.env`, or an exported empty string, leaves the layer below it alone rather than

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -12,7 +12,7 @@ Layout:
 
 * :mod:`rhiza_task.spec` -- the task model: ``Task``, ``Guard``, ``Skip``/``Failed``, and
   the registry that replaces make's double-colon rules.
-* :mod:`rhiza_task.config` -- five-layer settings resolution, replacing ``?=`` and ``+=``.
+* :mod:`rhiza_task.config` -- six-layer settings resolution, replacing ``?=`` and ``+=``.
 * :mod:`rhiza_task.uv` -- the three ways rhiza reaches a tool.
 * :mod:`rhiza_task.runner` -- prerequisite dedup, guard evaluation, outcome bookkeeping.
 * :mod:`rhiza_task.cli` -- the Typer app, generated from the registry.

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -11,11 +11,24 @@ Here the order is explicit and testable, lowest precedence first:
 
 1. The dataclass defaults below.
 2. ``.rhiza/.env`` -- kept unchanged, because it is already the file consumers edit and
-   the reusable workflows read it too.
-3. ``[tool.rhiza-task]`` in ``pyproject.toml`` -- the new home for what used to require
-   editing a synced ``.mk`` file or shadowing a target.
-4. ``RHIZA_*`` (or bare make-style) environment variables.
-5. Command-line flags.
+   the reusable workflows read it too. Now a developer-local channel rather than a
+   committed one: rhiza no longer ships ``.rhiza/.gitignore``, whose entire content was
+   the ``!.env`` negation that kept this file tracked, so it falls under the shipped
+   ``.gitignore``'s ``.env`` rule and a CI checkout never contains it.
+3. ``rhiza.toml`` -- the language-neutral settings file, and the only committed one a Go
+   module can have: it has no manifest to hide a table in. Read for every project, so a
+   polyglot repository has one place to look rather than one per layer.
+4. ``[tool.rhiza-task]`` in the language manifest -- ``Cargo.toml``, then
+   ``pyproject.toml``. This is the new home for what used to require editing a synced
+   ``.mk`` file or shadowing a target. Cargo ignores unknown top-level tables, so the
+   table is as harmless there as it is in pyproject.
+5. ``RHIZA_*`` (or bare make-style) environment variables.
+6. Command-line flags.
+
+Layers 3 and 4 are two files rather than one because neither alone covers the three
+language layers: pyproject is Python-only, and a repo that already moved its settings
+there should not have to move them again. ``rhiza.toml`` ranks *below* the manifest so
+that adding it to a Python repo cannot silently outrank the table already there.
 
 The ``+=`` accumulators do not survive as a mechanism, and do not need to: every one of
 them was a bundle contributing something it owned, which the task body can now *derive*
@@ -28,7 +41,7 @@ from __future__ import annotations
 import json
 import os
 import tomllib
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
@@ -164,7 +177,7 @@ class Config:
 
     @classmethod
     def load(cls, root: Path | None = None, **overrides: Any) -> Config:
-        """Build a config by walking the five layers in order.
+        """Build a config by walking the six layers in order.
 
         Args:
             root: Repository root; defaults to the current directory.
@@ -177,7 +190,12 @@ class Config:
         root = (root or Path.cwd()).absolute()
         raw: dict[str, Any] = {}
         raw.update(_from_env_file(root / ".rhiza" / ".env"))
-        raw.update(_from_pyproject(root / "pyproject.toml"))
+        raw.update(_from_rhiza_toml(root / "rhiza.toml"))
+        # Cargo before pyproject, so a repo carrying both -- a Rust crate with a Python
+        # binding package, say -- resolves to the same settings as the Python-only repo it
+        # grew out of, rather than to whichever manifest happened to be read last.
+        raw.update(_from_manifest(root / "Cargo.toml"))
+        raw.update(_from_manifest(root / "pyproject.toml"))
         raw.update(_from_environ(os.environ))
         raw.update({k: v for k, v in overrides.items() if v is not None})
 
@@ -215,22 +233,73 @@ def _from_env_file(path: Path) -> dict[str, Any]:
     return {_key(k): _coerce(v) for k, v in dotenv_values(path).items() if v and v.strip()}
 
 
-def _from_pyproject(path: Path) -> dict[str, Any]:
-    """Read ``[tool.rhiza-task]``.
+def _from_manifest(path: Path) -> dict[str, Any]:
+    """Read ``[tool.rhiza-task]`` from a language manifest.
 
-    Values here are already typed by TOML, so they bypass :func:`_coerce` -- a TOML array
-    arrives as a list and is tupled, nothing is parsed out of a string.
+    ``pyproject.toml`` and ``Cargo.toml`` alike: the table is namespaced under ``tool``,
+    which cargo ignores as readily as any Python build backend does, so one reader serves
+    both and a Rust crate needs no file a Python project does not have.
 
     Args:
-        path: Path to pyproject.toml.
+        path: Path to pyproject.toml or Cargo.toml.
 
     Returns:
         Parsed settings; empty when the file or the table is absent.
     """
+    return _table(path, lambda data: data.get("tool", {}).get("rhiza-task", {}))
+
+
+def _from_rhiza_toml(path: Path) -> dict[str, Any]:
+    """Read ``rhiza.toml``, the manifest-free settings file.
+
+    Settings sit at the top level, because a file named after this tool has nothing to
+    namespace against. A ``[tool.rhiza-task]`` table is honoured too, and wins when both
+    are present: the pyproject spelling is what a reader will have seen first, and
+    silently ignoring it would be the worst of the three possible behaviours.
+
+    Args:
+        path: Path to rhiza.toml.
+
+    Returns:
+        Parsed settings; empty when the file is absent.
+    """
+    return _table(path, lambda data: data.get("tool", {}).get("rhiza-task") or data)
+
+
+def _table(path: Path, select: Callable[[dict[str, Any]], Any]) -> dict[str, Any]:
+    """Read a TOML file and normalise the selected table's keys and values.
+
+    Values here are already typed by TOML, so they bypass :func:`_coerce` -- a TOML array
+    arrives as a list and is tupled, nothing is parsed out of a string. Keys that are not
+    field names are left in place and dropped by :meth:`Config.load`, which is what makes
+    reading ``rhiza.toml``'s top level safe.
+
+    Args:
+        path: Path to the TOML file.
+        select: Picks the settings table out of the parsed document.
+
+    Returns:
+        Parsed settings; empty when the file is absent or unreadable.
+
+    Raises:
+        ValueError: When the file is not valid TOML. A settings file that does not parse
+            is a mistake worth reporting, not a file to skip -- unlike an absent one.
+    """
     if not path.is_file():
         return {}
-    table = tomllib.loads(path.read_text()).get("tool", {}).get("rhiza-task", {})
-    return {k.replace("-", "_"): tuple(v) if isinstance(v, list) else v for k, v in table.items()}
+    try:
+        data = tomllib.loads(path.read_text())
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"{path.name} is not valid TOML: {exc}"
+        raise ValueError(msg) from exc
+    table = select(data)
+    if not isinstance(table, dict):
+        return {}
+    return {
+        k.replace("-", "_"): tuple(v) if isinstance(v, list) else v
+        for k, v in table.items()
+        if not isinstance(v, dict)
+    }
 
 
 def _from_environ(environ: Mapping[str, str]) -> dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""The five-layer resolution order, and the three value shapes ``.rhiza/.env`` uses."""
+"""The six-layer resolution order, and the three value shapes ``.rhiza/.env`` uses."""
 
 from __future__ import annotations
 
@@ -54,6 +54,104 @@ def test_pyproject_beats_env_file(tmp_path: Path) -> None:
     cfg = Config.load(root=tmp_path)
     assert cfg.source_folder == "app"
     assert cfg.coverage_fail_under == 75
+
+
+def test_rhiza_toml_beats_the_env_file(tmp_path: Path) -> None:
+    """``rhiza.toml`` outranks ``.rhiza/.env``.
+
+    The env file is now developer-local -- rhiza ships no ``.rhiza/.gitignore`` to keep it
+    tracked -- so the committed neutral file has to win over a machine-local leftover.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text("SOURCE_FOLDER=lib\nTYPECHECKER=mypy\n")
+    (tmp_path / "rhiza.toml").write_text('source_folder = "app"\ncoverage_fail_under = 75\n')
+    cfg = Config.load(root=tmp_path)
+    assert cfg.source_folder == "app"
+    assert cfg.coverage_fail_under == 75
+    assert cfg.typechecker == "mypy"
+
+
+def test_rhiza_toml_serves_a_repo_with_no_manifest(tmp_path: Path) -> None:
+    """A Go module has no manifest to hide a table in, and needs no special case.
+
+    This is the layer's reason to exist: ``go.mod`` is not TOML and holds nothing a tool
+    can namespace into, so before this the only committed settings surface a Go repo had
+    was the root Makefile -- the very file the shim migration removes.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.23\n")
+    (tmp_path / "rhiza.toml").write_text('source_folder = "cmd"\nrhiza_checks = ["a", "b"]\n')
+    cfg = Config.load(root=tmp_path)
+    assert cfg.source_folder == "cmd"
+    assert cfg.rhiza_checks == ("a", "b")
+
+
+def test_rhiza_toml_honours_the_pyproject_spelling(tmp_path: Path) -> None:
+    """A ``[tool.rhiza-task]`` table in ``rhiza.toml`` is read, and wins over the top level.
+
+    Copying the table across from pyproject is the obvious first thing to try, and silently
+    ignoring it would be the worst of the three possible behaviours.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "rhiza.toml").write_text('source_folder = "ignored"\n\n[tool.rhiza-task]\nsource_folder = "app"\n')
+    assert Config.load(root=tmp_path).source_folder == "app"
+
+
+def test_cargo_toml_carries_the_table_too(tmp_path: Path) -> None:
+    """``[tool.rhiza-task]`` in ``Cargo.toml`` is read, and outranks ``rhiza.toml``.
+
+    Cargo ignores unknown top-level tables, so the table is as harmless there as the same
+    table is in pyproject.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "rhiza.toml").write_text('source_folder = "neutral"\ntests_folder = "t"\n')
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "demo"\nversion = "0.1.0"\n\n[tool.rhiza-task]\nsource_folder = "crate-src"\n'
+    )
+    cfg = Config.load(root=tmp_path)
+    assert cfg.source_folder == "crate-src"
+    assert cfg.tests_folder == "t"
+
+
+def test_pyproject_beats_cargo_and_the_neutral_file(tmp_path: Path) -> None:
+    """In a repo carrying both manifests, pyproject is the last word before the environment.
+
+    Fixed rather than incidental: a Rust crate that grows a Python binding package should
+    resolve to the settings the Python-only repo already had.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "rhiza.toml").write_text('source_folder = "neutral"\n')
+    (tmp_path / "Cargo.toml").write_text('[tool.rhiza-task]\nsource_folder = "crate-src"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "d"\nversion = "0"\n\n[tool.rhiza-task]\nsource_folder = "app"\n'
+    )
+    assert Config.load(root=tmp_path).source_folder == "app"
+
+
+def test_unparseable_settings_file_names_itself(tmp_path: Path) -> None:
+    """A settings file that is not valid TOML is reported, not skipped.
+
+    An absent file means "nothing to say"; a broken one means a setting the author believes
+    is in effect is not, which is exactly the failure the layered resolution exists to make
+    impossible to have silently.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "rhiza.toml").write_text("source_folder = \n")
+    with pytest.raises(ValueError, match=r"rhiza\.toml is not valid TOML"):
+        Config.load(root=tmp_path)
 
 
 def test_environ_beats_pyproject(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #11.

## The problem

Layer 3 was `pyproject.toml`-only. A Rust project has `Cargo.toml`; a Go module has no manifest at all — so the layer documented as "the new home for what used to require editing a synced `.mk` file" was unavailable to two of rhiza's three language layers.

And it matters more than it did: with `.rhiza/.env` and the `.rhiza/.gitignore` that kept it tracked both retired, layer 2 is now developer-local and a CI checkout never contains it. For a Rust or Go repo that left **no committed settings surface at all** except the root `Makefile` — the very file the shim migration removes.

## What this does

Option 3 from the issue.

- **`rhiza.toml`**, read for every project, settings at the top level. A `[tool.rhiza-task]` table there is honoured too and wins when both are present — copying the table across from pyproject is the obvious first thing to try, and ignoring it silently would be the worst of the three possible behaviours.
- **`[tool.rhiza-task]` in `Cargo.toml`**, through the same reader as pyproject. Cargo ignores unknown top-level tables, so nothing there needs a per-language special case.

Resolution order, lowest first — six layers now, same shape:

```
defaults → .rhiza/.env → rhiza.toml → Cargo.toml → pyproject.toml → environment → flags
```

The neutral file ranks *below* the manifest so that adding it to a Python repo cannot silently outrank the table already there. Cargo is read before pyproject so a repo carrying both — a crate that grew a Python binding package — resolves the way the Python-only repo it grew out of did, rather than by whichever manifest was read last.

One behaviour change beyond the new layers: a settings file that is not valid TOML now raises naming itself (`rhiza.toml is not valid TOML: ...`) rather than surfacing a bare parse error. An absent file means "nothing to say"; a broken one means a setting its author believes is in effect is not.

## Docs

`config.py`'s module docstring is the authoritative description of the resolution order, so it carries the new layers and the reason each ranks where it does; README and `__init__` follow.

## Tests

Six added: `rhiza.toml` beats `.rhiza/.env`; it serves a repo with no manifest (a `go.mod`-only project); the pyproject spelling inside it is honoured and wins over the top level; `Cargo.toml` carries the table and outranks `rhiza.toml`; pyproject beats both; an unparseable file names itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)