### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 # Changelog
 
-## [Unreleased]
+## [0.2.0] - 2026-08-18
 
 ### 🚀 Features
 
-- *(tasks)* Add `coverage` to all three layers (#10). It is named in the gate-parity
-  contract and writes `_tests/coverage.xml`, the path `book`'s badge step reads and CI
-  uploads. Python gains the name it was missing -- the flags its `test` already carried --
-  Rust gets `cargo llvm-cov --cobertura`, and Go gets the profile, the Cobertura
-  conversion, and the floor check `go test` has no flag for.
-- *(tasks)* Add the Rust and Go language layers (#9). `rhiza_task/tasks/` served one of
-  rhiza's three layers, so `core` could not drop the make layer without leaving `rust-core`
-  and `go-core` with no targets at all. Tasks now carry a layer, the registry is keyed
-  `layer:name`, and a bare `test` resolves against the manifests a repository actually has.
-  `RHIZA_CHECKS` is derived from the layer set, replacing the `+=` accumulator each
-  language fragment used.
+- *(tasks)* Add the Rust and Go language layers
+- *(config)* Add rhiza.toml, and read the table from Cargo.toml too
+- *(tasks)* Add coverage to all three layers
 
 ### 🐛 Bug Fixes
 
-- *(shim)* Bootstrap uv when it is absent, restoring the make layer's "`make <anything>`
-  works on a bare runner" contract (#8). `bootstrap.mk` provisioned uv itself; a shim whose
-  only recipe was `uvx ...` needed uv already on PATH, which turned rhiza's `pre-commit`
-  required check red on a runner with no `astral-sh/setup-uv` step.
+- *(config)* Split a string reaching a tuple field, and stop print eating markup
+- *(config)* Let RHIZA_CHECKS name the rhiza_checks field
+- *(shim)* Bootstrap uv when it is absent
+- *(go)* Pass the coverage profile path with forward slashes
+
+### 📚 Documentation
+
+- *(changelog)* Note the Rust and Go layers
+
+### 🎨 Styling
+
+- *(config)* Restore the import order two merges shuffled
 
 ## [0.1.2] - 2026-08-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.1.2"
+version = "0.2.0"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.1.2 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@0.2.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -9,7 +9,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.1.2
+RHIZA_TASK ?= rhiza-task@0.2.0
 
 # The one thing the shim cannot delegate to the CLI: uv itself, because uv is what runs
 # the CLI. `bootstrap.mk` had an `install-uv` target for exactly this, and the make layer's

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Version bump only: **0.1.2 → 0.2.0**. Chosen as a minor because the three `feat` commits since v0.1.2 add behaviour compatibly — no commit is marked breaking.

## Files the bump touched

| file | why it is a version location |
|---|---|
| `pyproject.toml` | `[project] version` — bump-my-version's own source, no `current_version` key in the config |
| `src/rhiza_task/__init__.py` | `__version__`, plus the `uvx rhiza-task@…` example in the module docstring |
| `src/rhiza_task/templates/Makefile` | `RHIZA_TASK ?= rhiza-task@0.2.0` — the shim's default pin. A release that left this behind would hand consumers a Makefile pinned to the previous version |
| `uv.lock` | the project's own entry. Not a bumpversion location; it moved because `uv sync` re-recorded it, and it belongs in this commit because the `install` gate runs `uv lock --check` |

No self-referencing `uses:` in `.github/` — every workflow pin is third-party — so nothing here depends on the tag existing.

## Changelog

The generated `## [0.2.0]` section replaces the hand-written `## [Unreleased]` block that accumulated over the four issue PRs, so the entries read like every other release in the file. Nothing below `## [0.1.2]` changed.

Nine commits: 3 feat (the Rust and Go language layers, the `rhiza.toml`/`Cargo.toml` config layer, `coverage` for all three layers), 4 fix, 1 docs, 1 style.

## Merging this does not publish the release

There is **no tag yet**, deliberately: a tag has to name a commit that exists on `main`, and a squash-merge replaces this branch's commit with a new one. The tag is cut afterwards, from the merged commit, by a second `/rhiza:release` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
