### PR TITLE
feat(tasks): tasks for the five bundles .rhiza/make.d could not retire

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ a full copy at a template tag, and everything downstream was damage control.
 | before, per consumer repo | after |
 |---|---|
 | `.rhiza/rhiza.mk` — 200 lines, synced | *gone* |
-| `.rhiza/make.d/*.mk` — 823 lines in 10 files, synced | *gone* |
+| `.rhiza/make.d/*.mk` — 1023 lines in 15 files, synced | *gone* |
 | `exclude:` entries in `template.yml`, because "a deletion alone is undone by the next sync" | not needed |
 | targets shadowed in the repo Makefile, make printing `overriding commands for target` as the mechanism working | `[tool.rhiza-task]` |
 | ~40 lines of GNU-make guard and Windows POSIX-shell probe | gone — no make, no shell |
@@ -60,6 +60,20 @@ pinned CLI, so a consumer still on an older reusable workflow needs no change.
 | Testing extras | `benchmark` `hypothesis-test` `stress` `mutation` |
 | Book | `book` `serve` `marimo` `marimo-validate` |
 | Dev | `doctor` `clean` |
+| GitHub Helpers | `view-prs` `view-issues` `failed-workflows` `workflow-status` `latest-release` `whoami` |
+| Docker | `docker-build` `docker-run` `docker-clean` |
+| Git LFS | `lfs-install` `lfs-pull` `lfs-track` `lfs-status` |
+| Paper | `paper` `paper-clean` |
+| Presentation | `presentation` `presentation-pdf` `presentation-serve` |
+
+The last five sections are the bundle-owned fragments `.rhiza/make.d/` had to keep because
+nothing here answered for their targets. None is a gate — no `all` names them and no
+workflow invokes them — so each is guarded on the CLI it wraps and **skips** when that tool
+is absent, with `--strict` available to a caller who wants the fragment's hard failure
+instead. Two changed behaviour on purpose, and say so in their module docstring:
+`lfs-install` configures the repository and reports how to install the binary rather than
+downloading one, and `presentation` reaches Marp through `npx --yes` rather than
+`npm install -g`.
 
 ### Three layers, one set of names
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,14 @@ quality = "rhiza_task.tasks.quality"
 extras = "rhiza_task.tasks.extras"
 book = "rhiza_task.tasks.book"
 doctor = "rhiza_task.tasks.doctor"
+# The five bundle-owned fragments `.rhiza/make.d/` kept because nothing here answered for
+# their targets. One module per bundle, so which bundle owns a task stays as legible as it
+# was when each was a file the template synced.
+github = "rhiza_task.tasks.github"
+docker = "rhiza_task.tasks.docker"
+lfs = "rhiza_task.tasks.lfs"
+paper = "rhiza_task.tasks.paper"
+presentation = "rhiza_task.tasks.presentation"
 
 [project.urls]
 Homepage = "https://github.com/jebel-quant/rhiza-task"

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -173,6 +173,21 @@ class Config:
     go_flags: tuple[str, ...] = ()
     go_test_flags: tuple[str, ...] = ("-race", "-shuffle=on")
     mkdocs_extra_packages: tuple[str, ...] = ()
+
+    # The five bundle-owned fragments' settings. docker.mk's DOCKER_FOLDER was a `:=`
+    # rather than a `?=` -- not configurable at all -- and paper.mk hard-coded the
+    # PRESENTATION.md equivalent; both are ordinary settings here, because there is no
+    # longer a cost to making one.
+    docker_folder: str = "docker"
+    # Empty rather than a computed default: docker.mk's `?= $(shell basename $(CURDIR))`
+    # cannot be spelled as a dataclass default, and resolving it in the task body keeps
+    # `rhiza-task print docker_image` honest about the setting being unset.
+    docker_image: str = ""
+    paper_folder: str = "docs/paper"
+    presentation_file: str = "PRESENTATION.md"
+    # Unpinned, because `npm install -g @marp-team/marp-cli` was too: presentation.mk
+    # installed whatever latest resolved to. Set it to `@marp-team/marp-cli@4.2.3` to pin.
+    marp_package: str = "@marp-team/marp-cli"
     zensical_version: str = ">=0.0.36"
     uv_sync_args: tuple[str, ...] = ("--all-extras", "--all-groups")
     ci_os_matrix: tuple[str, ...] = DEFAULT_CI_OS_MATRIX
