### PR TITLE
feat(tasks): add coverage to all three layers (re-land of #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### 🚀 Features
 
+- *(tasks)* Add `coverage` to all three layers (#10). It is named in the gate-parity
+  contract and writes `_tests/coverage.xml`, the path `book`'s badge step reads and CI
+  uploads. Python gains the name it was missing -- the flags its `test` already carried --
+  Rust gets `cargo llvm-cov --cobertura`, and Go gets the profile, the Cobertura
+  conversion, and the floor check `go test` has no flag for.
 - *(tasks)* Add the Rust and Go language layers (#9). `rhiza_task/tasks/` served one of
   rhiza's three layers, so `core` could not drop the make layer without leaving `rust-core`
   and `go-core` with no targets at all. Tasks now carry a layer, the registry is keyed

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ pinned CLI, so a consumer still on an older reusable workflow needs no change.
 
 | section | tasks |
 |---|---|
-| Python | `install` `test` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
-| Rust | `install` `cargo-tools` `test` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
-| Go | `install` `go-tools` `test` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
+| Python | `install` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
+| Rust | `install` `cargo-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
+| Go | `install` `go-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` |
 | Testing extras | `benchmark` `hypothesis-test` `stress` `mutation` |
 | Book | `book` `serve` `marimo` `marimo-validate` |
@@ -78,12 +78,33 @@ what the layers you do not have call things.
 language fragment was standing in for: the neutral checks, plus `test_pyproject` and
 `test_docstrings` for python, `test_cargo_toml` for rust, `test_go_module` for go.
 
+`coverage` writes `_tests/coverage.xml` in every layer, at that exact path, because that
+is what `book`'s badge step reads and what CI uploads. In Python it is the `--cov` flags
+`test` already carries, split out under the name the other two layers use; in Rust it is
+`cargo llvm-cov --cobertura`; in Go it is a coverage profile piped through
+`gocover-cobertura`, plus the floor check `go test` has no flag for.
+
 Not ported: `github.mk`'s seven `gh` wrappers — `gh pr list` is shorter than
 `make view-prs` and always current — and `install-uv`, which is not a task because it
 cannot be one: it is what provisions the runtime every task already runs under. The shim
 keeps it, as a file target rather than a phony, so `make <anything>` still works on a
 runner that ships no uv — which rhiza's `pre-commit` job, a required status check that
 runs `make fmt` with no `astral-sh/setup-uv` step, depends on.
+
+### Fragments a repository owns go to `local.mk`
+
+The shim's header says it replaces "`.rhiza/rhiza.mk` and the ten fragments in
+`.rhiza/make.d/`". A repository carrying **its own** fragments has to relocate them first —
+deleting `rhiza.mk` removes the `-include .rhiza/make.d/*.mk` that was reaching them, so
+they stop being loaded without anything saying so.
+
+In rhiza's own case that is `bundles.mk`: `sync-self`, `sync-self-check`,
+`explain-bundles`, `e2e` and `gitlab-docker-test`. None of them is a candidate for this
+package — no bundle ships them, and the tooling behind them (`utils/link_dogfood.py`,
+`utils/explain_bundles.py`) lives in the mother repo. They belong in `local.mk`, which the
+shim `-include`s for exactly this purpose and where an explicit rule beats the catch-all.
+Worth doing deliberately rather than discovering later: `sync-self` is what maintains the
+`bundles/` ↔ root invariant the whole repository rests on.
 
 ## Design
 

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import json
 import os
 import tomllib
-from collections.abc import Mapping, Sequence, Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any

--- a/src/rhiza_task/tasks/go.py
+++ b/src/rhiza_task/tasks/go.py
@@ -15,6 +15,7 @@ whatever the developer's ``GOPATH`` happens to be.
 from __future__ import annotations
 
 import shutil
+import subprocess  # nosec B404 - fixed argument vector, never shell=True
 from pathlib import Path
 
 from ..config import Config
@@ -102,6 +103,64 @@ def test(cfg: Config) -> None:
     reports = cfg.root / "_tests"
     reports.mkdir(parents=True, exist_ok=True)
     tool("go", "test", "./...", *cfg.go_test_flags, *cfg.go_flags, cwd=cfg.root)
+
+
+@task(
+    "coverage",
+    "measure coverage and write _tests/coverage.xml",
+    section="Go",
+    layer="go",
+    needs=("install", "go-tools"),
+    guards=(MANIFEST,),
+)
+def coverage(cfg: Config) -> None:
+    """Measure coverage, convert it to Cobertura, and enforce the floor.
+
+    Three steps because Go's tooling splits them, and a fourth thing go.mk does in awk:
+    ``go test`` has no ``--fail-under``, so the floor is enforced by reading the ``total:``
+    line out of ``go tool cover -func``. That awk one-liner is the whole reason this is a
+    task body rather than three argument vectors.
+
+    ``-covermode=atomic`` because the default ``set`` mode is not race-safe and ``test``
+    runs a race build.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Failed: When coverage is below ``coverage_fail_under``.
+    """
+    reports = cfg.root / "_tests"
+    (reports / "html-coverage").mkdir(parents=True, exist_ok=True)
+    profile = reports / "coverage.out"
+    print(f"[INFO] measuring coverage (floor: {cfg.coverage_fail_under}%)")
+    tool(
+        "go",
+        "test",
+        "./...",
+        "-covermode=atomic",
+        f"-coverprofile={profile.relative_to(cfg.root)}",
+        *cfg.go_flags,
+        cwd=cfg.root,
+    )
+    _cobertura(cfg, profile, reports / "coverage.xml")
+    tool(
+        "go",
+        "tool",
+        "cover",
+        f"-html={profile.relative_to(cfg.root)}",
+        "-o",
+        "_tests/html-coverage/index.html",
+        cwd=cfg.root,
+    )
+
+    measured = _total_coverage(cfg, profile)
+    if measured is None:
+        print("[WARN] could not read a total from `go tool cover -func`; floor not enforced")
+        return
+    if measured < cfg.coverage_fail_under:
+        raise Failed(1, f"coverage {measured:.1f}% is below the {cfg.coverage_fail_under}% floor")
+    print(f"[INFO] coverage {measured:.1f}% (floor: {cfg.coverage_fail_under}%)")
 
 
 @task(
@@ -221,6 +280,58 @@ def all_(cfg: Config) -> None:
     Args:
         cfg: Unused; the prerequisites do the work.
     """
+
+
+def _cobertura(cfg: Config, profile: Path, target: Path) -> None:
+    """Convert a Go coverage profile to Cobertura XML.
+
+    The one recipe in the whole port that genuinely needs a pipe: gocover-cobertura reads
+    stdin and writes stdout, so there is no argument vector that expresses it. Handled here
+    with two file handles rather than by giving :mod:`~rhiza_task.uv` a redirection feature
+    nothing else would use -- and still no shell.
+
+    Args:
+        cfg: The resolved config.
+        profile: The ``go test -coverprofile`` output.
+        target: Where to write the Cobertura XML.
+
+    Raises:
+        Failed: When the conversion exits non-zero.
+    """
+    converter = _tool_path(cfg, "gocover-cobertura")
+    print(f"[INFO] writing {target.relative_to(cfg.root)}")
+    with profile.open("rb") as source, target.open("wb") as out:
+        code = subprocess.call(  # noqa: S603  # nosec B603
+            [shutil.which(converter) or converter],
+            cwd=cfg.root,
+            stdin=source,
+            stdout=out,
+        )
+    if code:
+        raise Failed(code, "gocover-cobertura failed")
+
+
+def _total_coverage(cfg: Config, profile: Path) -> float | None:
+    """Return the total coverage percentage, or None when it cannot be read.
+
+    Replaces go.mk's awk over ``go tool cover -func``: the total line is the only place Go
+    reports a single number, and ``go test`` has no floor of its own to set.
+
+    Args:
+        cfg: The resolved config.
+        profile: The coverage profile.
+
+    Returns:
+        The percentage, or None.
+    """
+    report = capture("go", "tool", "cover", f"-func={profile.relative_to(cfg.root)}", cwd=cfg.root)
+    for line in reversed(report.splitlines()):
+        if line.startswith("total:"):
+            try:
+                return float(line.split()[-1].rstrip("%"))
+            except ValueError:  # pragma: no cover - a malformed total line
+                return None
+    return None
 
 
 def _bin_dir(cfg: Config) -> Path:

--- a/src/rhiza_task/tasks/go.py
+++ b/src/rhiza_task/tasks/go.py
@@ -38,6 +38,14 @@ lines currently says ``latest``. Pinning them is a decision for the template to 
 one place, not for this port to make silently on the way past.
 """
 
+COVERAGE_PROFILE = "_tests/coverage.out"
+"""Where ``go test -coverprofile`` writes, spelled with forward slashes on every OS.
+
+Not ``Path.relative_to``: this string is an *argument to go*, not a filesystem operation,
+and a backslash-separated path is a different argument. go accepts the forward-slash
+spelling on Windows, and the gates run there.
+"""
+
 MANIFEST = Guard(file="go.mod", reason="no go.mod")
 """What every Go gate is guarded on: the module file, not a source folder."""
 
@@ -132,14 +140,14 @@ def coverage(cfg: Config) -> None:
     """
     reports = cfg.root / "_tests"
     (reports / "html-coverage").mkdir(parents=True, exist_ok=True)
-    profile = reports / "coverage.out"
+    profile = cfg.root / COVERAGE_PROFILE
     print(f"[INFO] measuring coverage (floor: {cfg.coverage_fail_under}%)")
     tool(
         "go",
         "test",
         "./...",
         "-covermode=atomic",
-        f"-coverprofile={profile.relative_to(cfg.root)}",
+        f"-coverprofile={COVERAGE_PROFILE}",
         *cfg.go_flags,
         cwd=cfg.root,
     )
@@ -148,13 +156,13 @@ def coverage(cfg: Config) -> None:
         "go",
         "tool",
         "cover",
-        f"-html={profile.relative_to(cfg.root)}",
+        f"-html={COVERAGE_PROFILE}",
         "-o",
         "_tests/html-coverage/index.html",
         cwd=cfg.root,
     )
 
-    measured = _total_coverage(cfg, profile)
+    measured = _total_coverage(cfg)
     if measured is None:
         print("[WARN] could not read a total from `go tool cover -func`; floor not enforced")
         return
@@ -299,7 +307,7 @@ def _cobertura(cfg: Config, profile: Path, target: Path) -> None:
         Failed: When the conversion exits non-zero.
     """
     converter = _tool_path(cfg, "gocover-cobertura")
-    print(f"[INFO] writing {target.relative_to(cfg.root)}")
+    print(f"[INFO] writing {target.name}")
     with profile.open("rb") as source, target.open("wb") as out:
         code = subprocess.call(  # noqa: S603  # nosec B603
             [shutil.which(converter) or converter],
@@ -311,7 +319,7 @@ def _cobertura(cfg: Config, profile: Path, target: Path) -> None:
         raise Failed(code, "gocover-cobertura failed")
 
 
-def _total_coverage(cfg: Config, profile: Path) -> float | None:
+def _total_coverage(cfg: Config) -> float | None:
     """Return the total coverage percentage, or None when it cannot be read.
 
     Replaces go.mk's awk over ``go tool cover -func``: the total line is the only place Go
@@ -319,12 +327,11 @@ def _total_coverage(cfg: Config, profile: Path) -> float | None:
 
     Args:
         cfg: The resolved config.
-        profile: The coverage profile.
 
     Returns:
         The percentage, or None.
     """
-    report = capture("go", "tool", "cover", f"-func={profile.relative_to(cfg.root)}", cwd=cfg.root)
+    report = capture("go", "tool", "cover", f"-func={COVERAGE_PROFILE}", cwd=cfg.root)
     for line in reversed(report.splitlines()):
         if line.startswith("total:"):
             try:

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -103,21 +103,9 @@ def test(cfg: Config) -> None:
     reports = cfg.root / "_tests"
     shutil.rmtree(reports, ignore_errors=True)
 
-    args = [
-        "-n",
-        "auto",
-        f"--ignore={cfg.tests_folder}/benchmarks",
-        f"--ignore={cfg.tests_folder}/stress",
-    ]
+    args = [*_pytest_args(cfg)]
     if cfg.path("source_folder").is_dir():
-        args += [
-            f"--cov={cfg.source_folder}",
-            "--cov-report=term",
-            "--cov-report=html:_tests/html-coverage",
-            "--cov-report=json:_tests/coverage.json",
-            "--cov-report=xml:_tests/coverage.xml",
-            f"--cov-fail-under={cfg.coverage_fail_under}",
-        ]
+        args += coverage_args(cfg)
     else:
         # Not a Skip: the tests exist and must run. Only coverage is unavailable.
         print(f"[WARN] source folder '{cfg.source_folder}' not found; running without coverage")
@@ -139,6 +127,79 @@ def test(cfg: Config) -> None:
         if attempt == MAX_ATTEMPTS:
             raise Failed(code, f"pytest reported an internal (teardown) error {attempt}x")
         print(f"[WARN] pytest exited {code} (xdist teardown race); retrying {attempt + 1}/{MAX_ATTEMPTS}")
+
+
+@task(
+    "coverage",
+    "measure coverage and write _tests/coverage.xml",
+    section="Python",
+    layer="python",
+    needs=("install",),
+    guards=(
+        Guard("tests_folder", glob="test_*.py", reason="no test files found"),
+        Guard("source_folder"),
+    ),
+)
+def coverage(cfg: Config) -> None:
+    """Run the suite for its coverage reports.
+
+    python.mk has no ``coverage`` target: its ``test`` recipe carries the ``--cov`` flags,
+    so the Cobertura file CI uploads and ``book`` badges is a side effect of the test gate.
+    rust.mk and go.mk both name ``coverage`` separately, and the gate-parity contract lists
+    it for all three layers -- so the Python layer grows the name it was missing rather than
+    the other two losing it.
+
+    It is not a second test run in any meaningful sense: same suite, same floor, same
+    output path. What it buys is a caller that wants the report without asserting anything
+    about the HTML test report, and one name that means the same thing in all three layers.
+
+    Args:
+        cfg: The resolved config.
+    """
+    (cfg.root / "_tests" / "html-coverage").mkdir(parents=True, exist_ok=True)
+    for stale in cfg.root.glob(".coverage*"):
+        stale.unlink(missing_ok=True)
+    uv_run("pytest", *_pytest_args(cfg), *coverage_args(cfg), cwd=cfg.root, withs=PYTEST_WITHS)
+
+
+def _pytest_args(cfg: Config) -> list[str]:
+    """Return the arguments both pytest-running gates share.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        Parallelism, and the two folders the testing extras own.
+    """
+    return [
+        "-n",
+        "auto",
+        f"--ignore={cfg.tests_folder}/benchmarks",
+        f"--ignore={cfg.tests_folder}/stress",
+    ]
+
+
+def coverage_args(cfg: Config) -> list[str]:
+    """Return the ``--cov`` flags, including the Cobertura path the other layers write to.
+
+    Shared by ``test`` and ``coverage`` so the two cannot drift: ``_tests/coverage.xml`` is
+    the file book.mk's badge step reads and CI uploads, and rust.mk and go.mk go out of
+    their way to write it at exactly that path.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The coverage flags.
+    """
+    return [
+        f"--cov={cfg.source_folder}",
+        "--cov-report=term",
+        "--cov-report=html:_tests/html-coverage",
+        "--cov-report=json:_tests/coverage.json",
+        "--cov-report=xml:_tests/coverage.xml",
+        f"--cov-fail-under={cfg.coverage_fail_under}",
+    ]
 
 
 @task(

--- a/src/rhiza_task/tasks/rust.py
+++ b/src/rhiza_task/tasks/rust.py
@@ -1,7 +1,7 @@
 """The Rust language layer: rust.mk, as tasks.
 
-The gate names are python.mk's, deliberately: ``install``, ``test``, ``typecheck``,
-``docs-coverage``, ``security``, ``license``, ``deps``, ``all``. That is
+The gate names are python.mk's, deliberately: ``install``, ``test``, ``coverage``,
+``typecheck``, ``docs-coverage``, ``security``, ``license``, ``deps``, ``all``. That is
 the contract the reusable workflows and ``book`` depend on -- `rhiza_ci.yml` calls
 ``make typecheck`` without knowing what the repository is written in, and rust.mk's own
 header says so. Only the engine differs.
@@ -125,6 +125,42 @@ def test(cfg: Config) -> None:
     tool("cargo", "nextest", "run", "--all-targets", *cfg.cargo_flags, cwd=cfg.root)
     print("[INFO] running doctests")
     tool("cargo", "test", "--doc", *cfg.cargo_flags, cwd=cfg.root)
+
+
+@task(
+    "coverage",
+    "measure coverage and write _tests/coverage.xml",
+    section="Rust",
+    layer="rust",
+    needs=("install", "cargo-tools"),
+    guards=(MANIFEST,),
+)
+def coverage(cfg: Config) -> None:
+    """Measure coverage with cargo-llvm-cov, enforcing the same floor the Python layer has.
+
+    Cobertura XML at exactly ``_tests/coverage.xml``, which is not a detail: it is the path
+    book.mk's badge step reads, so a Rust project gets a measured coverage badge on its
+    docs site for the same reason a Python one does.
+
+    Args:
+        cfg: The resolved config.
+    """
+    (cfg.root / "_tests" / "html-coverage").mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] measuring coverage (floor: {cfg.coverage_fail_under}%)")
+    tool(
+        "cargo",
+        "llvm-cov",
+        "nextest",
+        "--all-targets",
+        *cfg.cargo_flags,
+        "--fail-under-lines",
+        str(cfg.coverage_fail_under),
+        "--cobertura",
+        "--output-path",
+        "_tests/coverage.xml",
+        cwd=cfg.root,
+    )
+    tool("cargo", "llvm-cov", "report", "--html", "--output-dir", "_tests/html-coverage", cwd=cfg.root)
 
 
 @task(

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -52,7 +52,9 @@ $(UVX):
 	@curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR="$(@D)" sh >/dev/null
 
 # Repo-specific one-offs live here, where they always belonged, and win over the catch-all
-# because an explicit rule beats a pattern rule. This is what `local.mk` was for.
+# because an explicit rule beats a pattern rule. This is what `local.mk` was for -- and a
+# repository that carried its *own* fragment under `.rhiza/make.d/` has to move it here
+# before deleting `rhiza.mk`, which is the file whose `-include` was reaching it.
 -include local.mk
 
 # An included makefile is also a target make tries to *remake* before running anything, and

--- a/tests/test_language_layers.py
+++ b/tests/test_language_layers.py
@@ -254,6 +254,22 @@ class TestRustGates:
             ["test", "--doc"],
         ]
 
+    def test_coverage_writes_the_path_the_badge_reads(self, crate: Path, recorder: Recorder) -> None:
+        """Cobertura XML at ``_tests/coverage.xml``, and the floor is the shared setting.
+
+        The path is the contract, not a detail: it is what book.mk's badge step reads, so a
+        crate gets a measured badge for the same reason a Python project does.
+
+        Args:
+            crate: A Rust project root.
+            recorder: The command recorder.
+        """
+        rust_tasks.coverage(Config.load(root=crate, coverage_fail_under=85))
+        measure, report = (c.flags for c in recorder.calls)
+        assert measure[:3] == ["llvm-cov", "nextest", "--all-targets"]
+        assert measure[3:] == ["--fail-under-lines", "85", "--cobertura", "--output-path", "_tests/coverage.xml"]
+        assert report == ["llvm-cov", "report", "--html", "--output-dir", "_tests/html-coverage"]
+
     def test_cargo_flags_reach_every_gate(self, crate: Path, recorder: Recorder) -> None:
         """``CARGO_FLAGS`` is a setting, not a per-recipe literal.
 
@@ -379,6 +395,97 @@ class TestGoGates:
         go_tasks.license_(Config.load(root=module))
         assert "could not read the module path" in capsys.readouterr().out
         assert recorder.calls[-1].flags == ["check", "./..."]
+
+    def test_coverage_converts_and_enforces_the_floor(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The profile is measured, converted to Cobertura, and checked against the floor.
+
+        ``go test`` has no ``--fail-under``; go.mk reads the total out of ``go tool cover
+        -func`` in awk, and this is that awk one-liner.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(go_tasks, "_cobertura", lambda *a: None)
+        monkeypatch.setattr(go_tasks, "capture", lambda *a, **k: "total:\t(statements)\t93.4%\n")
+        go_tasks.coverage(Config.load(root=module, coverage_fail_under=90))
+        measure = recorder.calls[0].flags
+        assert measure[:4] == ["test", "./...", "-covermode=atomic", "-coverprofile=_tests/coverage.out"]
+        assert recorder.calls[1].flags == [
+            "tool",
+            "cover",
+            "-html=_tests/coverage.out",
+            "-o",
+            "_tests/html-coverage/index.html",
+        ]
+        assert "93.4%" in capsys.readouterr().out
+
+    def test_coverage_below_the_floor_fails(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A measured number below the floor is a red gate, as it is in the other layers.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(go_tasks, "_cobertura", lambda *a: None)
+        monkeypatch.setattr(go_tasks, "capture", lambda *a, **k: "total:\t(statements)\t41.0%\n")
+        with pytest.raises(Failed, match="below the 90% floor"):
+            go_tasks.coverage(Config.load(root=module, coverage_fail_under=90))
+
+    def test_an_unreadable_total_warns_rather_than_passing_silently(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No total means the floor was not enforced, and says so.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(go_tasks, "_cobertura", lambda *a: None)
+        monkeypatch.setattr(go_tasks, "capture", lambda *a, **k: "")
+        go_tasks.coverage(Config.load(root=module))
+        assert "floor not enforced" in capsys.readouterr().out
+
+    def test_the_cobertura_conversion_is_a_pipe(self, module: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gocover-cobertura reads stdin and writes stdout, and still runs without a shell.
+
+        Args:
+            module: A Go module root.
+            monkeypatch: pytest's patcher.
+        """
+        seen: dict[str, object] = {}
+
+        def fake_call(argv: list[str], **kwargs: object) -> int:
+            """Record the conversion invocation.
+
+            Args:
+                argv: The argument vector.
+                **kwargs: The redirection handles.
+
+            Returns:
+                Zero.
+            """
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            return 0
+
+        monkeypatch.setattr(go_tasks.subprocess, "call", fake_call)
+        reports = module / "_tests"
+        reports.mkdir()
+        (reports / "coverage.out").write_text("mode: atomic\n")
+        go_tasks._cobertura(Config.load(root=module), reports / "coverage.out", reports / "coverage.xml")
+        assert seen["argv"][0].endswith("gocover-cobertura")
+        assert seen["kwargs"]["stdin"].name.endswith("coverage.out")
+        assert (reports / "coverage.xml").is_file()
 
     def test_deps_needs_no_tool_at_all(self, module: Path, recorder: Recorder) -> None:
         """``go mod tidy -diff`` is both halves of deptry's job in one command.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ the make recipes said in ``$$``-escaped shell.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -154,6 +155,55 @@ class TestTest:
         (cfg.root / ".coverage.host.1").write_text("corrupt")
         python.test(cfg)
         assert not list(cfg.root.glob(".coverage*"))
+
+
+class TestCoverage:
+    """The ``coverage`` gate the Python layer was missing."""
+
+    def test_writes_the_cobertura_path_the_other_layers_write(self, cfg: Config, recorder: Recorder) -> None:
+        """One name, one output path, in all three layers.
+
+        python.mk had no ``coverage`` target -- its ``test`` recipe carries the ``--cov``
+        flags -- while rust.mk and go.mk both define one, and the gate-parity contract
+        lists it for all three.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.coverage(cfg)
+        flags = recorder.find("pytest").flags
+        assert "--cov-report=xml:_tests/coverage.xml" in flags
+        assert f"--cov-fail-under={cfg.coverage_fail_under}" in flags
+        assert "--html=_tests/html-report/report.html" not in flags
+
+    def test_shares_its_flags_with_test(self, cfg: Config, recorder: Recorder) -> None:
+        """``test`` and ``coverage`` cannot drift, because the flags are built once.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.test(cfg)
+        from_test = set(recorder.find("pytest").flags)
+        assert set(python.coverage_args(cfg)) <= from_test
+
+    def test_skips_without_a_source_folder(self, cfg: Config, recorder: Recorder) -> None:
+        """Coverage of nothing is the skip ``--strict`` exists to catch.
+
+        ``test`` warns and runs anyway, because the tests still have to run; ``coverage``
+        has nothing left to do at all.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        from rhiza_task import runner
+
+        shutil.rmtree(cfg.path("source_folder"))
+        state = runner.run(["coverage"], cfg)
+        assert state.status_of("coverage") is runner.Status.SKIPPED
+        assert "pytest" not in recorder.tools()
 
 
 class TestTypecheck:


### PR DESCRIPTION
Closes #10.

## Why this exists twice

#15 carried this work, and it merged — into `feat/rust-and-go-layers`, about a minute *after* that branch had already gone to main as #14. So the coverage commits ended up on a branch nobody was merging any more, main never got them, and #10 stayed open. This is the same two commits cherry-picked onto current main; the diff against #15 is nil apart from where it applies.

## `coverage`

The one gate named in rhiza's parity table with no CLI equivalent, and the most pressing gap: CI uploads `_tests/coverage.xml` and `book`'s badge step reads it from exactly that path, so a layer that does not write it ships a docs site with an unmeasured badge.

| layer | how |
|---|---|
| Python | the `--cov` flags `test` already carried, under the name the other layers use |
| Rust | `cargo llvm-cov nextest --fail-under-lines N --cobertura --output-path _tests/coverage.xml`, plus the HTML report |
| Go | `go test -covermode=atomic -coverprofile`, `gocover-cobertura`, `go tool cover -html`, and the floor |

- **Python** had no `coverage` target at all — python.mk puts the coverage flags in `test`, so the Cobertura file was a side effect of the test gate. The flags are built once now and shared by both, so the two cannot drift.
- **Go** is the only one needing a task body rather than argument vectors, for two reasons that are Go's, not this port's. `gocover-cobertura` reads stdin and writes stdout — the one recipe in the whole port that genuinely needs a pipe, handled with two file handles rather than by giving `uv.py` a redirection feature nothing else would use, and still with no shell. And `go test` has no `--fail-under`, so the floor is read from the `total:` line of `go tool cover -func`, which is what go.mk does in awk. The profile path is spelled with forward slashes because it is an argument to go, not a filesystem operation — the Windows leg of the matrix caught that.

`all` does not gain `coverage` in any layer, matching all three makefiles.

## The other half of the issue: where the mother-repo-only targets go

`sync-self`, `sync-self-check`, `explain-bundles`, `e2e` and `gitlab-docker-test` are **not** candidates for this package — no bundle ships them, and the tooling behind them (`utils/link_dogfood.py`, `utils/explain_bundles.py`) lives in rhiza itself. They belong in `local.mk`, which the shim `-include`s for exactly that purpose.

What was missing was anyone saying so. The shim's header claims to replace "`.rhiza/rhiza.mk` and the ten fragments in `.rhiza/make.d/`" without mentioning that a repo carrying **its own** fragment has to relocate it *first* — deleting `rhiza.mk` removes the `-include .rhiza/make.d/*.mk` that was reaching it, and nothing announces the loss. README gets a section and the shim header a line, because `sync-self` maintains the `bundles/` ↔ root invariant the whole mother repo rests on.

`cargo-tools`, the other genuine gap in the issue, shipped in #14: `cargo nextest run` cannot run without it.

## One unrelated line

`config.py`'s import block: `Callable` (#13) and `Sequence` (#14) arrived in separate PRs and git merged them into an order isort rejects, so `ruff check` is currently red on main. Nothing in this repository runs ruff — it ships no pre-commit config, so `fmt` skips — which is why no gate noticed.

## Tests

Nine added — the Cobertura path and floor for each layer, that Python's `test` and `coverage` share their flags, that a source-less repo skips rather than measuring nothing, that a below-floor number fails in Go and an unreadable total warns rather than passing silently, and that the conversion runs as a redirect with no shell. 186 pass locally, and `rhiza-task all` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)