### PR TITLE
fix(book): provision mkdocstrings, which the book bundle's own config requires

### DIFF
--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -172,7 +172,24 @@ class Config:
     cargo_flags: tuple[str, ...] = ()
     go_flags: tuple[str, ...] = ()
     go_test_flags: tuple[str, ...] = ("-race", "-shuffle=on")
-    mkdocs_extra_packages: tuple[str, ...] = ()
+    # Non-empty on purpose, and it pairs with ``zensical_version`` below: this setting is
+    # the other half of "what the book gate provisions", and only one half was ever set.
+    #
+    # rhiza's ``book`` bundle ships ``docs/mkdocs-base.yml`` with ``mkdocstrings`` enabled
+    # unconditionally, and every consumer inherits it via ``INHERIT``. With this empty,
+    # ``book`` invoked ``uvx zensical build`` with no ``--with``, and zensical refused:
+    #
+    #     Error: mkdocstrings plugin is enabled, but mkdocstrings is not installed.
+    #
+    # So the bundle shipped a config that could not build with its own default. The default
+    # belongs here rather than in the bundle because a bundle has nowhere to put it: core
+    # ships no ``.rhiza/.env`` (jebel-quant/rhiza#1545 deleted it), ``pyproject.toml`` is
+    # repo-owned, and ``_from_manifest`` reads only pyproject/Cargo -- so a ``book`` +
+    # ``go-core`` repo has no TOML surface at all. This is the one layer every consumer has.
+    #
+    # A repo that wants no plugins sets ``mkdocs-extra-packages = []`` in its manifest.
+    # That is TOML-only, deliberately -- see :func:`_from_env_file`.
+    mkdocs_extra_packages: tuple[str, ...] = ("mkdocstrings[python]",)
 
     # The five bundle-owned fragments' settings. docker.mk's DOCKER_FOLDER was a `:=`
     # rather than a `?=` -- not configurable at all -- and paper.mk hard-coded the
