### PR TITLE
fix(shim): export PATH so the CLI can find uv on a bare runner

### DIFF
--- a/src/rhiza_task/templates/Makefile
+++ b/src/rhiza_task/templates/Makefile
@@ -17,10 +17,21 @@ RHIZA_TASK ?= rhiza-task@0.3.1
 # runs `make fmt` with no `astral-sh/setup-uv` step, and `ubuntu-latest` ships no uv. A shim
 # that only ran `uvx` would turn a required status check red on the day a repo migrated.
 #
-# So the bootstrap survives, minus the parts the CLI took over: no `bin/uv`, no PATH export,
-# no clean-up, just the one binary needed to reach the pin above.
+# So the bootstrap survives, minus the parts the CLI took over: no `bin/uv`, no clean-up,
+# just the one binary needed to reach the pin above -- and the PATH export, because
+# reaching the CLI is not the same as letting it run. Every task body shells out to a bare
+# `uv` or `uvx` (`uv.py` resolves both with `shutil.which`, which reads the PATH it
+# inherits), so provisioning `./bin/uvx` and then not exporting `./bin` gets as far as the
+# first gate that shells out and dies with `FileNotFoundError: 'uvx'` -- after a bootstrap
+# that looked like it worked. `version`, `print` and `list` are pure-CLI and stay green,
+# which is how this reached a required status check.
+#
+# Prepended, not appended: with `$(INSTALL_DIR)` last, a runner carrying an older uv
+# earlier on PATH resolves differently from a bare one, and `RHIZA_TASK` quietly stops
+# being the whole version contract the header above claims it is.
 INSTALL_DIR ?= $(abspath ./bin)
 UVX ?= $(shell command -v uvx 2>/dev/null || echo $(INSTALL_DIR)/uvx)
+export PATH := $(INSTALL_DIR):$(PATH)
 
 .DEFAULT_GOAL := help
 

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -3,8 +3,10 @@
 The shim is the one artefact this package ships that is not Python, and its failure modes
 are make's, not the CLI's: a circular dependency, a match-anything rule applied to the
 makefile itself, a bootstrap that runs twice or never. None of those are visible in the
