### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [0.3.0] - 2026-08-19
+
+### 🚀 Features
+
+- *(tasks)* Tasks for the five bundles `.rhiza/make.d` could not retire (#22). One module
+  per bundle — `github`, `docker`, `lfs`, `paper`, `presentation` — covering all eighteen
+  targets under their original names, so `make view-prs` keeps working through the shim's
+  catch-all. This reverses 0.1.0's "not ported: github.mk's seven `gh` wrappers (use `gh`
+  directly)": `github` is in rhiza's `github-project` profile, so leaving it out kept the
+  whole `.rhiza/make.d/` folder alive for the flagship profile.
+- *(spec)* `Guard(tool=...)`, which is what `require-gh` and `require-marp` were — a target
+  whose entire body is `command -v X >/dev/null || exit 1`, declared as a prerequisite of
+  every helper. A missing tool is a **skip** carrying the install hint rather than the
+  fragment's hard exit, because nothing in these five bundles is a gate; `--strict` gives
+  the failure back to a caller who wants it.
+- *(config)* `docker_folder`, `docker_image`, `paper_folder`, `presentation_file` and
+  `marp_package`. `docker.mk`'s `DOCKER_FOLDER` was a `:=` — not configurable at all — and
+  `PRESENTATION.md` was a literal.
+
+### Deliberate differences from the fragments
+
+Three, each recorded in its module docstring:
+
+- **`lfs-install` configures the repository; it no longer downloads a binary.** lfs.mk's
+  macOS branch queried the releases API, unzipped git-lfs into `.local/bin`, and ran
+  `git-lfs install` — but `.local/bin` is not on PATH afterwards and every other target
+  invokes the bare command, so `lfs-install` followed by `lfs-pull` still failed on a
+  machine that had none. The `git lfs install` at the end is the part that worked and is
+  what survives; the binary is now reported per platform, not fetched. Consumers who
+  relied on the Linux `sudo apt-get` branch need one line of their own.
+- **Marp comes from `npx --yes`, not `npm install -g`.** `require-marp` did not check for
+  Marp, it installed it globally as a side effect of typing `make presentation`. `npx`
+  keeps the convenience without mutating the machine; Marp on PATH still wins, and
+  `marp_package` pins the spec.
+- **`paper` no longer prefers `basanos.tex`** — one downstream repository's filename,
+  hard-coded in a template every consumer syncs. Now `main.tex`, then `paper.tex`, then
+  alphabetical, which is identical behaviour for a folder holding one `.tex`.
+
+Dropped with the fragments: `require-gh`/`gh-install`, the same question spelled twice
+because make cannot say it once; `require-marp`; and `FORGE_TYPE`, which github.mk computed
+at parse time and no target ever read. The six gh templates are carried over byte-identical
+— reproducing `timeago` and gh's colour handling in Python would be a worse table.
+
 ## [0.2.0] - 2026-08-18
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.2.0"
+version = "0.3.0"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.2.0 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@0.3.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -9,7 +9,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.2.0
+RHIZA_TASK ?= rhiza-task@0.3.0
 
 # The one thing the shim cannot delegate to the CLI: uv itself, because uv is what runs
 # the CLI. `bootstrap.mk` had an `install-uv` target for exactly this, and the make layer's

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Version bump and changelog for **v0.3.0**, cut on top of #22.

`bump-my-version bump minor` rewrote four places: `[project].version`, `__version__`, `uv.lock`, and — via the `[[tool.bumpversion.files]]` entry that exists for exactly this — the shim's `RHIZA_TASK ?= rhiza-task@0.3.0` pin. A release that missed the last one would hand consumers a Makefile pinned to the previous version.

Minor rather than patch: #22 adds eighteen tasks, a `Guard` field and five settings, and reverses 0.1.0's "not ported: github.mk's seven \`gh\` wrappers".

The changelog section is hand-written in git-cliff's heading structure rather than regenerated. Regenerating rewrites the whole file from commit subjects, which is what flattened 0.2.0's entries into one-liners and lost the prose about the Rust and Go layers. The release notes GitHub shows are generated separately by `git-cliff --latest` at tag time, so nothing downstream depends on this file's shape.

After merge: tag the merge commit `v0.3.0` and push, which fires `(RHIZA) RELEASE` — validate, build, SBOM, draft, PyPI via OIDC, finalise.

Then rhiza can delete the five fragments and bump its own `RHIZA_TASK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)