### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.0.0] - 2026-08-20
+
+### 🚀 Features
+
+- *(shim)* Spell out the named tasks and declare them phony
+- *(shim)* Name paper and presentation too
+- *(shim)* Drop doctor from the named set
+- *(shim)* List local.mk's own targets in `make help`
+- *(shim)* Provision `uv` alongside `uvx`
+- *(cli)* [**breaking**] Remove the Makefile shim
+
+### 🚜 Refactor
+
+- *(shim)* Name the goal the catch-all forwards
+- *(shim)* Make FORCE the phony mechanism, drop the named list
+
+### 📚 Documentation
+
+- *(shim)* Cut the shim's comments back, and say what belongs in it
+
+### ⚙️ Miscellaneous Tasks
+
+- Untrack the root Makefile again
+
 ## [0.3.1] - 2026-08-19
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "0.3.1"
+version = "1.0.0"
 description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@0.3.1 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@1.0.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "0.3.1"
+__version__ = "1.0.0"


### PR DESCRIPTION
Version bump **v0.3.1 → v1.0.0**, cut by `/rhiza:release` (phase A).

`v1.0.0` strictly increases past the highest existing tag (`v0.3.1`), and no tag of that
name exists.

## Why major

The unreleased set carries one breaking change — `feat(cli)!: remove the Makefile shim`
(`rhiza-task shim` is gone) — alongside six features. At `0.x` that would also have been a
legitimate `minor`; `v1.0.0` was chosen deliberately, so this release additionally declares
the CLI's API stable.

## Files the bump touched

`bump-my-version` rewrote only the locations `[tool.bumpversion]` in `pyproject.toml`
declares:

| File | What changed |
| --- | --- |
| `pyproject.toml` | `[project].version` → `1.0.0` |
| `src/rhiza_task/__init__.py` | `__version__` → `1.0.0`, and the `uvx rhiza-task@…` example in the module docstring |
| `CHANGELOG.md` | new `## [1.0.0]` section (see below) |

The config is tag-derived — it has no `current_version` key — so the bump was run with an
explicit `--current-version 0.3.1`, read from the newest tag. There is nothing in the
config to update.

No CI stub pins moved: every `uses:` in `.github/` is a third-party action
(`astral-sh/setup-uv`, `ncipollo/release-action`, `pypa/gh-action-pypi-publish`), so this
repo does not self-reference its own tag.

## Changelog

One section prepended by `git-cliff --unreleased --tag v1.0.0`; the diff is 24 insertions
and 0 deletions, so no existing section was rewritten. The section was moved below the
`# Changelog` title after insertion (the repo has no `cliff.toml`, so git-cliff prepends
at byte 0).

```
## [1.0.0] - 2026-08-20

### 🚀 Features
- *(shim)* Spell out the named tasks and declare them phony
- *(shim)* Name paper and presentation too
- *(shim)* Drop doctor from the named set
- *(shim)* List local.mk's own targets in `make help`
- *(shim)* Provision `uv` alongside `uvx`
- *(cli)* [**breaking**] Remove the Makefile shim

### 🚜 Refactor
- *(shim)* Name the goal the catch-all forwards
- *(shim)* Make FORCE the phony mechanism, drop the named list

### 📚 Documentation
- *(shim)* Cut the shim's comments back, and say what belongs in it

### ⚙️ Miscellaneous Tasks
- Untrack the root Makefile again
```

## Merging this PR does not publish the release

**No tag exists yet.** The tag has to point at a commit that is on `main`, and a
squash-merge replaces this branch's commit with a new one — so a tag cut now would name a
SHA that never lands. After this merges, re-run `/rhiza:release`; it will detect that the
declared version has moved past the highest tag, tag the merged commit as `v1.0.0`, and
push the tag, which is what starts release CI.