-file, so the tests below run ``make -n`` against a throwaway checkout with a stub ``uvx``
-on PATH -- no network, no uv, and every recipe printed rather than executed.
+file, so the tests below run make against a throwaway checkout with a stub ``uvx`` on
+PATH -- no network and no uv. Mostly under ``-n``, which prints every recipe rather than
+executing it; the exceptions are the PATH-export tests, which need a recipe's actual
+environment and so run a ``local.mk`` target that shells out to nothing but ``echo``.
 """
 
 from __future__ import annotations
@@ -40,6 +42,33 @@ def _make(root: Path, *args: str, path: str) -> subprocess.CompletedProcess[str]
     env.pop("MAKEFLAGS", None)
     return subprocess.run(  # nosec B603
         [shutil.which("make") or "make", "-n", *args],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _make_run(root: Path, *args: str, path: str) -> subprocess.CompletedProcess[str]:
+    """Run make for real in ``root`` with a controlled PATH.
+
+    The sibling of :func:`_make`, without ``-n``. The PATH export is only observable in a
+    recipe's *environment*, which ``-n`` never builds -- it prints the recipe instead of
+    handing it to a shell.
+
+    Args:
+        root: Directory holding the shim.
+        *args: Goals to pass to make.
+        path: The PATH the invocation sees.
+
+    Returns:
+        The completed process, with output captured.
+    """
+    env = dict(os.environ, PATH=path)
+    env.pop("MAKEFLAGS", None)
+    return subprocess.run(  # nosec B603
+        [shutil.which("make") or "make", *args],
         cwd=root,
         env=env,
         capture_output=True,
@@ -148,3 +177,43 @@ def test_local_mk_wins_over_the_catch_all(shim: Path, stub_path: str) -> None:
     assert result.returncode == 0, result.stderr
     assert "repo-owned" in result.stdout
     assert "rhiza-task@" not in result.stdout
+
+
+def test_install_dir_is_exported_first_on_path(shim: Path, stub_path: str) -> None:
+    """A recipe's environment has ``./bin`` on PATH, ahead of everything inherited.
+
+    The other half of the bootstrap: the shim reaches the CLI by absolute path, but the
+    CLI's task bodies shell out to bare ``uv``/``uvx``, so a child that inherits a PATH
+    without ``./bin`` dies with ``FileNotFoundError: 'uvx'`` on the first gate that shells
+    out -- immediately after a bootstrap that appeared to succeed.
+
+    Args:
+        shim: The directory holding the Makefile.
+        stub_path: A PATH whose ``uvx`` is a stub.
+    """
+    (shim / "local.mk").write_text('show-path:\n\t@echo "$$PATH"\n')
+    result = _make_run(shim, "show-path", path=stub_path)
+    assert result.returncode == 0, result.stderr
+    entries = result.stdout.strip().split(os.pathsep)
+    # First, not merely present: an older uv earlier on PATH would otherwise win, and
+    # RHIZA_TASK would stop being the whole version contract.
+    assert entries[0] == str(shim / "bin")
+    # And nothing inherited is dropped or reordered behind it.
+    assert entries[1:] == stub_path.split(os.pathsep)
+
+
+def test_the_exported_path_survives_an_overridden_install_dir(shim: Path, stub_path: str) -> None:
+    """``INSTALL_DIR=/somewhere`` moves the exported entry too, not just the bootstrap.
+
+    ``INSTALL_DIR`` is a ``?=`` override, and the export is computed from it, so the two
+    cannot drift into provisioning one directory and exporting another.
+
+    Args:
+        shim: The directory holding the Makefile.
+        stub_path: A PATH whose ``uvx`` is a stub.
+    """
+    (shim / "local.mk").write_text('show-path:\n\t@echo "$$PATH"\n')
+    elsewhere = shim / "elsewhere"
+    result = _make_run(shim, f"INSTALL_DIR={elsewhere}", "show-path", path=stub_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().split(os.pathsep)[0] == str(elsewhere)

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Closes #19.

## The change

One line in `src/rhiza_task/templates/Makefile`, exactly as the issue specifies:

```make
export PATH := $(INSTALL_DIR):$(PATH)
```

Plus the comment above it, which previously stated the omission as deliberate ("no PATH export") and is quoted in the issue as the bug in one line.

## Why one line was enough

The CLI already resolves `uv`/`uvx` through `uv.py`'s `_bin`, which is `os.environ.get(env_var) or shutil.which(name) or name`. `shutil.which` reads the PATH of the process, and the shim's recipes are that process's parent — so exporting `./bin` is all it takes for the child to find a bootstrapped uvx. No CLI change is needed for the shim path.

**Prepended, not appended**, per the issue: with `$(INSTALL_DIR)` last, a runner carrying an older uv earlier on PATH resolves differently from a bare one, and `RHIZA_TASK` quietly stops being the whole version contract the shim's header claims it is.

## Tests

Two, in `tests/test_shim.py`, and **both fail without the export** (verified by removing just that line):

- `test_install_dir_is_exported_first_on_path` — asserts `./bin` is `entries[0]`, not merely present, and that nothing inherited is dropped or reordered behind it.
- `test_the_exported_path_survives_an_overridden_install_dir` — `INSTALL_DIR=/somewhere` has to move the exported entry too, so provisioning and exporting cannot drift apart.

These run make **without** `-n`, unlike the existing shim tests: the export is only observable in a recipe's actual environment, which `-n` never builds. The goal they run is an `echo`-only target in a throwaway `local.mk`, so there is still no network and no uv. The module docstring is updated to say so.

Full suite: 231 passed. `ruff format --check` and `ruff check` clean.

## Not included, deliberately

The issue's "worth considering alongside" — having the CLI prefer an absolute path from `sys.argv[0]`'s directory over a bare name — is left out. It is a separate concern with a different blast radius (it changes resolution for every caller, not just the shim), and `RHIZA_UV_BIN`/`RHIZA_UVX_BIN` already exist as the escape hatch for a machine where uv lives somewhere unusual. Worth its own issue if you want it.
