### PR TITLE
fix(quality): pass source_folder to the doctest check via RHIZA_DOCTEST_FOLDERS

### DIFF
--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -99,10 +99,26 @@ def rhiza_test(cfg: Config) -> None:
     ``install`` is a prerequisite because the docstring check imports the project's own
     packages to run their doctests, which needs the dependencies present.
 
+    ``RHIZA_DOCTEST_FOLDERS`` is what tells ``test_docstrings`` where to look, and it has
+    to be passed: the check falls back to ``SOURCE_FOLDER`` in ``.rhiza/.env`` and then to
+    a literal ``src``, so a repo whose Python lives anywhere else got
+    ``SKIPPED  No doctest folder found (looked for: src)`` and a **green** gate -- the
+    doctests went unchecked with nothing failing to say so. ``.rhiza/.env`` cannot cover
+    for it either: since rhiza stopped shipping ``.rhiza/.gitignore``, whose only content
+    was the ``!.env`` negation, that file is gitignored and a CI checkout never has one.
+    ``quality.mk`` exported the variable from ``DOCSTRING_FOLDERS``; this is that export.
+
     Args:
         cfg: The resolved config.
     """
-    uv_run("pytest", "--pyargs", *cfg.rhiza_checks, cwd=cfg.root, withs=(cfg.pytest_rhiza,))
+    uv_run(
+        "pytest",
+        "--pyargs",
+        *cfg.rhiza_checks,
+        cwd=cfg.root,
+        withs=(cfg.pytest_rhiza,),
+        env={"RHIZA_DOCTEST_FOLDERS": cfg.source_folder},
+    )
 
 
 @task(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,6 +7,7 @@ the make recipes said in ``$$``-escaped shell.
 from __future__ import annotations
 
 import shutil
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -332,6 +333,35 @@ class TestQuality:
         assert "pytest_rhiza.checks.test_readme" in call.flags
         assert not [f for f in call.flags if "test_cargo_toml" in f or "test_go_module" in f]
         assert call.kwargs["withs"] == (cfg.pytest_rhiza,)
+
+    def test_rhiza_test_tells_the_docstring_check_where_to_look(self, cfg: Config, recorder: Recorder) -> None:
+        """``RHIZA_DOCTEST_FOLDERS`` carries ``source_folder`` into the checks.
+
+        Without it ``test_docstrings`` falls back to a literal ``src`` and reports
+        ``SKIPPED  No doctest folder found`` -- a green gate that measured nothing, which is
+        exactly the regression rhiza's doctest gate exists to prevent.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        quality.rhiza_test(cfg)
+        assert recorder.find("pytest").kwargs["env"] == {"RHIZA_DOCTEST_FOLDERS": cfg.source_folder}
+
+    def test_rhiza_test_honours_a_relocated_source_folder(self, cfg: Config, recorder: Recorder) -> None:
+        """A repo declaring ``source-folder = "utils"`` gets its doctests checked.
+
+        The default would pass the assertion above by coincidence, since ``source_folder``
+        already defaults to ``src``. This is the case that actually failed: rhiza itself
+        ships configuration, so its only non-test Python is ``utils/``.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        relocated = replace(cfg, source_folder="utils")
+        quality.rhiza_test(relocated)
+        assert recorder.find("pytest").kwargs["env"] == {"RHIZA_DOCTEST_FOLDERS": "utils"}
 
     def test_todos_reports_file_and_line(self, cfg: Config, capsys: pytest.CaptureFixture[str]) -> None:
         """A TODO is reported with a repo-relative path and a line number.

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Closes #18.

## The change

`rhiza_test` already had `cfg.source_folder`; it now passes it, exactly as the issue specifies:

```python
env={"RHIZA_DOCTEST_FOLDERS": cfg.source_folder},
```

An explicit env var is the highest-precedence channel `test_docstrings` reads, ahead of `SOURCE_FOLDER` in `.rhiza/.env` and the literal `src` fallback — so this works on a CI checkout, which is the case that mattered: `.rhiza/.env` is gitignored since rhiza stopped shipping `.rhiza/.gitignore` (whose only content was the `!.env` negation), so a runner never has one.

## Tests

Two, both of which **fail without the change** (verified by removing the `env=` line):

- `test_rhiza_test_tells_the_docstring_check_where_to_look` — asserts the env dict reaches `uv_run`.
- `test_rhiza_test_honours_a_relocated_source_folder` — uses `source_folder="utils"`. This one matters: `source_folder` already defaults to `src`, so a test on the default would have passed by coincidence and proved nothing. `utils` is the real failing case, since rhiza ships configuration and that is its only non-test Python.

Full suite: 231 passed. `ruff check` and `ruff format --check` clean.

## One unrelated line: uv.lock

`uv.lock` still recorded `rhiza-task 0.3.0` while `pyproject.toml` said `0.3.1` — running the test suite here refreshed it, and I have kept that. **`uv.lock` is not a `[[tool.bumpversion.files]]` location**, so `chore: release v0.3.1` (#25) bumped the manifest and left the lock behind; the same will happen on every release until the config covers it. Flagging rather than fixing in this PR, since a lock refresh belongs in the release flow, not in a bug fix. Happy to file it separately.

## Not included, deliberately

The issue's two "worth deciding alongside" items are both larger design changes and are left out:

1. **Making the skip a failure.** `strict` does not reach inside pytest-rhiza — the skip happens in the check, not the task — so this needs a pytest option plumbed through, and it would affect the whole family of "no folder found" skips, not just this one.
2. **Letting pytest-rhiza read `[tool.rhiza-task]` directly.** The better fix, and the one that removes the coupling instead of moving it — but it is a change to *pytest-rhiza*, not to this repo, so it cannot land here.

This PR closes the silent-skip hole; neither item is a prerequisite for that.
