### PR TITLE
ci: adopt rhiza's applicable workflows, and fix the lockfile that breaks every gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`, `v9` or
       # `v10` alias tag, so `@v10` fails to resolve at job start.
@@ -37,7 +37,7 @@ jobs:
       # `version` pins the uv binary itself, not just the action, to the same uv that
       # rhiza_release.yml builds and publishes with. A gate that passes here on one uv and
       # a release built on another is a resolver difference nothing would catch.
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.16"
           python-version: ${{ matrix.python-version }}
@@ -54,8 +54,8 @@ jobs:
     name: the gates this package applies to others
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.16"
           enable-cache: true
@@ -70,3 +70,34 @@ jobs:
       # subject; asserting it here would only assert that this repo is something it is not.
       - name: rhiza-task all
         run: uv run rhiza-task all
+
+  # The floors in pyproject.toml -- typer>=0.15, rich>=13.0, python-dotenv>=1.0 -- are a
+  # claim, and `--frozen` everywhere else means nothing tests it: the lockfile resolves
+  # typer 0.27.1 and rich 15.0.0, nine and two minor versions above what the manifest
+  # says is enough. This job is the only place those numbers are asserted. Lifted from
+  # rhiza's rhiza_ci.yml `lowest-deps`, which is the one job there that calls plain uv
+  # rather than a pinned older rhiza-task, so it carries no circular dependency on this
+  # package.
+  lowest-deps:
+    name: lowest-direct dependency floors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # Deliberately not --frozen: resolving against the manifest rather than the
+      # lockfile is the whole point.
+      - name: Resolve the declared floors
+        run: uv sync --all-extras --all-groups --resolution lowest-direct
+
+      - name: Show what that resolved to
+        run: uv pip list
+
+      # pytest directly rather than `rhiza-task test`: the task provisions pytest through
+      # `uv run --with`, which resolves newest and would silently undo the floors this job
+      # exists to check.
+      - name: Run tests against the floors
+        run: uv run --all-extras --all-groups --resolution lowest-direct pytest -ra

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -1,0 +1,35 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: CodeQL
+#
+# Purpose: Automated code scanning for Python and GitHub Actions using
+#          GitHub's CodeQL engine. Free for public repositories; requires
+#          GitHub Advanced Security for private repositories.
+#          Set the CODEQL_ENABLED repository variable to 'true' to force-enable
+#          on private repos, 'false' to disable, or leave unset for auto-detect.
+#
+# Trigger: On push to main/master, pull requests, and weekly schedule.
+
+name: "(RHIZA) CODEQL"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+  schedule:
+    - cron: '27 1 * * 1'
+
+jobs:
+  codeql:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
+    secrets: inherit
+    permissions:
+      security-events: write   # Upload CodeQL results to code scanning
+      packages: read
+      actions: read
+      contents: read

--- a/.github/workflows/rhiza_quality_review.yml
+++ b/.github/workflows/rhiza_quality_review.yml
@@ -1,0 +1,38 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Quality Review (Claude)
+#
+# Purpose: Advisory, agentic *design review* of a pull request's diff, posted as
+#          a PR comment. It covers only what the deterministic gates cannot —
+#          architecture/design fit, unnecessary complexity, and test-coverage
+#          gaps. It deliberately does NOT re-run fmt/lint/typecheck/test/deptry/
+#          security; rhiza_ci already runs those. MUST NOT be a required check.
+#
+#          Thin stub: all logic, cost gating, and the enablement gate live in
+#          the reusable workflow in jebel-quant/rhiza; this file only wires up
+#          the pull_request trigger and inherits secrets.
+#
+# Setup (required — the workflow no-ops until both are present):
+#   1. Set the repository (or org) variable CLAUDE_QUALITY_REVIEW_ENABLED=true.
+#   2. Provide the ANTHROPIC_API_KEY secret — cleanest as an organisation
+#      secret so every opted-in repo inherits it.
+#   NOTE: this workflow spends Anthropic API tokens on every PR and sends diff
+#         context to the Anthropic API. Enable it only where that is acceptable.
+#
+# Trigger: On pull_request (opened / synchronize / reopened).
+
+name: "(RHIZA) QUALITY REVIEW"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  quality-review:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_quality_review.yml@v1.4.2
+    secrets: inherit

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -102,8 +102,13 @@ jobs:
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -175,7 +180,9 @@ jobs:
           exit 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
 
       - name: Ensure release version is newer than latest published
         env:
@@ -229,13 +236,18 @@ jobs:
       id-token: write       # OIDC for attestation signing
       attestations: write   # SLSA provenance + SBOM attestations (public repos only)
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.16"
 
@@ -279,7 +291,7 @@ jobs:
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version-file: .python-version
 
@@ -305,7 +317,7 @@ jobs:
         # The XML format is provided for compatibility but doesn't need separate attestation.
         id: attest-sbom
         if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
-        uses: actions/attest@v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: sbom.cdx.json
           sbom-path: sbom.cdx.json
@@ -321,7 +333,7 @@ jobs:
 
       - name: Upload SBOM artifacts
         if: hashFiles('pyproject.toml') != ''
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: |
@@ -332,7 +344,7 @@ jobs:
       - name: Generate SLSA provenance attestations
         id: provenance
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
-        uses: actions/attest-build-provenance@v4.2.2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/*
 
@@ -345,7 +357,7 @@ jobs:
 
       - name: Upload dist artifact
         if: steps.buildable.outputs.buildable == 'true'
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist
@@ -359,20 +371,27 @@ jobs:
       contents: write   # Needed to create the GitHub release and upload artifacts
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
 
       - name: Generate release notes with git-cliff
         run: uvx git-cliff --latest --output RELEASE_NOTES.md
 
       - name: Download SBOM artifact
         # Downloads sbom.cdx.json and sbom.cdx.xml into sbom/ directory
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
           path: sbom
@@ -381,14 +400,14 @@ jobs:
       - name: Download dist artifact
         # Brings in provenance.intoto.jsonl (and the built distributions) staged
         # by the build job, so the SLSA provenance ships as a release asset.
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
         continue-on-error: true
 
       - name: Create GitHub Release with artifacts
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.tag.outputs.tag }}
           name: ${{ needs.tag.outputs.tag }}
@@ -410,13 +429,18 @@ jobs:
       should_publish: ${{ steps.check_dist.outputs.should_publish }}
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
@@ -438,18 +462,11 @@ jobs:
           fi
           cat "$GITHUB_OUTPUT"
 
-      - name: Remove non-distribution files before publish
-        # The dist artifact also carries the SLSA provenance bundle (staged for
-        # the GitHub release). twine/pypi-publish rejects it as an unknown
-        # distribution format, so strip it here before publishing.
-        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
-        run: rm -f dist/*.intoto.jsonl
-
       # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI
         if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           skip-existing: true
@@ -465,13 +482,18 @@ jobs:
     permissions:
       contents: write   # Needed to undraft/publish the GitHub release
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Code
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.11.16"
 
@@ -483,7 +505,7 @@ jobs:
           uv sync --all-extras --all-groups --frozen
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
 
       - name: Generate PyPI Link
         id: pypi_link

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -1,0 +1,45 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: OSSF Scorecard
+#
+# Purpose: Run the OpenSSF Scorecard supply-chain security analysis and upload
+#          the results to GitHub code scanning. On public repositories the
+#          results are also published to the OpenSSF REST API, which powers
+#          the README badge and lets adopters verify the score independently.
+#          Set the SCORECARD_ENABLED repository variable to 'true' to
+#          force-enable on private repos, 'false' to disable, or leave unset
+#          for auto-detect (public repositories only).
+#
+#          Thin stub: the analysis logic and its enablement/visibility gate
+#          live in the reusable workflow in jebel-quant/rhiza; this file only
+#          wires up the triggers and grants the token scopes Scorecard needs.
+#
+# Trigger: Weekly schedule, pushes to main, branch-protection changes, and
+#          manual dispatch.
+
+name: "(RHIZA) SCORECARD"
+
+on:
+  # Re-evaluate when branch protection rules change (Scorecard's
+  # Branch-Protection check reads them).
+  branch_protection_rule:
+  schedule:
+    - cron: '34 2 * * 2'
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+# Least privilege by default; the called workflow grants its job only what
+# Scorecard needs (see the job-level permissions below).
+permissions: read-all
+
+jobs:
+  scorecard:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
+    secrets: inherit
+    permissions:
+      security-events: write   # Upload the SARIF results to code scanning
+      id-token: write          # Publish results to the OpenSSF REST API (badge)
+      contents: read
+      actions: read

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,69 @@
+# Adapted from jebel-quant/rhiza's rhiza_weekly.yml (v1.4.2) rather than delegated to it
+# as a stub. The reusable workflow runs its gates as `uvx "$RHIZA_TASK" <gate>` with
+# RHIZA_TASK pinned to rhiza-task@0.3.1 -- correct for a consumer, circular here: this
+# repository's own gates would run through a published, pre-1.0 copy of itself instead of
+# the working tree. So the two jobs worth having are lifted and the indirection dropped.
+#
+# Its third job, semgrep, is not lifted: `rhiza-task semgrep` skips without
+# .rhiza/semgrep.yml and this repository ships none, exactly as pytest-rhiza does not.
+
+name: Weekly
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"  # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  # The complement of ci.yml's `lowest-deps`: that job pins the floors the manifest
+  # declares, this one resolves the ceiling nobody has seen yet. Between them, both ends
+  # of `typer>=0.15` are actually tested -- and a break here is upstream's release, not a
+  # commit, which is why it runs on a schedule rather than on push.
+  dep-compat:
+    name: latest compatible dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # --upgrade ignores the committed lockfile and resolves the newest versions that
+      # still satisfy pyproject.toml. Deliberately not --frozen, for the same reason
+      # `lowest-deps` is not.
+      - name: Resolve the newest compatible dependencies
+        run: uv sync --all-extras --all-groups --upgrade
+
+      - name: Show what that resolved to
+        run: uv pip list
+
+      # `uv run`, not `uvx rhiza-task@<pin>`: the point is to test HEAD against tomorrow's
+      # dependencies, so the CLI under test has to be the one in the tree.
+      - name: Run the gates
+        run: uv run rhiza-task test
+
+  # The README carries six badges and a dozen links -- to PyPI, to sibling repos, to the
+  # uv and Ruff endpoints. Nothing else notices when one of them rots.
+  link-check:
+    name: README links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check links in README.md
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --accept 200,206,429
+            README.md
+          fail: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,19 @@ filename = "README.md"
 search = "rhiza-task@{current_version}"
 replace = "rhiza-task@{new_version}"
 
+# The lockfile records this package's own version, and `uv lock --check` is the first
+# command `install` runs -- so a bump that leaves uv.lock behind fails every gate that
+# names `install` as a prerequisite, which is all of them. v1.0.0 shipped that way: the
+# release commit touched pyproject.toml, __init__.py and CHANGELOG.md only. The search is
+# anchored on the package name because a bare `version = "..."` matches every one of the
+# seventeen locked packages.
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = """name = "rhiza-task"
+version = "{current_version}\""""
+replace = """name = "rhiza-task"
+version = "{new_version}\""""
+
 [tool.deptry.package_module_name_map]
 # python-dotenv installs a module called `dotenv`. deptry runs isolated via `uvx`, so the
 # package is not importable and it cannot discover the mapping itself -- it guesses

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "0.3.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Brings over the workflows from `jebel-quant/rhiza` that apply to this repository, and fixes a lockfile bug found on the way in.

## CI is currently red on `main`

`uv.lock` records `rhiza-task 0.3.1` against a `pyproject.toml` saying `1.0.0`, so on a clean checkout:

```
$ uv lock --check
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

That is the first command `install` runs, and `install` is a prerequisite of every gate in `rhiza-task all` — so the `gates` job fails at step one. Cause: 182615c (`chore: release v1.0.0`) touched `pyproject.toml`, `__init__.py` and `CHANGELOG.md`, and `[tool.bumpversion]` had no `uv.lock` entry, so every release would have done the same.

Relocked, and added the bumpversion entry that stops it recurring — anchored on the package name, because a bare `version = "…"` matches all seventeen locked packages.

## What is adopted, and why by hand

Most rhiza workflows ship as thin stubs: ~30 lines delegating to a reusable workflow, needing no `.rhiza/`, no sync and no Makefile. `pytest-rhiza` — the sibling this README names, equally unmanaged — already carries four of them at `@v1.4.2`, so the pattern is proven in the closest precedent.

| Workflow | Note |
|---|---|
| `rhiza_scorecard.yml` | stub `@v1.4.2`; public repos auto-enable |
| `rhiza_codeql.yml` | stub `@v1.4.2`; free on public |
| `rhiza_quality_review.yml` | stub `@v1.4.2`; inert until `CLAUDE_QUALITY_REVIEW_ENABLED=true` **and** `ANTHROPIC_API_KEY` are set |
| `rhiza_release.yml` | re-synced from `v1.4.2`, `conda`/`devcontainer` re-trimmed. Cannot be a stub — PyPI OIDC validates the exact workflow path |
| `ci.yml` | `lowest-deps` job added; actions SHA-pinned |
| `weekly.yml` | `dep-compat` + `link-check`, adapted rather than delegated |

Scorecard is worth having first because `rhiza_release.yml` was already written for it — its comments cite the Signed-Releases and Token-Permissions checks — so the score was being engineered for and never published.

**Not adopted:** `rhiza_book`, `_marimo`, `_paper`, `_docker`, `_devcontainer` have no subject here. `rhiza_e2e` declares no `workflow_call`. `rhiza_ci`, `rhiza_weekly` and `rhiza_benchmark` run their gates as `uvx rhiza-task@0.3.1` — correct for a consumer, circular here, which is also why `ci.yml`'s `uv run rhiza-task all` stays as it is: it dogfoods HEAD, which is the point of that job.

## The release workflow had drifted

|  | before | after |
|---|---|---|
| lines | 528 | 546 |
| `harden-runner` steps | 0 | 5 |
| SHA-pinned actions | 1 / 21 | **26 / 26** |

The `conda` and `devcontainer` trim was deliberate and is preserved, as is the local preamble explaining why this file cannot be a stub — the template carries no equivalent.

Closes #37, but not as a side effect of the re-sync: the template itself supplies `version:` on only two of four `setup-uv` steps. All six `setup-uv` uses across both workflows now pin the same action SHA (v10.0.1, resolved via the API) and the same uv binary (`0.11.16`).

## Both ends of the dependency range are now tested

`typer>=0.15`, `rich>=13.0`, `python-dotenv>=1.0` were a claim nothing checked — `--frozen` everywhere meant every job resolved the lockfile, which pins typer 0.27.1 and rich 15.0.0.

- `lowest-deps` (ci.yml) asserts the floors. Verified locally: typer 0.15.0, rich 13.0.0, python-dotenv 1.0.0, pytest 8.0.0, **224 passed**.
- `dep-compat` (weekly.yml) resolves the newest compatible set on a schedule, since a break there is upstream's release rather than a commit.

## Verification

- `actionlint` clean across all six workflows; YAML parses, job graphs as expected
- `uv run rhiza-task all` — all green, and `install` now passes on the committed lockfile
- `ruff check` / `ruff format --check` clean

## Deliberately left out

- **No `harden-runner` in `ci.yml` / `weekly.yml`.** The template adds it everywhere; `ci.yml` never had it. Two of three files would be incoherent, and all three is wider than this PR. Next Scorecard point.
- **`fmt` still skips** — no `.pre-commit-config.yaml` (#36). The README carries a Ruff badge for a linter no gate runs.
- Upstream, unrelated to this branch: rhiza's own workflows pin `rhiza-task@0.3.1` while this package is at 1.0.0 with a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