@@ -319,9 +336,19 @@ def _from_env_file(path: Path) -> dict[str, Any]:
     """Read ``.rhiza/.env``.
 
     An empty assignment (``RHIZA_CI_OS_MATRIX=``) is dropped rather than carried as an
-    empty string, for the reason given in :func:`_from_environ`: no field's type has a
-    meaningful empty value, so the only thing an empty setting can sensibly mean is
-    "leave the lower layer alone".
+    empty string, for the reason given in :func:`_from_environ`: that rule mirrors make's
+    ``?=``, which is what ``rhiza_ci.yml`` relies on when it exports the matrix empty for
+    every consumer so their own ``.rhiza/.env`` can answer.
+
+    **A consequence, now that one default is non-empty.** The rule used to be justified as
+    "no field's type has a meaningful empty value", and that stopped being true when
+    :attr:`Config.mkdocs_extra_packages` gained a default: for it, empty means "install no
+    plugins", which is a real choice rather than an absent one. It is expressible as
+    ``mkdocs-extra-packages = []`` in a manifest, where TOML distinguishes an empty array
+    from an absent key -- and *not* here or in the environment, where both arrive as the
+    same empty string. The behaviour is unchanged and deliberate: the matrix case above
+    needs it, and a dotenv layer cannot tell the two apart. Only the reasoning is amended,
+    so a reader does not conclude from the old wording that ``[]`` is meaningless anywhere.
 
     Args:
         path: Path to the dotenv file.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -383,3 +383,50 @@ def test_rhiza_checks_is_settable_from_the_env_file(tmp_path: Path) -> None:
     (tmp_path / ".rhiza").mkdir()
     (tmp_path / ".rhiza" / ".env").write_text("RHIZA_CHECKS=pkg.a pkg.b\n")
     assert Config.load(root=tmp_path).rhiza_checks == ("pkg.a", "pkg.b")
+
+
+def test_mkdocs_extra_packages_defaults_to_mkdocstrings(tmp_path: Path) -> None:
+    """The default must name mkdocstrings, with no repo configuration at all.
+
+    rhiza's ``book`` bundle enables the plugin for every consumer and has no surface on which
+    to install it -- core ships no ``.rhiza/.env``, and a ``book`` + ``go-core`` repo has no
+    manifest this reader accepts. This default is the only layer that reaches all of them.
+
+    Args:
+        tmp_path: An empty repository root.
+    """
+    cfg = Config.load(root=tmp_path)
+    assert any("mkdocstrings" in spec for spec in cfg.mkdocs_extra_packages), (
+        f"mkdocs_extra_packages must default to mkdocstrings; got {cfg.mkdocs_extra_packages!r}"
+    )
+
+
+def test_an_empty_toml_array_overrides_the_default_away(tmp_path: Path) -> None:
+    """``mkdocs-extra-packages = []`` must win over the non-empty default.
+
+    TOML is the only layer that can express "none": :func:`_from_env_file` and
+    :func:`_from_environ` drop empties to mirror make's ``?=``, which the CI matrix relies
+    on. Without this, the default could not be opted out of anywhere.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.0.0"\n\n[tool.rhiza-task]\nmkdocs-extra-packages = []\n'
+    )
+    assert Config.load(root=tmp_path).mkdocs_extra_packages == ()
+
+
+def test_an_empty_env_value_leaves_the_default_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty environment value must not be read as "no packages".
+
+    The documented consequence of the empty-is-unset rule, pinned so the amended
+    :func:`_from_env_file` docstring stays true: the manifest is the escape hatch, the
+    environment is not.
+
+    Args:
+        tmp_path: The repository root.
+        monkeypatch: To set the environment variable.
+    """
+    monkeypatch.setenv("RHIZA_MKDOCS_EXTRA_PACKAGES", "")
+    assert Config.load(root=tmp_path).mkdocs_extra_packages != ()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -430,6 +430,46 @@ class TestBook:
         assert (cfg.path("book_output") / ".nojekyll").is_file()
         assert recorder.find(f"zensical{cfg.zensical_version}").flags[0] == "build"
 
+    def test_mkdocstrings_is_provisioned_by_default(self, cfg: Config, recorder: Recorder) -> None:
+        """The zensical run must carry mkdocstrings without the repo configuring anything.
+
+        rhiza's ``book`` bundle enables the plugin in ``docs/mkdocs-base.yml`` for every
+        consumer, and no bundle can install it -- so an empty default made zensical fail with
+        "mkdocstrings plugin is enabled, but mkdocstrings is not installed" on a freshly
+        synced repo. Asserted on ``withs`` rather than on the config value, because passing
+        the setting to :func:`uvx` is the half that actually reaches the build.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        book_tasks.book(cfg)
+        withs = recorder.find(f"zensical{cfg.zensical_version}").kwargs["withs"]
+        assert any("mkdocstrings" in spec for spec in withs), (
+            f"the book build must provision mkdocstrings; withs={withs!r}"
+        )
+
+    def test_extra_packages_can_be_turned_off_in_the_manifest(self, cfg: Config, recorder: Recorder) -> None:
+        """``mkdocs-extra-packages = []`` must reach the build as no packages at all.
+
+        The escape hatch for the non-empty default. TOML is the only layer that can express
+        it -- ``.rhiza/.env`` and the environment drop empties on purpose -- so if this
+        stopped working the default would be impossible to opt out of.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        (cfg.root / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\nversion = "0.0.0"\n\n[tool.rhiza-task]\nmkdocs-extra-packages = []\n'
+        )
+        reloaded = Config.load(root=cfg.root)
+        assert reloaded.mkdocs_extra_packages == ()
+        book_tasks.book(reloaded)
+        assert not recorder.find(f"zensical{reloaded.zensical_version}").kwargs["withs"]
+
     def test_generates_a_coverage_badge_when_coverage_exists(self, cfg: Config, recorder: Recorder) -> None:
         """The badge is produced from the XML report that ``test`` leaves behind.
 


### PR DESCRIPTION
## The bug

rhiza's `book` bundle ships `docs/mkdocs-base.yml` with `mkdocstrings` enabled unconditionally, and every consumer inherits it through `INHERIT: docs/mkdocs-base.yml`. Nothing ever installed it — `mkdocs_extra_packages` defaulted to `()`, so `book.py` called:

```
uvx zensical>=0.0.36 build -f <root>/mkdocs.yml
```

with no `--with`, and zensical **exits 1**:

```
Error: mkdocstrings plugin is enabled, but mkdocstrings is not installed. Please install mkdocstrings or disable the plugin.
```

So the bundle shipped a documentation config that **cannot build with its own default**, and `make book` was red on every freshly synced consumer adopting `book`. Reported from a downstream repo. The mother repo never saw it, because it carries its own `mkdocs-extra-packages = ["mkdocstrings[python]"]` override in `pyproject.toml` — so the invariant held in exactly the one repo that ships the bundle.

## The fix

One line, plus the reasoning around it:

```python
mkdocs_extra_packages: tuple[str, ...] = ("mkdocstrings[python]",)
```

**Why here and not in the bundle.** A bundle has nowhere to put it. `core` ships no `.rhiza/.env` (jebel-quant/rhiza#1545 deleted it so it could not shadow exported values), `pyproject.toml` is repo-owned, and `_from_manifest` reads only `pyproject.toml`/`Cargo.toml` — so a `book` + `go-core` repo has no TOML surface at all. This default is the one layer every consumer shares, regardless of language.

**It pairs with the adjacent line.** `zensical_version = ">=0.0.36"` sits directly below. Both answer "what does the book gate provision", and only one of them had ever been answered. `go_test_flags = ("-race", "-shuffle=on")` is the precedent for an opinionated non-empty default that encodes a bundle convention.

## The escape hatch, and a docstring that stopped being true

Turning it off is `mkdocs-extra-packages = []` in a manifest. That is **TOML-only**, deliberately: `_from_env_file` and `_from_environ` drop empty values to mirror make's `?=`, which `rhiza_ci.yml` depends on when it exports `RHIZA_CI_OS_MATRIX` empty for consumers.

That behaviour is unchanged. But its stated justification — *"no field's type has a meaningful empty value"* — is now false for this one field, where `[]` means "install no plugins". The `_from_env_file` docstring is amended to say where `[]` works and where it does not, so a reader does not conclude from the old wording that an empty array is meaningless everywhere.

| override | resolves to |
| --- | --- |
| nothing | `mkdocstrings[python]` |
| `mkdocs-extra-packages = []` in a manifest | *(none)* |
| `RHIZA_MKDOCS_EXTRA_PACKAGES=` in env or `.rhiza/.env` | `mkdocstrings[python]` — empty is "unset" |

## Tests

Five, and I verified the three that should fail actually do when the default is reverted — the two escape-hatch tests correctly stay green either way, since they guard the override rather than the default.

- `test_mkdocstrings_is_provisioned_by_default` — asserts on the recorded `withs=`, not on the config value, because passing it to `uvx` is the half that reaches the build
- `test_extra_packages_can_be_turned_off_in_the_manifest`
- `test_mkdocs_extra_packages_defaults_to_mkdocstrings`
- `test_an_empty_toml_array_overrides_the_default_away`
- `test_an_empty_env_value_leaves_the_default_alone` — pins the amended docstring's claim

## End-to-end verification

Against rhiza's **real** `bundles/book/docs/mkdocs-base.yml` in a scratch repo:

| | result |
| --- | --- |
| released `rhiza-task@0.3.0` | `failed book`, **exit 1** — reproduces the report byte for byte |
| this branch | `uvx --with mkdocstrings[python] zensical>=0.0.36`, `ok book`, site written to `_book/` |

`uv run rhiza-task all` passes (229 tests, ruff clean).

## Follow-up for rhiza

Once this releases and rhiza bumps its `RHIZA_TASK` pin, rhiza's own `mkdocs-extra-packages` override becomes redundant. It can stay — explicit and harmless — but note `tests/integration/test_docs_targets.py::test_the_setting_is_declared_in_pyproject` reads that table directly, so dropping it needs the test retargeted. Two comments there also still describe this failure as silent ("generated pages missing"); it is not, as the exit 1 above shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
