### PR TITLE
docs: say why the four C-complexity blocks are shaped as they are

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,11 @@ coverage_fail_under = 95
 # 100% floor would guarantee that, and this repo's is 95 (see above), so the honest
 # statement is that tests are located by behaviour and covered globally. Raising the floor
 # to 100 is the change that would make a stronger claim available.
+#
+# The reason says "95" and not "95%" on purpose: radon reads *every* `[tool.*]` table
+# through configparser, which treats `%` as interpolation syntax and dies on any value
+# containing one -- so a percent sign here breaks `radon cc src`, the command the
+# complexity notes in spec.py, runner.py and config.py are there to answer.
 [tool.check_test_layout]
 enforce = false
-reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Coverage is enforced globally by the 95% floor in [tool.rhiza-task], met at 96.5%."
+reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Coverage is enforced globally by the coverage_fail_under floor of 95 in [tool.rhiza-task], which the suite meets with headroom."

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -227,6 +227,11 @@ class Config:
 
     root: Path = field(default_factory=Path.cwd)
 
+    # radon scores this method C (12): one branch per field that needs normalising or
+    # checking -- str and list coercion, layer defaulting and membership, rhiza_checks
+    # defaulting, typechecker, coverage_fail_under. It is a flat sequence, one field per
+    # step, with no interaction between the steps; the count grows with the number of
+    # validated settings and not with the depth of anything. Deliberate.
     def __post_init__(self) -> None:
         """Normalise the list fields, then validate the enumerated and numeric ones.
 

--- a/src/rhiza_task/runner.py
+++ b/src/rhiza_task/runner.py
@@ -142,6 +142,11 @@ def run(names: list[str], cfg: Config) -> Run:
     return run_state
 
 
+# radon scores this function C (12), which is one branch per *outcome* a task can have:
+# already seen, unknown, blocked by a prerequisite, skipped, skipped under --strict,
+# failed, ok. Each writes exactly one line of the run summary, so the branch count is the
+# size of :class:`Status` plus the two early returns -- flat dispatch over a closed set,
+# and deliberate. Splitting it would put the outcomes in two places.
 def _run_one(name: str, cfg: Config, state: Run) -> None:
     """Run one task after its prerequisites, recording the outcome.
 

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -61,6 +61,12 @@ class Failed(Exception):  # noqa: N818 - ditto
         self.code = code
 
 
+# radon scores this class C (14) and :meth:`Guard.check` C (13) -- the class figure *is*
+# check's, since everything else here is five fields and a docstring. Both count the same
+# five ``if ... raise Skip`` clauses: one per kind of precondition, flat, no nesting, in
+# the order they fire. A dispatch table of five predicates would move that count rather
+# than reduce it, and would cost the reader the ordering -- tool before file before folder
+# before glob, cheapest and most likely first. The shape is deliberate.
 @dataclass(frozen=True)
 class Guard:
     """A precondition on the repository layout.
@@ -147,6 +153,8 @@ class Guard:
             no test files found
             >>> tmp.cleanup()
         """
+        # Five guard clauses, each one precondition and each raising the line the runner
+        # prints -- see the note above the class for why they are not factored apart.
         if self.tool and not have(self.tool):
             raise Skip(self.reason or f"{self.tool} not found")
         if self.file and not (root / self.file).is_file():


### PR DESCRIPTION
Closes #40.

`uvx radon cc src -a -s` reports A (3.05) across 133 blocks; four rank C:

| Block | CC | Why the count |
|---|---|---|
| `spec.py` `Guard` | 14 | it *is* `Guard.check`'s -- the rest is five fields |
| `spec.py` `Guard.check` | 13 | five `if … raise Skip` clauses, one per precondition kind |
| `runner.py` `_run_one` | 12 | one branch per outcome: seen, unknown, blocked, skipped, strict, failed, ok |
| `config.py` `Config.__post_init__` | 12 | one step per normalised or validated field |

None of them nest; the count tracks the number of cases handled, and factoring
any of them apart would relocate the branches rather than remove them. Each block
now carries a comment saying so — the second of the issue's two acceptance routes.

Along the way: `[tool.check_test_layout].reason` lost its `%`. radon slurps every
`[tool.*]` table through configparser, which reads `%` as interpolation syntax and
raises, so `radon cc src` did not run in this repo at all. The reason now says "the
coverage_fail_under floor of 95", and a comment above the table records the
constraint so it does not get reintroduced.

Gates: `rhiza-task all` green (fmt skipped, no pre-commit config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)