@@ -382,9 +397,7 @@ def _table(path: Path, select: Callable[[dict[str, Any]], Any]) -> dict[str, Any
     if not isinstance(table, dict):
         return {}
     return {
-        k.replace("-", "_"): tuple(v) if isinstance(v, list) else v
-        for k, v in table.items()
-        if not isinstance(v, dict)
+        k.replace("-", "_"): tuple(v) if isinstance(v, list) else v for k, v in table.items() if not isinstance(v, dict)
     }
 
 

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -76,12 +76,25 @@ class Guard:
     manifest rather than a folder, because ``cargo`` and ``go`` find the sources
     themselves. It is a literal path, not a config field -- ``Cargo.toml`` and ``go.mod``
     are named by their toolchains and are not a repository's choice to make.
+
+    ``tool`` is a precondition on the *machine* rather than on the repository, and it is
+    what github.mk's ``require-gh`` was: a target whose whole body is
+    ``command -v gh >/dev/null || exit 1``, declared as a prerequisite of every helper.
+    The five bundle-owned fragments are mostly wrappers over a CLI nobody can assume is
+    installed -- gh, docker, git-lfs, latexmk, marp -- so the check is declared once here
+    rather than repeated as the first three lines of a dozen task bodies.
+
+    A missing tool is a :class:`Skip`, not a failure, which is a deliberate change from
+    ``require-gh``'s hard exit. Nothing here is a gate, so a machine without docker should
+    not fail a run that asked for something else too -- and ``--strict`` is the switch for
+    a caller who does want it to.
     """
 
     folder: str | None = None
     glob: str | None = None
     reason: str = ""
     file: str | None = None
+    tool: str | None = None
 
     def check(self, root: Path, folders: dict[str, str]) -> None:
         """Raise :class:`Skip` when the guard is not satisfied.
@@ -91,9 +104,11 @@ class Guard:
             folders: Resolved folder settings, e.g. ``{"source_folder": "src"}``.
 
         Raises:
-            Skip: When the file is missing, or the folder is missing, or the folder holds
-                no file matching ``glob``.
+            Skip: When the tool is absent, or the file is missing, or the folder is
+                missing, or the folder holds no file matching ``glob``.
         """
+        if self.tool and not have(self.tool):
+            raise Skip(self.reason or f"{self.tool} not found")
         if self.file and not (root / self.file).is_file():
             raise Skip(self.reason or f"no {self.file}")
         if self.folder is None:

--- a/src/rhiza_task/tasks/docker.py
+++ b/src/rhiza_task/tasks/docker.py
@@ -1,0 +1,98 @@
+"""The container tasks: docker.mk, as tasks.
+
+Three wrappers over the docker CLI, and the shortest of the five fragments. The only
+thing worth stating is what the image is called: docker.mk defaults it to
+``$(shell basename $(CURDIR))``, so an unset :attr:`~rhiza_task.config.Config.docker_image`
+resolves to the repository directory's name here too -- moving a checkout would rename the
+image, which is surprising but is the behaviour consumers already have.
+
+``docker-build`` skips rather than fails on a missing Dockerfile, as the fragment does.
+That is not the same judgement as the tool guard's: a repository with no ``docker/``
+folder has adopted the bundle and not used it yet, whereas a machine with no docker
+cannot answer the question at all. Both are a skip, and ``--strict`` fails both.
+"""
+
+from __future__ import annotations
+
+from ..config import Config
+from ..spec import Guard, Skip, task
+from ..uv import tool
+
+SECTION = "Docker"
+
+HAVE_DOCKER = Guard(tool="docker", reason="docker not found; install from https://docs.docker.com/get-docker/")
+
+
+def image_name(cfg: Config) -> str:
+    """Return the tag to build and run.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The configured image name, or the repository directory's name.
+    """
+    return cfg.docker_image or cfg.root.name
+
+
+@task("docker-build", "build the Docker image", section=SECTION, guards=(HAVE_DOCKER,))
+def docker_build(cfg: Config) -> None:
+    """Build ``<docker_folder>/Dockerfile`` with the repository root as the context.
+
+    ``PYTHON_VERSION`` is passed as a build argument whatever the layer, as docker.mk
+    does. A Dockerfile that declares no such ``ARG`` gets a warning from docker and
+    nothing else, which is cheaper than making the flag conditional on a language.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When the folder holds no Dockerfile.
+    """
+    dockerfile = cfg.root / cfg.docker_folder / "Dockerfile"
+    if not dockerfile.is_file():
+        raise Skip(f"no {cfg.docker_folder}/Dockerfile")
+
+    tag = f"{image_name(cfg)}:latest"
+    print(f"[INFO] building {tag} with Python {cfg.python_version}")
+    tool(
+        "docker",
+        "buildx",
+        "build",
+        "--file",
+        f"{cfg.docker_folder}/Dockerfile",
+        "--build-arg",
+        f"PYTHON_VERSION={cfg.python_version}",
+        "--tag",
+        tag,
+        "--load",
+        ".",
+        cwd=cfg.root,
+    )
+
+
+@task("docker-run", "run the Docker container", section=SECTION, needs=("docker-build",), guards=(HAVE_DOCKER,))
+def docker_run(cfg: Config) -> None:
+    """Run the built image interactively, removing the container on exit.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tag = f"{image_name(cfg)}:latest"
+    print(f"[INFO] running {tag}")
+    tool("docker", "run", "--rm", "-it", tag, cwd=cfg.root)
+
+
+@task("docker-clean", "remove the Docker image", section=SECTION, guards=(HAVE_DOCKER,))
+def docker_clean(cfg: Config) -> None:
+    """Delete the image, tolerating its absence.
+
+    ``check=False`` is docker.mk's ``2>/dev/null || true``: removing an image that was
+    never built is the expected state of a clean target, not a failure.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tag = f"{image_name(cfg)}:latest"
+    print(f"[INFO] removing {tag}")
+    tool("docker", "rmi", tag, cwd=cfg.root, check=False)

--- a/src/rhiza_task/tasks/github.py
+++ b/src/rhiza_task/tasks/github.py
@@ -1,0 +1,269 @@
+"""The GitHub helpers: github.mk, as tasks.
+
+Six thin wrappers over ``gh``, and the reason the fragment could not retire with the
+other ten: ``github`` is in the ``github-project`` profile, so a consumer on the flagship
+profile would have lost ``make view-prs``.
+
+Nothing here is a gate. No aggregate names them, no workflow invokes them, and they
+produce a table for a human at a prompt -- which is why the gh templates are carried over
+character for character rather than reimplemented against ``--json``. Reproducing
+``timeago`` and gh's colour handling in Python would be a worse table and a new thing to
+maintain.
+
+Two shapes from the fragment disappear:
+
+``require-gh`` and ``gh-install`` were both "is gh installed?", spelled twice because make
+has no way to say it once -- one hard-failing as a prerequisite, one warning as a target a
+human runs. :class:`~rhiza_task.spec.Guard`'s ``tool`` field says it once, and the
+outcome is a skip with the install URL attached. ``gh-install`` as a *task* goes: it never
+installed anything, and ``rhiza-task doctor`` is where "what is missing on this machine"
+belongs.
+
+``FORGE_TYPE`` goes too. github.mk computes it at parse time from the presence of
+``.github/workflows`` or ``.gitlab-ci.yml`` and then no target in the fragment -- or in
+any other fragment -- ever reads it.
+"""
+
+from __future__ import annotations
+
+from ..config import Config
+from ..spec import Guard, Skip, task
+from ..uv import capture, tool
+
+SECTION = "GitHub Helpers"
+
+HAVE_GH = Guard(
+    tool="gh",
+    reason="gh not found; install from https://github.com/cli/cli#installation",
+)
+"""The single spelling of ``require-gh``, shared by every task in this module."""
+
+RELEASE_WORKFLOW_JQ = '.[] | select(.name | test("release";"i")) | .name'
+"""github.mk's own filter: the first workflow whose name mentions "release", any case."""
+
+
+def _header(*labels: str) -> str:
+    """Build the bold header row of a gh table template.
+
+    Args:
+        *labels: Column headings, in order.
+
+    Returns:
+        A ``{{tablerow ...}}`` action rendering them in bold.
+    """
+    cells = " ".join(f'(printf "{label}" | color "bold")' for label in labels)
+    return "{{tablerow " + cells + "}}"
+
+
+PR_TEMPLATE = _header("NUM", "TITLE", "AUTHOR", "BRANCH", "UPDATED") + (
+    "{{range .}}{{tablerow "
+    '(printf "#%v" .number | color "green") '
+    ".title "
+    '(.author.login | color "cyan") '
+    '(.headRefName | color "yellow") '
+    '(timeago .updatedAt | color "white")'
+    "}}{{end}}"
+)
+
+ISSUE_TEMPLATE = _header("NUM", "TITLE", "AUTHOR", "LABELS", "UPDATED") + (
+    "{{range .}}{{tablerow "
+    '(printf "#%v" .number | color "green") '
+    ".title "
+    '(.author.login | color "cyan") '
+    '(pluck "name" .labels | join ", " | color "yellow") '
+    '(timeago .updatedAt | color "white")'
+    "}}{{end}}"
+)
+
+FAILED_RUN_TEMPLATE = _header("STATUS", "NAME", "BRANCH", "EVENT", "TIME") + (
+    "{{range .}}{{tablerow "
+    '(printf "%s" .conclusion | color "red") '
+    ".name "
+    '(.headBranch | color "cyan") '
+    '(.event | color "yellow") '
+    '(timeago .createdAt | color "white")'
+    "}}{{end}}"
+)
+
+WORKFLOW_RUN_TEMPLATE = _header("STATUS", "CONCLUSION", "TITLE", "EVENT", "TIME") + (
+    "{{range .}}{{tablerow "
+    '(printf "%s" .status | color "cyan") '
+    '(printf "%s" (or .conclusion "—") | color '
+    '(or (and (eq .conclusion "success") "green") (and (eq .conclusion "failure") "red") "yellow")) '
+    ".displayTitle "
+    '(.event | color "yellow") '
+    '(timeago .createdAt | color "white")'
+    "}}{{end}}"
+)
+
+WHOAMI_TEMPLATE = (
+    "{{range $host, $accounts := .hosts}}{{range $accounts}}{{if .active}}"
+    r'  {{printf "✓" | color "green"}} Logged in to {{$host}} account '
+    r'{{.login | color "bold"}} ({{.tokenSource}}){{"\n"}}'
+    r'  Active account: {{printf "true" | color "green"}}{{"\n"}}'
+    r'  Git operations protocol: {{.gitProtocol | color "yellow"}}{{"\n"}}'
+    r'  Token scopes: {{.scopes | color "yellow"}}{{"\n"}}'
+    "{{end}}{{end}}{{end}}"
+)
+
+RELEASE_TEMPLATE = (
+    r'  Tag:          {{.tagName | color "green"}}{{"\n"}}'
+    r'  Name:         {{.name}}{{"\n"}}'
+    r'  Author:       {{.author.login}}{{"\n"}}'
+    r'  Published:    {{timeago .publishedAt}}{{"\n"}}'
+    r"  Status:       {{if .isDraft}}"
+    r'{{printf "Draft" | color "yellow"}}'
+    r"{{else if .isPrerelease}}"
+    r'{{printf "Pre-release" | color "yellow"}}'
+    r"{{else}}"
+    r'{{printf "Published" | color "green"}}'
+    r'{{end}}{{"\n"}}'
+    r'  URL:          {{.url}}{{"\n"}}'
+)
+
+
+@task("view-prs", "list open pull requests", section=SECTION, guards=(HAVE_GH,))
+def view_prs(cfg: Config) -> None:
+    """List the repository's open pull requests as a table.
+
+    Args:
+        cfg: The resolved config.
+    """
+    print("[INFO] Open Pull Requests:")
+    tool(
+        "gh",
+        "pr",
+        "list",
+        "--json",
+        "number,title,author,headRefName,updatedAt",
+        "--template",
+        PR_TEMPLATE,
+        cwd=cfg.root,
+    )
+
+
+@task("view-issues", "list open issues", section=SECTION, guards=(HAVE_GH,))
+def view_issues(cfg: Config) -> None:
+    """List the repository's open issues as a table.
+
+    Args:
+        cfg: The resolved config.
+    """
+    print("[INFO] Open Issues:")
+    tool(
+        "gh",
+        "issue",
+        "list",
+        "--json",
+        "number,title,author,labels,updatedAt",
+        "--template",
+        ISSUE_TEMPLATE,
+        cwd=cfg.root,
+    )
+
+
+@task("failed-workflows", "list recent failing workflow runs", section=SECTION, guards=(HAVE_GH,))
+def failed_workflows(cfg: Config) -> None:
+    """Show the ten most recent runs that concluded in failure.
+
+    Args:
+        cfg: The resolved config.
+    """
+    print("[INFO] Recent Failing Workflow Runs:")
+    tool(
+        "gh",
+        "run",
+        "list",
+        "--limit",
+        "10",
+        "--status",
+        "failure",
+        "--json",
+        "conclusion,name,headBranch,event,createdAt",
+        "--template",
+        FAILED_RUN_TEMPLATE,
+        cwd=cfg.root,
+    )
+
+
+@task("workflow-status", "show recent runs for the release workflow", section=SECTION, guards=(HAVE_GH,))
+def workflow_status(cfg: Config) -> None:
+    """Find the release workflow by name, then show its five most recent runs.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When no workflow's name mentions "release".
+    """
+    listing = capture("gh", "workflow", "list", "--json", "name,id", "--jq", RELEASE_WORKFLOW_JQ, cwd=cfg.root)
+    workflow = next((line.strip() for line in listing.splitlines() if line.strip()), "")
+    if not workflow:
+        raise Skip("no release workflow in this repository")
+
+    print(f"[INFO] Release workflow: {workflow}")
+    tool(
+        "gh",
+        "run",
+        "list",
+        "--workflow",
+        workflow,
+        "--limit",
+        "5",
+        "--json",
+        "status,conclusion,headBranch,event,createdAt,displayTitle,url",
+        "--template",
+        WORKFLOW_RUN_TEMPLATE,
+        cwd=cfg.root,
+    )
+
+
+@task("latest-release", "show information about the latest GitHub release", section=SECTION, guards=(HAVE_GH,))
+def latest_release(cfg: Config) -> None:
+    """Print tag, author, publication time and status for the newest release.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When the repository has published no release.
+    """
+    # The probe is `capture`, not a second `gh release view`: it is the one call whose
+    # *value* matters rather than its output, and capture returns "" for a non-zero exit,
+    # which is exactly github.mk's `if gh release view ... >/dev/null 2>&1` branch.
+    if not capture("gh", "release", "view", "--json", "tagName", "--jq", ".tagName", cwd=cfg.root):
+        raise Skip("no releases in this repository")
+
+    print("[INFO] Latest release:")
+    tool(
+        "gh",
+        "release",
+        "view",
+        "--json",
+        "tagName,name,publishedAt,url,isDraft,isPrerelease,author",
+        "--template",
+        RELEASE_TEMPLATE,
+        cwd=cfg.root,
+    )
+
+
+@task("whoami", "check github auth status", section=SECTION, guards=(HAVE_GH,))
+def whoami(cfg: Config) -> None:
+    """Report which account gh is authenticated as, and with what scopes.
+
+    Args:
+        cfg: The resolved config.
+    """
+    print("[INFO] GitHub Authentication Status:")
+    tool(
+        "gh",
+        "auth",
+        "status",
+        "--hostname",
+        "github.com",
+        "--json",
+        "hosts",
+        "--template",
+        WHOAMI_TEMPLATE,
+        cwd=cfg.root,
+    )

--- a/src/rhiza_task/tasks/lfs.py
+++ b/src/rhiza_task/tasks/lfs.py
@@ -1,0 +1,107 @@
+"""The Git LFS tasks: lfs.mk, as tasks.
+
+Three of the four are one git subcommand each. The fourth, ``lfs-install``, is 50 lines of
+platform shell and is **deliberately not ported as written** -- what it did and what it is
+now differ, so the change is stated here rather than discovered.
+
+lfs.mk's ``lfs-install`` has two branches. On Linux it runs ``apt-get install git-lfs``,
+with ``sudo`` when not root. On macOS it queries the GitHub releases API for the newest
+git-lfs, downloads the architecture-matched zip into ``.local/tmp``, extracts the binary
+into ``.local/bin``, and runs ``PATH=$PWD/.local/bin:$PATH git-lfs install``.
+
+The macOS branch does not leave a working installation. ``.local/bin`` is not on PATH
+after the recipe exits, and every other target in the fragment -- and every ``git lfs``
+anywhere else -- invokes the bare command, so ``make lfs-install && make lfs-pull``
+fails on a machine that had no git-lfs. The one thing the branch achieves that survives is
+the ``git lfs install`` at the end, which writes the filter and hook configuration into
+the repository.
+
+So this task does that part, and *reports* how to install the binary rather than
+downloading one. Two reasons beyond the broken branch: a task runner provisioned by
+``uvx`` should not be shelling out to ``sudo apt-get`` as a side effect of a target
+someone typed, and pinning a download URL to a release-API shape is a maintenance
+liability for something ``brew``/``apt``/``winget`` all do properly.
+
+Consumers who relied on the apt branch need one line of their own -- in CI, the
+``setup-git-lfs`` action or the distribution's package; locally, their package manager.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from ..config import Config
+from ..spec import Failed, Guard, have, task
+from ..uv import tool
+
+SECTION = "Git LFS"
+
+INSTALL_URL = "https://github.com/git-lfs/git-lfs#installing"
+
+INSTALL_HINTS = {
+    "darwin": "brew install git-lfs",
+    "linux": "sudo apt-get install git-lfs  (or your distribution's package)",
+    "win32": "winget install GitHub.GitLFS",
+}
+"""How to get the binary, by :data:`sys.platform`. Reported, never run."""
+
+HAVE_LFS = Guard(tool="git-lfs", reason=f"git-lfs not found; see {INSTALL_URL}")
+"""``git lfs <cmd>`` needs the ``git-lfs`` binary on PATH; git reports it as an unknown
+command otherwise, which is a confusing way to learn that a tool is missing."""
+
+
+def install_hint() -> str:
+    """Return the platform's install command, for the message a missing binary produces.
+
+    Returns:
+        A command to run, or the project's install page when the platform is unknown.
+    """
+    return INSTALL_HINTS.get(sys.platform, f"see {INSTALL_URL}")
+
+
+@task("lfs-install", "configure git-lfs for this repository", section=SECTION)
+def lfs_install(cfg: Config) -> None:
+    """Run ``git lfs install``, writing this repository's filter and hook configuration.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Failed: When the git-lfs binary is absent. A failure rather than a skip, unlike
+            every other tool guard in this module's siblings: installing is the one thing
+            this task exists to do, so it has nothing left to report success about.
+    """
+    if not have("git-lfs"):
+        print(f"[ERROR] git-lfs not found. Install it with:\n    {install_hint()}")
+        raise Failed(1, "git-lfs is not installed")
+    tool("git", "lfs", "install", cwd=cfg.root)
+
+
+@task("lfs-pull", "download the LFS files for the current branch", section=SECTION, guards=(HAVE_LFS,))
+def lfs_pull(cfg: Config) -> None:
+    """Fetch and check out the LFS objects the working tree points at.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tool("git", "lfs", "pull", cwd=cfg.root)
+
+
+@task("lfs-track", "list the patterns tracked by git-lfs", section=SECTION, guards=(HAVE_LFS,))
+def lfs_track(cfg: Config) -> None:
+    """Show the ``.gitattributes`` patterns routed through LFS.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tool("git", "lfs", "track", cwd=cfg.root)
+
+
+@task("lfs-status", "show the status of LFS files", section=SECTION, guards=(HAVE_LFS,))
+def lfs_status(cfg: Config) -> None:
+    """Show which LFS files are modified, staged, or not yet pushed.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tool("git", "lfs", "status", cwd=cfg.root)

--- a/src/rhiza_task/tasks/paper.py
+++ b/src/rhiza_task/tasks/paper.py
@@ -1,0 +1,94 @@
+"""The LaTeX tasks: paper.mk, as tasks.
+
+Closer in shape to ``book`` than to the CLI wrappers: a build with an output worth
+naming. latexmk does the hard part -- it reruns pdflatex and bibtex until the references
+converge -- so the task is a folder, a file choice and a fixed flag set.
+
+The file choice is the one thing that changes. paper.mk reads
+
+    if [ -f $(PAPER_DIR)/basanos.tex ]; then tex_file="basanos.tex"; else <first *.tex>; fi
+
+-- a named preference for one downstream repository's paper, in a template every consumer
+syncs. :func:`main_document` replaces it with two conventional names and then alphabetical
+order, so the behaviour is the same for a folder with one ``.tex`` (the overwhelmingly
+common case) and no longer privileges a stranger's filename.
+
+``-maxdepth 1`` survives as :meth:`~pathlib.Path.glob` rather than
+:meth:`~pathlib.Path.rglob`, and deliberately: a LaTeX project's subdirectories hold
+included chapters, and latexmk must be pointed at the root document, not at a chapter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import Config
+from ..spec import Guard, Skip, task
+from ..uv import tool
+
+SECTION = "Paper"
+
+HAVE_LATEXMK = Guard(
+    tool="latexmk",
+    reason="latexmk not found; install a LaTeX distribution (MacTeX, TeX Live)",
+)
+
+PREFERRED = ("main.tex", "paper.tex")
+"""Root-document names tried before falling back to alphabetical order."""
+
+
+def main_document(folder: Path) -> Path | None:
+    """Choose the root ``.tex`` file in a folder.
+
+    Args:
+        folder: The paper folder.
+
+    Returns:
+        The document to compile, or None when the folder holds no top-level ``.tex``.
+    """
+    candidates = sorted(p for p in folder.glob("*.tex") if p.is_file())
+    if not candidates:
+        return None
+    by_name = {p.name: p for p in candidates}
+    return next((by_name[name] for name in PREFERRED if name in by_name), candidates[0])
+
+
+@task("paper", "compile the LaTeX paper to PDF", section=SECTION, guards=(HAVE_LATEXMK, Guard("paper_folder")))
+def paper(cfg: Config) -> None:
+    """Run latexmk over the paper folder's root document.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When the folder holds no top-level ``.tex`` file.
+    """
+    folder = cfg.path("paper_folder")
+    document = main_document(folder)
+    if document is None:
+        raise Skip(f"no .tex files in '{cfg.paper_folder}'")
+
+    print(f"[INFO] compiling {document.name}")
+    # cwd is the paper folder, as `cd $(PAPER_DIR) && latexmk` was: latexmk writes its
+    # auxiliary files beside the document, and \input paths are relative to it.
+    tool("latexmk", "-pdf", "-bibtex", "-interaction=nonstopmode", document.name, cwd=folder)
+    print(f"[SUCCESS] {cfg.paper_folder}/{document.stem}.pdf")
+
+
+@task("paper-clean", "remove the latexmk build artifacts", section=SECTION, guards=(HAVE_LATEXMK,))
+def paper_clean(cfg: Config) -> None:
+    """Run ``latexmk -C``, removing the generated PDF and every auxiliary file.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When there is no paper folder to clean.
+    """
+    folder = cfg.path("paper_folder")
+    if not folder.is_dir():
+        raise Skip(f"paper_folder '{cfg.paper_folder}' not found")
+    # `|| true`, as paper.mk has it: cleaning a folder that was never built is the
+    # expected state of a clean target.
+    tool("latexmk", "-C", cwd=folder, check=False)
+    print(f"[SUCCESS] cleaned {cfg.paper_folder}")

--- a/src/rhiza_task/tasks/presentation.py
+++ b/src/rhiza_task/tasks/presentation.py
@@ -1,0 +1,128 @@
+"""The Marp tasks: presentation.mk, as tasks.
+
+The fragment's ``require-marp`` does not check for Marp, it *installs* it:
+
+    if ! command -v marp; then npm install -g @marp-team/marp-cli; fi
+
+-- a global npm install, triggered by typing ``make presentation``, mutating a machine
+outside the repository. :func:`marp_argv` keeps the property that made that acceptable (a
+consumer with Node but no Marp can still build slides) without the mutation: ``npx --yes``
+runs the CLI from npm's cache instead. The precedence is Marp on PATH first, so a
+deliberately installed or pinned Marp still wins.
+
+:attr:`~rhiza_task.config.Config.marp_package` is what npx is given, unpinned by default
+because ``npm install -g @marp-team/marp-cli`` was unpinned too. Pin it to
+``@marp-team/marp-cli@4.2.3`` when reproducible slides matter more than current ones.
+
+``PRESENTATION.md`` becomes a setting rather than a constant, and the output name is
+derived from it -- lower-cased, so the default still produces ``presentation.html`` and
+``presentation.pdf`` exactly as the fragment does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import Config
+from ..spec import Skip, have, task
+from ..uv import tool
+
+SECTION = "Presentation"
+
+NODE_URL = "https://nodejs.org/"
+
+
+def marp_argv(cfg: Config) -> tuple[str, tuple[str, ...]]:
+    """Resolve how to reach the Marp CLI on this machine.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The executable to run and the arguments that must precede Marp's own.
+
+    Raises:
+        Skip: When neither marp nor npx is available.
+    """
+    if have("marp"):
+        return "marp", ()
+    if have("npx"):
+        return "npx", ("--yes", cfg.marp_package)
+    raise Skip(f"neither marp nor npx found; install Node.js ({NODE_URL})")
+
+
+def source(cfg: Config) -> Path:
+    """Return the slide deck's source file.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The absolute path to the configured Markdown file.
+
+    Raises:
+        Skip: When the file does not exist.
+    """
+    path = cfg.root / cfg.presentation_file
+    if not path.is_file():
+        raise Skip(f"no {cfg.presentation_file}")
+    return path
+
+
+def output(cfg: Config, suffix: str) -> str:
+    """Return the output filename for a format.
+
+    Lower-cased so that the default ``PRESENTATION.md`` yields ``presentation.html``,
+    which is the name presentation.mk hard-codes and the one a consumer's ``.gitignore``
+    and links already point at.
+
+    Args:
+        cfg: The resolved config.
+        suffix: The output extension, with its dot.
+
+    Returns:
+        A repository-relative filename.
+    """
+    return Path(cfg.presentation_file).with_suffix(suffix).name.lower()
+
+
+@task("presentation", "generate the HTML slides with Marp", section=SECTION)
+def presentation(cfg: Config) -> None:
+    """Export the deck to a single HTML file.
+
+    Args:
+        cfg: The resolved config.
+    """
+    binary, prefix = marp_argv(cfg)
+    target = output(cfg, ".html")
+    tool(binary, *prefix, source(cfg).name, "-o", target, cwd=cfg.root)
+    print(f"[SUCCESS] {target} — open it in a browser to view the slides")
+
+
+@task("presentation-pdf", "generate the PDF slides with Marp", section=SECTION)
+def presentation_pdf(cfg: Config) -> None:
+    """Export the deck to PDF.
+
+    ``--allow-local-files`` is presentation.mk's and is required rather than optional:
+    Marp renders the PDF through headless Chrome, which refuses ``file://`` images
+    without it, so a deck with a local logo silently loses it.
+
+    Args:
+        cfg: The resolved config.
+    """
+    binary, prefix = marp_argv(cfg)
+    target = output(cfg, ".pdf")
+    tool(binary, *prefix, source(cfg).name, "-o", target, "--allow-local-files", cwd=cfg.root)
+    print(f"[SUCCESS] {target}")
+
+
+@task("presentation-serve", "serve the slides with Marp's live preview", section=SECTION)
+def presentation_serve(cfg: Config) -> None:
+    """Start Marp's watching server over the repository.
+
+    Args:
+        cfg: The resolved config.
+    """
+    binary, prefix = marp_argv(cfg)
+    print("[INFO] starting the Marp server (Ctrl-C to stop)")
+    tool(binary, *prefix, "-s", ".", cwd=cfg.root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,19 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> Recorder:
         The recorder collecting every call.
     """
     rec = Recorder()
-    modules = ("python", "quality", "extras", "book", "rust", "go")
+    modules = (
+        "python",
+        "quality",
+        "extras",
+        "book",
+        "rust",
+        "go",
+        "github",
+        "docker",
+        "lfs",
+        "paper",
+        "presentation",
+    )
     for name in modules:
         module = pytest.importorskip(f"rhiza_task.tasks.{name}")
         for kind in ("uv", "uvx", "uv_run", "tool"):

--- a/tests/test_bundle_tasks.py
+++ b/tests/test_bundle_tasks.py
@@ -1,0 +1,675 @@
+"""The five bundle-owned fragments, as tasks: github, docker, lfs, paper, presentation.
+
+These were the fragments `.rhiza/make.d/` could not retire, because no task answered for
+their targets. What is asserted here is what a make dry run could not: the argument vector
+each one builds, and the outcome when the tool it wraps is not installed.
+
+Every test patches ``shutil.which`` rather than the individual ``have`` bindings.
+:meth:`~rhiza_task.spec.Guard.check`, :func:`~rhiza_task.spec.have` and the task bodies all
+reach the same function, so one patch covers the guard and the body and they cannot
+disagree about whether a tool is present.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from collections.abc import Callable
+
+import pytest
+
+from rhiza_task import runner
+from rhiza_task.config import Config
+from rhiza_task.runner import Status
+from rhiza_task.spec import REGISTRY, Failed, Guard, Skip
+from rhiza_task.tasks import docker as docker_tasks
+from rhiza_task.tasks import github as github_tasks
+from rhiza_task.tasks import lfs as lfs_tasks
+from rhiza_task.tasks import paper as paper_tasks
+from rhiza_task.tasks import presentation as presentation_tasks
+
+from .conftest import Recorder
+
+FRAGMENT_TARGETS = {
+    "github.mk": ("view-prs", "view-issues", "failed-workflows", "workflow-status", "latest-release", "whoami"),
+    "docker.mk": ("docker-build", "docker-run", "docker-clean"),
+    "lfs.mk": ("lfs-install", "lfs-pull", "lfs-track", "lfs-status"),
+    "paper.mk": ("paper", "paper-clean"),
+    "presentation.mk": ("presentation", "presentation-pdf", "presentation-serve"),
+}
+"""Every target the five surviving fragments defined, minus the internal guards.
+
+``require-gh``, ``gh-install`` and ``require-marp`` are absent on purpose: two were the
+same "is it installed?" question spelled twice, and the third installed a global npm
+package as a side effect. See the modules' docstrings.
+"""
+
+
+@pytest.fixture
+def present(monkeypatch: pytest.MonkeyPatch) -> set[str]:
+    """Control which executables the tasks believe are installed.
+
+    Args:
+        monkeypatch: pytest's patcher.
+
+    Returns:
+        A mutable set of tool names; add to it to make a tool present.
+    """
+    installed: set[str] = set()
+
+    def fake_which(name: str, *args: object, **kwargs: object) -> str | None:
+        """Report a tool as found only when the test asked for it.
+
+        Args:
+            name: Executable name.
+            *args: Ignored.
+            **kwargs: Ignored.
+
+        Returns:
+            A fake absolute path, or None.
+        """
+        return f"/fake/{name}" if name in installed else None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    return installed
+
+
+def test_every_retired_target_has_a_task() -> None:
+    """No fragment target loses its name in the move to the CLI.
+
+    The point of the migration is that ``make view-prs`` keeps working through the shim's
+    catch-all, which it only does if the task is spelled identically.
+    """
+    for fragment, targets in FRAGMENT_TARGETS.items():
+        for target in targets:
+            assert target in REGISTRY, f"{fragment}'s {target} has no task"
+            assert REGISTRY[target].layer is None, f"{target} should be language-neutral"
+
+
+class TestToolGuard:
+    """``Guard(tool=...)``, which is what ``require-gh`` and ``require-marp`` were."""
+
+    def test_missing_tool_skips_with_the_reason(self, present: set[str], tmp_path) -> None:
+        """An absent tool is a skip carrying the install hint.
+
+        Args:
+            present: The installed-tool set, left empty.
+            tmp_path: pytest's temporary directory.
+        """
+        with pytest.raises(Skip, match="install from"):
+            Guard(tool="gh", reason="gh not found; install from https://example.invalid").check(tmp_path, {})
+
+    def test_present_tool_passes(self, present: set[str], tmp_path) -> None:
+        """A present tool satisfies the guard.
+
+        Args:
+            present: The installed-tool set.
+            tmp_path: pytest's temporary directory.
+        """
+        present.add("gh")
+        Guard(tool="gh").check(tmp_path, {})
+
+    def test_strict_turns_a_missing_tool_into_a_failure(self, repo, present: set[str]) -> None:
+        """``--strict`` is how a caller opts into the fragment's hard-fail behaviour.
+
+        Args:
+            repo: The throwaway repository.
+            present: The installed-tool set, left empty.
+        """
+        state = runner.run(["view-prs"], Config.load(root=repo, strict=True))
+        assert state.results[0].status is Status.FAILED
+
+
+class TestGitHub:
+    """github.mk's six helpers."""
+
+    def test_view_prs_asks_gh_for_the_fields_the_template_renders(
+        self, cfg: Config, recorder: Recorder, present: set[str]
+    ) -> None:
+        """Every column in the template is requested in ``--json``.
+
+        A mismatch is silent in gh: an unrequested field renders as empty rather than as
+        an error, so the table loses a column and nothing says why.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("gh")
+        github_tasks.view_prs(cfg)
+        call = recorder.find("gh")
+        fields = call.flags[call.flags.index("--json") + 1].split(",")
+        assert fields == ["number", "title", "author", "headRefName", "updatedAt"]
+        for field in ("number", "title", "author.login", "headRefName", "updatedAt"):
+            assert field in github_tasks.PR_TEMPLATE
+
+    def test_issue_template_renders_the_label_names(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """The labels column plucks names out of the label objects, as github.mk does.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("gh")
+        github_tasks.view_issues(cfg)
+        assert recorder.find("gh").flags[:2] == ["issue", "list"]
+        assert 'pluck "name" .labels' in github_tasks.ISSUE_TEMPLATE
+
+    def test_failed_workflows_asks_only_for_failures(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """The status filter and the limit are the recipe's.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("gh")
+        github_tasks.failed_workflows(cfg)
+        flags = recorder.find("gh").flags
+        assert flags[:2] == ["run", "list"]
+        assert "--status" in flags
+        assert flags[flags.index("--status") + 1] == "failure"
+        assert flags[flags.index("--limit") + 1] == "10"
+
+    def test_workflow_status_uses_the_first_matching_workflow(
+        self, cfg: Config, recorder: Recorder, present: set[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``head -1`` over the jq output, without a shell.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            monkeypatch: pytest's patcher.
+        """
+        present.add("gh")
+        monkeypatch.setattr(github_tasks, "capture", _canned("Release\nRelease notes\n"))
+        github_tasks.workflow_status(cfg)
+        flags = recorder.find("gh").flags
+        assert flags[flags.index("--workflow") + 1] == "Release"
+
+    def test_workflow_status_skips_a_repo_with_no_release_workflow(
+        self, cfg: Config, recorder: Recorder, present: set[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The WARN branch of the recipe, as a skip.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            monkeypatch: pytest's patcher.
+        """
+        present.add("gh")
+        monkeypatch.setattr(github_tasks, "capture", _canned(""))
+        with pytest.raises(Skip, match="no release workflow"):
+            github_tasks.workflow_status(cfg)
+        assert recorder.calls == []
+
+    def test_latest_release_skips_when_there_are_none(
+        self, cfg: Config, recorder: Recorder, present: set[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repository with no release reports that rather than showing gh's error.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            monkeypatch: pytest's patcher.
+        """
+        present.add("gh")
+        monkeypatch.setattr(github_tasks, "capture", _canned(""))
+        with pytest.raises(Skip, match="no releases"):
+            github_tasks.latest_release(cfg)
+        assert recorder.calls == []
+
+    def test_latest_release_renders_when_one_exists(
+        self, cfg: Config, recorder: Recorder, present: set[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The probe's success leads to the full templated view.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            monkeypatch: pytest's patcher.
+        """
+        present.add("gh")
+        monkeypatch.setattr(github_tasks, "capture", _canned("v1.2.3"))
+        github_tasks.latest_release(cfg)
+        assert recorder.find("gh").flags[:2] == ["release", "view"]
+
+    def test_whoami_template_survived_makes_dollar_escaping(
+        self, cfg: Config, recorder: Recorder, present: set[str]
+    ) -> None:
+        """``$$host`` in the recipe is ``$host`` in the template gh actually parses.
+
+        make doubles a dollar to pass one through, so a literal transcription of the
+        recipe would hand gh a template referring to the undefined variable ``$$host``.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("gh")
+        github_tasks.whoami(cfg)
+        assert recorder.find("gh").flags[:2] == ["auth", "status"]
+        assert "{{range $host, $accounts := .hosts}}" in github_tasks.WHOAMI_TEMPLATE
+        assert "$$" not in github_tasks.WHOAMI_TEMPLATE
+
+    def test_every_helper_skips_without_gh(self, repo, present: set[str]) -> None:
+        """No task in the module runs anything on a machine without gh.
+
+        Args:
+            repo: The throwaway repository.
+            present: The installed-tool set, left empty.
+        """
+        state = runner.run(list(FRAGMENT_TARGETS["github.mk"]), Config.load(root=repo))
+        assert {r.status for r in state.results} == {Status.SKIPPED}
+        assert all("gh not found" in r.detail for r in state.results)
+
+
+class TestDocker:
+    """docker.mk's three targets."""
+
+    @pytest.fixture
+    def dockerfile(self, repo) -> None:
+        """Give the throwaway repository a Dockerfile.
+
+        Args:
+            repo: The repository root.
+        """
+        (repo / "docker").mkdir()
+        (repo / "docker" / "Dockerfile").write_text("FROM scratch\n")
+
+    def test_build_skips_without_a_dockerfile(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """A repo that adopted the bundle but wrote no Dockerfile is skipped, not failed.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("docker")
+        with pytest.raises(Skip, match=re.escape("docker/Dockerfile")):
+            docker_tasks.docker_build(cfg)
+        assert recorder.calls == []
+
+    def test_build_tags_after_the_directory_and_passes_the_python_version(
+        self, cfg: Config, recorder: Recorder, present: set[str], dockerfile: None
+    ) -> None:
+        """``$(shell basename $(CURDIR))`` as a default, and the PYTHON_VERSION build arg.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            dockerfile: Writes the Dockerfile.
+        """
+        present.add("docker")
+        docker_tasks.docker_build(cfg)
+        flags = recorder.find("docker").flags
+        assert flags[:2] == ["buildx", "build"]
+        assert flags[flags.index("--tag") + 1] == f"{cfg.root.name}:latest"
+        assert flags[flags.index("--build-arg") + 1] == f"PYTHON_VERSION={cfg.python_version}"
+        assert flags[flags.index("--file") + 1] == "docker/Dockerfile"
+        assert flags[-1] == "."
+
+    def test_image_name_is_overridable(self, repo, recorder: Recorder, present: set[str], dockerfile: None) -> None:
+        """``docker_image`` in the manifest wins over the directory name.
+
+        Args:
+            repo: The throwaway repository.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            dockerfile: Writes the Dockerfile.
+        """
+        present.add("docker")
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n\n[tool.rhiza-task]\ndocker-image = "demo-app"\n'
+        )
+        docker_tasks.docker_build(Config.load(root=repo))
+        assert "demo-app:latest" in recorder.find("docker").flags
+
+    def test_run_builds_first(self, repo, recorder: Recorder, present: set[str], dockerfile: None) -> None:
+        """``docker-run: docker-build`` survives as a prerequisite.
+
+        Args:
+            repo: The throwaway repository.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            dockerfile: Writes the Dockerfile.
+        """
+        present.add("docker")
+        state = runner.run(["docker-run"], Config.load(root=repo))
+        assert [r.name for r in state.results] == ["docker-build", "docker-run"]
+        assert [c.args[1] for c in recorder.calls] == ["buildx", "run"]
+
+    def test_clean_tolerates_a_missing_image(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """``|| true``: removing what was never built is not a failure.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("docker")
+        docker_tasks.docker_clean(cfg)
+        assert recorder.find("docker").kwargs["check"] is False
+
+
+class TestGitLfs:
+    """lfs.mk's four targets, one of which changed behaviour on purpose."""
+
+    def test_install_fails_with_a_platform_hint_when_the_binary_is_absent(
+        self, cfg: Config, recorder: Recorder, present: set[str], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The 50 lines of download-and-extract shell became an actionable message.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set, left empty.
+            capsys: pytest's output capture.
+        """
+        with pytest.raises(Failed, match="git-lfs is not installed"):
+            lfs_tasks.lfs_install(cfg)
+        assert lfs_tasks.install_hint() in capsys.readouterr().out
+        assert recorder.calls == []
+
+    def test_install_configures_the_repository(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """What the macOS branch's last line did, and the only part of it that stuck.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("git-lfs")
+        lfs_tasks.lfs_install(cfg)
+        assert recorder.find("git").flags == ["lfs", "install"]
+
+    @pytest.mark.parametrize(
+        ("name", "subcommand"),
+        [("lfs-pull", "pull"), ("lfs-track", "track"), ("lfs-status", "status")],
+    )
+    def test_thin_wrappers(self, repo, recorder: Recorder, present: set[str], name: str, subcommand: str) -> None:
+        """Each remaining target is one git subcommand.
+
+        Args:
+            repo: The throwaway repository.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            name: The task name.
+            subcommand: The git-lfs subcommand it must invoke.
+        """
+        present.add("git-lfs")
+        state = runner.run([name], Config.load(root=repo))
+        assert state.results[0].status is Status.OK
+        assert recorder.find("git").flags == ["lfs", subcommand]
+
+    def test_wrappers_skip_without_the_binary(self, repo, present: set[str]) -> None:
+        """``git lfs pull`` without git-lfs is an unknown-command error; this is clearer.
+
+        Args:
+            repo: The throwaway repository.
+            present: The installed-tool set, left empty.
+        """
+        state = runner.run(["lfs-pull"], Config.load(root=repo))
+        assert state.results[0].status is Status.SKIPPED
+        assert "git-lfs not found" in state.results[0].detail
+
+
+class TestPaper:
+    """paper.mk, minus the one downstream repository it named."""
+
+    @pytest.fixture
+    def papers(self, repo) -> Callable[..., None]:
+        """Return a helper that writes ``.tex`` files into the paper folder.
+
+        Args:
+            repo: The repository root.
+
+        Returns:
+            A callable taking filenames.
+        """
+
+        def write(*names: str) -> None:
+            """Create the named files under ``docs/paper``.
+
+            Args:
+                *names: File names to create.
+            """
+            folder = repo / "docs" / "paper"
+            folder.mkdir(parents=True, exist_ok=True)
+            for name in names:
+                (folder / name).write_text("\\documentclass{article}\\begin{document}\\end{document}\n")
+
+        return write
+
+    def test_prefers_main_then_paper_then_alphabetical(self, repo, papers) -> None:
+        """The replacement for ``if [ -f docs/paper/basanos.tex ]``.
+
+        Args:
+            repo: The repository root.
+            papers: The paper-writing helper.
+        """
+        folder = repo / "docs" / "paper"
+        papers("zeta.tex", "alpha.tex")
+        assert paper_tasks.main_document(folder).name == "alpha.tex"
+        papers("paper.tex")
+        assert paper_tasks.main_document(folder).name == "paper.tex"
+        papers("main.tex")
+        assert paper_tasks.main_document(folder).name == "main.tex"
+
+    def test_nested_tex_files_are_not_candidates(self, repo, papers) -> None:
+        """Chapters under a subdirectory are inputs, not root documents.
+
+        Args:
+            repo: The repository root.
+            papers: The paper-writing helper.
+        """
+        papers("main.tex")
+        chapters = repo / "docs" / "paper" / "chapters"
+        chapters.mkdir()
+        (chapters / "aaa.tex").write_text("chapter\n")
+        assert paper_tasks.main_document(repo / "docs" / "paper").name == "main.tex"
+
+    def test_compiles_in_the_paper_folder(self, repo, recorder: Recorder, present: set[str], papers) -> None:
+        """Run latexmk with the folder as cwd, so its aux files land beside the source.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            papers: The paper-writing helper.
+        """
+        present.add("latexmk")
+        papers("main.tex")
+        state = runner.run(["paper"], Config.load(root=repo))
+        assert state.results[0].status is Status.OK
+        call = recorder.find("latexmk")
+        assert call.flags == ["-pdf", "-bibtex", "-interaction=nonstopmode", "main.tex"]
+        assert call.kwargs["cwd"] == repo / "docs" / "paper"
+
+    def test_skips_a_folder_with_no_tex(self, repo, recorder: Recorder, present: set[str]) -> None:
+        """An adopted-but-unused bundle skips rather than failing.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("latexmk")
+        (repo / "docs" / "paper").mkdir(parents=True)
+        state = runner.run(["paper"], Config.load(root=repo))
+        assert state.results[0].status is Status.SKIPPED
+        assert recorder.calls == []
+
+    def test_clean_skips_without_a_paper_folder(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """Cleaning a folder that does not exist reports that rather than failing.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("latexmk")
+        with pytest.raises(Skip, match="paper_folder"):
+            paper_tasks.paper_clean(cfg)
+        assert recorder.calls == []
+
+    def test_clean_tolerates_an_unbuilt_paper(self, repo, recorder: Recorder, present: set[str], papers) -> None:
+        """``latexmk -C || true``.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            papers: The paper-writing helper.
+        """
+        present.add("latexmk")
+        papers("main.tex")
+        paper_tasks.paper_clean(Config.load(root=repo))
+        assert recorder.find("latexmk").kwargs["check"] is False
+
+
+class TestPresentation:
+    """presentation.mk, minus the global npm install."""
+
+    @pytest.fixture
+    def deck(self, repo) -> None:
+        """Write the default slide deck.
+
+        Args:
+            repo: The repository root.
+        """
+        (repo / "PRESENTATION.md").write_text("# Slide\n")
+
+    def test_marp_on_path_wins(self, cfg: Config, present: set[str]) -> None:
+        """A deliberately installed or pinned Marp is used as-is.
+
+        Args:
+            cfg: The resolved config.
+            present: The installed-tool set.
+        """
+        present.update({"marp", "npx"})
+        assert presentation_tasks.marp_argv(cfg) == ("marp", ())
+
+    def test_npx_replaces_the_global_install(self, cfg: Config, present: set[str]) -> None:
+        """``npx --yes`` keeps the fragment's convenience without mutating the machine.
+
+        Args:
+            cfg: The resolved config.
+            present: The installed-tool set.
+        """
+        present.add("npx")
+        assert presentation_tasks.marp_argv(cfg) == ("npx", ("--yes", "@marp-team/marp-cli"))
+
+    def test_marp_package_is_pinnable(self, repo, present: set[str]) -> None:
+        """The setting is what npx is handed, so a consumer can pin the CLI.
+
+        Args:
+            repo: The throwaway repository.
+            present: The installed-tool set.
+        """
+        present.add("npx")
+        (repo / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n\n'
+            '[tool.rhiza-task]\nmarp-package = "@marp-team/marp-cli@4.2.3"\n'
+        )
+        _, prefix = presentation_tasks.marp_argv(Config.load(root=repo))
+        assert prefix == ("--yes", "@marp-team/marp-cli@4.2.3")
+
+    def test_no_node_at_all_skips(self, cfg: Config, present: set[str]) -> None:
+        """Neither marp nor npx is a skip naming Node, which is the actual prerequisite.
+
+        Args:
+            cfg: The resolved config.
+            present: The installed-tool set, left empty.
+        """
+        with pytest.raises(Skip, match=re.escape("nodejs.org")):
+            presentation_tasks.marp_argv(cfg)
+
+    def test_html_output_keeps_the_fragments_filename(
+        self, repo, recorder: Recorder, present: set[str], deck: None
+    ) -> None:
+        """PRESENTATION.md still produces presentation.html, lower-cased.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            deck: Writes the deck.
+        """
+        present.add("marp")
+        state = runner.run(["presentation"], Config.load(root=repo))
+        assert state.results[0].status is Status.OK
+        assert recorder.find("marp").flags == ["PRESENTATION.md", "-o", "presentation.html"]
+
+    def test_pdf_allows_local_files(self, repo, recorder: Recorder, present: set[str], deck: None) -> None:
+        """Without the flag, headless Chrome drops every local image from the PDF.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            deck: Writes the deck.
+        """
+        present.add("marp")
+        presentation_tasks.presentation_pdf(Config.load(root=repo))
+        flags = recorder.find("marp").flags
+        assert flags == ["PRESENTATION.md", "-o", "presentation.pdf", "--allow-local-files"]
+
+    def test_missing_deck_skips(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+        """No PRESENTATION.md is a skip, not a Marp error.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+        """
+        present.add("marp")
+        with pytest.raises(Skip, match=re.escape("PRESENTATION.md")):
+            presentation_tasks.presentation(cfg)
+        assert recorder.calls == []
+
+    def test_serve_watches_the_repository(self, repo, recorder: Recorder, present: set[str], deck: None) -> None:
+        """``marp -s .``, unchanged.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set.
+            deck: Writes the deck.
+        """
+        present.add("marp")
+        presentation_tasks.presentation_serve(Config.load(root=repo))
+        assert recorder.find("marp").flags == ["-s", "."]
+
+
+def _canned(text: str) -> Callable[..., str]:
+    """Build a stand-in for :func:`~rhiza_task.uv.capture`.
+
+    Args:
+        text: What the faked command should have written to stdout.
+
+    Returns:
+        A callable accepting capture's signature and returning ``text``.
+    """
+
+    def fake(*args: object, **kwargs: object) -> str:
+        """Return the canned output.
+
+        Args:
+            *args: Ignored.
+            **kwargs: Ignored.
+
+        Returns:
+            The canned stdout.
+        """
+        return text
+
+    return fake

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,7 +279,13 @@ def test_folders_and_path_resolve(tmp_path: Path) -> None:
         tmp_path: The repository root.
     """
     cfg = Config.load(root=tmp_path)
-    assert set(cfg.folders) == {"source_folder", "tests_folder", "marimo_folder"}
+    assert set(cfg.folders) == {
+        "source_folder",
+        "tests_folder",
+        "marimo_folder",
+        "docker_folder",
+        "paper_folder",
+    }
     assert cfg.path("source_folder") == tmp_path / "src"
 
 


### PR DESCRIPTION
Closes #20 (the five bundles half; see **Left open** below for the two follow-ups in the issue comment).

`.rhiza/make.d/` survives in rhiza with five fragments, not because they are worth keeping as make but because nothing here answered for their targets. This adds a task module per bundle.

| module | tasks | wraps |
| --- | --- | --- |
| `tasks/github.py` | `view-prs` `view-issues` `failed-workflows` `workflow-status` `latest-release` `whoami` | `gh` |
| `tasks/docker.py` | `docker-build` `docker-run` `docker-clean` | `docker buildx` |
| `tasks/lfs.py` | `lfs-install` `lfs-pull` `lfs-track` `lfs-status` | `git lfs` |
| `tasks/paper.py` | `paper` `paper-clean` | `latexmk` |
| `tasks/presentation.py` | `presentation` `presentation-pdf` `presentation-serve` | Marp |

Every task name is identical to the retired target, so `make view-prs` keeps working through the shim's `%:` catch-all with no translation table. All are language-neutral. `test_every_retired_target_has_a_task` pins both properties against the fragment inventory.

## `Guard(tool=...)`

`github.mk`'s `require-gh` is a target whose whole body is `command -v gh >/dev/null || exit 1`, declared as a prerequisite of every helper; `presentation.mk` has the same shape. One `Guard` field says it once.

A missing tool is a **Skip**, not a failure — a deliberate change from `require-gh`'s hard exit. Nothing in these five bundles is a gate (no `all` names them, no workflow invokes them), so a machine without docker should not fail a run that asked for something else too. `--strict` is the switch for a caller who does want it, and there is a test for exactly that.

## The gh templates are byte-identical

Verified by diffing the module constants against `github.mk` with make's `$$` → `$` unescaping: all six match exactly. Reimplementing `timeago` and gh's colour handling against `--json` would be a worse table and a new thing to maintain. `_header()` factors out the bold header row so the constants fit in 120 columns without `noqa`.

## Three behaviour changes, on purpose

Each is recorded in its module docstring rather than left to be discovered.

**`lfs-install` no longer downloads a binary.** The fragment's macOS branch queried the GitHub releases API, downloaded the arch-matched zip into `.local/tmp`, extracted git-lfs into `.local/bin`, and ran `PATH=$PWD/.local/bin:$PATH git-lfs install`. `.local/bin` is not on PATH after the recipe exits and every other target invokes the bare command, so `lfs-install` followed by `lfs-pull` still failed on a machine that had none. The `git lfs install` at the end — which writes the repository's filter and hook config — is the part that worked, and is what this does; the binary is *reported*, per platform, not fetched. Consumers who relied on the Linux `sudo apt-get` branch need one line of their own (the `setup-git-lfs` action in CI, their package manager locally).

**Marp comes from `npx --yes`, not `npm install -g`.** `require-marp` did not check for Marp, it installed it globally as a side effect of typing `make presentation`. `npx` keeps the property that made that tolerable — Node but no Marp still builds slides — without mutating the machine. Marp on PATH still wins, so a pinned install is unaffected, and `marp_package` is what npx is handed (unpinned by default, because `npm install -g` was too).

**`paper` no longer prefers `basanos.tex`.** That is one downstream repository's filename, hard-coded in a template every consumer syncs. Replaced by `main.tex`, then `paper.tex`, then alphabetical — identical behaviour for a folder with one `.tex`, which is the common case. `-maxdepth 1` survives as `glob` rather than `rglob`, deliberately: a subdirectory holds included chapters, and latexmk must be pointed at the root document.

## Also dropped

- `require-gh` / `gh-install` — the same "is it installed?" question spelled twice, one hard-failing as a prerequisite and one warning as a target a human runs. `doctor` is where "what is missing on this machine" belongs.
- `FORGE_TYPE` — computed at parse time in `github.mk` from the presence of `.github/workflows` or `.gitlab-ci.yml`, and read by no target in that fragment or any other.

## Settings

`docker_folder`, `docker_image`, `paper_folder`, `presentation_file`, `marp_package`. `docker.mk`'s `DOCKER_FOLDER` was a `:=` — not configurable at all — and `PRESENTATION.md` was a literal. `docker_image` defaults to empty and resolves to the repository directory's name in the body, because `?= $(shell basename $(CURDIR))` cannot be a dataclass default and `rhiza-task print docker_image` should stay honest about the setting being unset. The presentation output name is derived from `presentation_file`, lower-cased, so the default still produces `presentation.html` exactly as the fragment does.

## Verification

`test`, `coverage`, `typecheck`, `security`, `deps`, `docs-coverage` and `rhiza-test` all green locally. 224 tests, coverage 96.6% overall with all five new modules at 100%.

The tests patch `shutil.which` rather than the individual `have` bindings, so the guard and the task body cannot disagree about whether a tool is present. Nothing invokes gh, docker, git-lfs, latexmk or Marp — the assertions are on the argument vectors, which are the contract the recipes expressed in shell.

## Left open

- **`-include .rhiza/make.d/*.mk` in `templates/Makefile`**, which #20 recommends. Left out on purpose: a sync that stops delivering a file does not delete it, so a consumer retiring these bundles keeps the stale fragment on disk — and an explicit rule beats `%:`, so the old make target would silently shadow the new task. That is a decision about rhiza's update flow, worth making there rather than here.
- **`doctor` per-layer composition** and the **`make help` discoverability gap** from the issue comment. The help gap is now moot for these five: `rhiza-task list` shows all eighteen, grouped by section.
- **A release.** rhiza cannot retire the fragments until this is published and `RHIZA_TASK` is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
