### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1] - 2026-08-19
+
+### 🐛 Bug Fixes
+
+- *(book)* Provision mkdocstrings, which the book bundle's own config requires
+
 ## [0.3.0] - 2026-08-19
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.3.0"
+version = "0.3.1"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.3.0 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@0.3.1 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -9,7 +9,7 @@
 #
 # RHIZA_TASK is the entire version contract. Bumping it is the migration that used to be
 # `/rhiza:update` re-syncing eleven .mk files and reconciling whatever had been shadowed.
-RHIZA_TASK ?= rhiza-task@0.3.0
+RHIZA_TASK ?= rhiza-task@0.3.1
 
 # The one thing the shim cannot delegate to the CLI: uv itself, because uv is what runs
 # the CLI. `bootstrap.mk` had an `install-uv` target for exactly this, and the make layer's


### PR DESCRIPTION
Version bump **0.3.0 → 0.3.1** (patch), cut from `main` at `70cecf8`.

## Version locations updated

All three are declared in `[tool.bumpversion]`; none was hand-edited.

| File | Change |
| --- | --- |
| `pyproject.toml` | `[project].version` → `0.3.1` (PEP 621 handler, a keyed location rather than a text pattern, so no `[tool.*]` table is at risk) |
| `src/rhiza_task/__init__.py` | `__version__` → `0.3.1`, and the `uvx rhiza-task@…` example pin in the module docstring |
| `src/rhiza_task/templates/Makefile` | `RHIZA_TASK ?= rhiza-task@0.3.1` — the shim's default pin, which is the whole version contract for consumers |

No self-referencing CI stub pins exist in `.github/`; every `uses:` there is third-party, so nothing else needed to move with this release.

## Changelog

One section added under the `# Changelog` heading, nothing existing rewritten:

```
## [0.3.1] - 2026-08-19

### 🐛 Bug Fixes

- *(book)* Provision mkdocstrings, which the book bundle's own config requires
```

The single `fix(book):` commit since `v0.3.0` is the whole of this release; there are no `feat` and no breaking commits, which is why `patch` was chosen.

## Merging this PR does not publish the release

**No tag exists yet.** The tag has to point at a commit that is actually on `main`, and a squash-merge replaces this branch's commit with a new one — so the tag is cut *after* this merges, from the merged commit, by a second `/rhiza:release` run. That run re-checks that the version strictly increases and refuses an existing tag before creating anything.

Pushing that tag is what triggers release CI and publishes to PyPI.
