### PR TITLE
docs: make the examples executable, and declare the layout opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ def audit(cfg):
     uvx("my-auditor", cfg.source_folder, cwd=cfg.root)
 ```
 
+The decorator has already done the registering, so the task is now reachable by the same
+`lookup` the runner and the CLI use — no override, no second path:
+
+```python
+from rhiza_task.spec import lookup
+
+spec = lookup("audit")
+print(spec.key, "-", spec.help)
+print(spec.needs, spec.guards[0].folder, spec.section)
+```
+
+```result
+audit - run the in-house audit
+('install',) source_folder Quality
+```
+
+That last pair of blocks is executed and diffed, not just rendered: the `result` block is
+compared against the fences' real output by the same convention `rhiza-task rhiza-test`
+applies to every docstring's `>>>` examples. A change to `lookup`, to `Task`, or to the
+decorator above breaks the README rather than quietly outdating it.
+
 A one-off that is only ever a make target goes in `local.mk` — but that file is in core's
 `.gitignore`, so it holds developer-local targets only. A repo-owned target CI invokes
 needs a committed home, and the repo's own `Makefile` is the only committed make surface
@@ -218,7 +239,13 @@ repo, which is the problem being deleted.
 ```bash
 uv sync --all-groups
 uv run pytest
+uv run rhiza-task all      # every gate, as the `gates` job runs them
 ```
+
+The examples above are checked, not decorative — `rhiza-task rhiza-test` runs the `>>>`
+examples in `config.py`, `runner.py` and `spec.py` and diffs this README's `python` fences
+against its `result` block. Both need the project environment, since the fences import the
+package: `uv run` rather than a bare interpreter.
 
 No test in the suite runs uv. Every task test patches the three entry points in `uv.py`
 and asserts on the argument vector that would have been executed — which is exactly what

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,30 @@ version = "{new_version}\""""
 # (DEP001). Declaring it is the documented fix, and cheaper than making the gate install
 # the project first.
 python-dotenv = "dotenv"
+
+# This repository's own settings, read by `rhiza-task` as layer 4 of its own resolution
+# order -- the package configuring itself with the mechanism it sells.
+#
+# The floor is raised from the shipped default of 90 because 90 is the *tool's* answer for
+# a repo it knows nothing about, and this repo can do better: the suite covers 96.5% of
+# 1070 statements, so 95 is a floor that is met with headroom and still says something. It
+# is enforced wherever `test` runs -- the `gates` job's `rhiza-task all` in CI, and every
+# local invocation -- which is what makes it a gate rather than a note.
+[tool.rhiza-task]
+coverage_fail_under = 95
+
+# The suite is organised by *behaviour*, not as a 1:1 mirror of `src/`: `test_tasks.py`,
+# `test_bundle_tasks.py`, `test_dev_tasks.py` and `test_language_layers.py` cover the
+# twelve task modules as groups, because what is worth asserting about them is the shape
+# they share -- a guard, a provision, an argument vector -- and a per-module test file
+# would be twelve copies of one test. Undeclared, `check_test_layout.py` reads that as 18
+# missing mirrors and 9 orphans, and reports disorder where there is a decision.
+#
+# `enforce = false` requires a non-empty `reason` precisely so the opt-out cannot be a
+# silent one. What the reason deliberately does *not* claim is per-module coverage: only a
+# 100% floor would guarantee that, and this repo's is 95 (see above), so the honest
+# statement is that tests are located by behaviour and covered globally. Raising the floor
+# to 100 is the change that would make a stronger claim available.
+[tool.check_test_layout]
+enforce = false
+reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Coverage is enforced globally by the 95% floor in [tool.rhiza-task], met at 96.5%."

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -304,6 +304,51 @@ class Config:
 
         Returns:
             The resolved config.
+
+        Examples:
+            Layer 4 -- ``[tool.rhiza-task]`` in the manifest -- over the dataclass
+            defaults, with an unset flag passed as ``None`` and correctly *not* shadowing
+            what the manifest said:
+
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> manifest = '''
+            ... [tool.rhiza-task]
+            ... source_folder = "lib"
+            ... coverage_fail_under = 100
+            ... uv_sync_args = "--group test"
+            ... '''
+            >>> with tempfile.TemporaryDirectory() as tmp:
+            ...     root = Path(tmp)
+            ...     _ = (root / "pyproject.toml").write_text(manifest)
+            ...     cfg = Config.load(root, source_folder=None, typechecker="mypy")
+            >>> cfg.source_folder, cfg.coverage_fail_under, cfg.typechecker
+            ('lib', 100, 'mypy')
+
+            A ``tuple[str, ...]`` field given as a string is split on whitespace rather
+            than one character per argument, which is the make layer's own format and the
+            bug ``__post_init__`` exists to prevent:
+
+            >>> cfg.uv_sync_args
+            ('--group', 'test')
+
+            The manifest that carried the table is also what put the repository in a
+            layer, and the check set follows from the layers rather than from a list
+            anyone maintains:
+
+            >>> cfg.layers
+            ('python',)
+            >>> cfg.rhiza_checks[-1]
+            'pytest_rhiza.checks.test_docstrings'
+
+            An unreadable setting fails here, before any tool is provisioned -- the shell
+            ``case`` that used to validate it ran after:
+
+            >>> with tempfile.TemporaryDirectory() as tmp:
+            ...     Config.load(Path(tmp), typechecker="pyright")
+            Traceback (most recent call last):
+                ...
+            ValueError: typechecker must be one of ty, mypy, both (got 'pyright')
         """
         root = (root or Path.cwd()).absolute()
         raw: dict[str, Any] = {}

--- a/src/rhiza_task/runner.py
+++ b/src/rhiza_task/runner.py
@@ -79,13 +79,39 @@ class Run:
         return next((r.status for r in self.results if r.name == name), None)
 
     def exit_code(self) -> int:
-        """Return the aggregate exit status.
+        """Return the aggregate exit status: 0 when nothing failed or was blocked, else 1.
 
-        The first real failure's own code is propagated where there is one, so a caller
-        can still distinguish e.g. pytest's exit codes. Blocked-only runs exit 1.
+        Uniformly 1, and the example below is what says so. :class:`~rhiza_task.spec.Failed`
+        carries the failing process's own code, but :class:`Result` does not record it, so
+        nothing here *can* propagate e.g. pytest's 3 or 4 -- and this docstring claimed it
+        did until a doctest was put under it. Whether the code should be carried through
+        is issue #33; until it is decided, the behaviour and its description agree.
 
         Returns:
-            0 when nothing failed, else the failing task's exit status.
+            0 when nothing failed or was blocked, else 1.
+
+        Examples:
+            An empty run, and a run whose only entry is a skip, both succeed -- a skip is
+            an outcome, not a failure, and ``--strict`` is the switch that changes that:
+
+            >>> state = Run()
+            >>> state.exit_code()
+            0
+            >>> state.results.append(Result("fmt", Status.SKIPPED, "no .pre-commit-config.yaml"))
+            >>> state.failed, state.exit_code()
+            (False, 0)
+
+            A failure, and the dependent it blocks, are both non-zero -- and both collapse
+            to 1 rather than to pytest's own status:
+
+            >>> state.results.append(Result("test", Status.FAILED, "tests failed"))
+            >>> state.results.append(Result("book", Status.BLOCKED, "prerequisite failed: test"))
+            >>> state.failed, state.exit_code()
+            (True, 1)
+            >>> state.status_of("book") is Status.BLOCKED
+            True
+            >>> state.status_of("todos") is None
+            True
         """
         return 1 if self.failed else 0
 

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -106,6 +106,46 @@ class Guard:
         Raises:
             Skip: When the tool is absent, or the file is missing, or the folder is
                 missing, or the folder holds no file matching ``glob``.
+
+        Examples:
+            A satisfied guard returns nothing, which is the whole of its success case:
+
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> tmp = tempfile.TemporaryDirectory()
+            >>> root = Path(tmp.name)
+            >>> (root / "src").mkdir()
+            >>> folders = {"source_folder": "src", "tests_folder": "tests"}
+            >>> Guard("source_folder").check(root, folders)
+
+            Each way of not being satisfied raises :class:`Skip` carrying the line the
+            runner prints, and ``folder`` is resolved through *folders* -- so the guard
+            names a setting and never a path:
+
+            >>> for guard in (
+            ...     Guard("tests_folder"),
+            ...     Guard("source_folder", glob="test_*.py"),
+            ...     Guard(file="Cargo.toml"),
+            ...     Guard(tool="a-tool-nobody-has"),
+            ... ):
+            ...     try:
+            ...         guard.check(root, folders)
+            ...     except Skip as exc:
+            ...         print(exc)
+            tests_folder 'tests' not found
+            no test_*.py below 'src'
+            no Cargo.toml
+            a-tool-nobody-has not found
+
+            ``reason`` replaces the generated message wherever a task has something more
+            useful to say:
+
+            >>> try:
+            ...     Guard("tests_folder", glob="test_*.py", reason="no test files found").check(root, folders)
+            ... except Skip as exc:
+            ...     print(exc)
+            no test files found
+            >>> tmp.cleanup()
         """
         if self.tool and not have(self.tool):
             raise Skip(self.reason or f"{self.tool} not found")
@@ -252,6 +292,37 @@ def lookup(name: str, layers: Sequence[str] = ()) -> Task | None:
 
     Returns:
         The task, or None when nothing matches.
+
+    Examples:
+        Importing a task module is what registers its tasks -- the entry point group in
+        ``pyproject.toml`` only decides *which* modules the CLI imports:
+
+        >>> from rhiza_task.tasks import python, quality, rust
+        >>> lookup("test", ["python"]).help
+        'run all tests'
+        >>> lookup("test", ["rust"]).help
+        'run the test suite with nextest, then the doctests'
+
+        The layers are tried in order, so a crate that has grown a Python package gets one
+        answer rather than an ambiguity -- and the explicit key is how the layer that lost
+        is still reachable:
+
+        >>> lookup("test", ["python", "rust"]).key
+        'python:test'
+        >>> lookup("test", ["rust", "python"]).key
+        'rust:test'
+        >>> lookup("rust:test", ["python"]).key
+        'rust:test'
+
+        A neutral task answers to its bare name whatever the layers are, and a name no
+        active layer has is None rather than an error -- which is what lets ``book``
+        depend on gates a repository may not have, in place of make's ``test:: ; @:``
+        no-op stubs:
+
+        >>> lookup("fmt", ["rust"]).key
+        'fmt'
+        >>> lookup("cargo-tools", ["python"]) is None
+        True
     """
     if ":" in name:
         return REGISTRY.get(name)


### PR DESCRIPTION
Closes #34, closes #35, closes #43 — three findings sharing one root: documentation and layout that were correct by discipline, with nothing asserting them.

## #34 — doctests on the four public seams

No module carried a `>>>` example, so `rhiza-task rhiza-test`'s docstring check *skipped*: 100% docstring coverage saying nothing about whether any docstring was true. `Config.load`, `Guard.check`, `lookup` and `Run.exit_code` now carry 36 examples between them.

| before | after |
|---|---|
| `SKIPPED [1] test_docstrings.py:213: No doctests were found in any module` | `34 passed` — no skips |
| `check_doc_examples.py`: `files: 20, examples: 0` | `src: 20 file(s), 36 example(s) in 4 docstring(s)` |

The examples were chosen to pin the contracts the prose asserts, not to decorate: `Config.load` shows layer 4 beating the defaults, `None` overrides *not* shadowing a configured value, whitespace-splitting of a `tuple[str, ...]` field, and the `ValueError` raised before any tool is provisioned. `Guard.check` shows all four skip messages and `reason` replacing them. `lookup` shows layer order, the explicit `rust:test` key reaching the layer that lost, and `None` for a task no active layer has.

### This surfaced #33

Writing the `Run.exit_code` example is exactly what the issue predicted it would be: the docstring claimed *"the first real failure's own code is propagated where there is one, so a caller can still distinguish e.g. pytest's exit codes"*, while the body is `return 1 if self.failed else 0` — and `Result` records no code for it to propagate. The prose now matches the body and names #33.

**#33 stays open and this PR does not decide it.** It offers two resolutions — propagate the code, or correct the docstring — and carrying `Failed.code` through `Result` is a behaviour change well outside this PR's scope. What changed here is only that the docstring no longer contradicts its own example.

## #35 — the test-layout opt-out

`check_test_layout.py` reported 18 missing mirrors and 9 orphans against a deliberate decision: the suite is grouped by behaviour, because what is worth asserting about the twelve task modules is the shape they share. Now declared, with the `reason` the checker requires — exit 0.

**Two corrections to the issue's evidence, both checked here:**

1. This repo has **no committed coverage floor**. `grep coverage_fail_under` finds nothing outside README samples; the shipped default of 90 applies. There is no `.rhiza/.env`, no `rhiza.toml`.
2. Coverage is **96.54% of 1070 statements**, not 423/423 at 100% — `rhiza-task test` reports `Required test coverage of 90% reached. Total coverage: 96.54%`.

So the `reason` the issue asked for — one naming a 100% gate that guarantees per-module coverage — would have been false, and only a 100% floor guarantees per-module coverage anyway. Instead:

- the floor is now **committed at 95** in `[tool.rhiza-task]` — a real choice rather than the tool's default-for-a-repo-it-knows-nothing-about, met with headroom, and enforced wherever `test` runs, including the `gates` job's `rhiza-task all`;
- the `reason` says what is true: tests are located by behaviour and covered globally at 95%. The comment above it records that raising the floor to 100 is the change that would make the stronger claim available.

## #43 — a verified README example

Every fence was parse-checked and none executed, so a claim could go stale while rendering perfectly. The `python` fence after the "Adding a task" example now looks that task up and prints, with a ```` ```result` ```` block diffed against the real output — which verifies the *preceding* fence too, since the checker concatenates the README's Python and runs it as one program. A change to `lookup`, to `Task` or to the decorator breaks the README instead of quietly outdating it.

The Development section now records how to run both halves, and why they need `uv run`: the fences import the package, so a bare interpreter has neither `rhiza_task` nor `python-dotenv`. That is a property of any repo with a third-party runtime dependency, not of these docs — the pre-existing fence at `README.md:168` failed the same way before this PR.

## Verification

```
check_doc_examples.py --source-root src --run   exit 0
    ran   36 example(s), 0 failed, 0 module(s) unimportable
    ran   python fences exited 0, output matched: True
check_test_layout.py                            exit 0
    Test layout OK: parity not enforced by request — ...
rhiza-task rhiza-test                           34 passed, 0 skipped
rhiza-task test                                 Required test coverage of 95% reached. Total coverage: 96.54%
rhiza-task all                                  every gate ok (fmt skips, as designed)
uv run pytest                                   224 passed
uvx ruff check / format --check                 clean
```

## Note on #38

The Development section gained one line naming `rhiza-task all` as the gate set CI runs. That is adjacent to #38, which asks for it to be named as **the pre-push check** — a different claim, so #38 is not closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)