### PR TITLE
fix(runner): propagate the failing task's own exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,15 @@ repo, which is the problem being deleted.
 
 ```bash
 uv sync --all-groups
-uv run pytest
-uv run rhiza-task all      # every gate, as the `gates` job runs them
+uv run pytest              # the fast inner loop
+uv run rhiza-task all      # run before pushing: every gate, as CI runs them
 ```
+
+`uv run rhiza-task all` is the pre-push check, and it is what `ci.yml`'s `gates` job runs
+— deptry, the 100% coverage floor, interrogate, bandit, the copyleft scan, `ty` and
+`rhiza-test` on top of the suite. `uv run pytest` alone is strictly weaker than the check
+that will fail a pull request, so a green pytest is not yet a green PR. This repo exists to
+provide that aggregate, so it gates itself with it.
 
 The examples above are checked, not decorative — `rhiza-task rhiza-test` runs the `>>>`
 examples in `config.py`, `runner.py` and `spec.py` and diffs this README's `python` fences

--- a/src/rhiza_task/cli.py
+++ b/src/rhiza_task/cli.py
@@ -156,7 +156,11 @@ def run_tasks(
         root: Repository root; defaults to the current directory.
 
     Raises:
-        typer.Exit: With 0 when everything passed, 1 on failure, 2 on a usage error.
+        typer.Exit: With 0 when everything passed, 2 on a usage error, and otherwise the
+            first failing task's own exit status -- pytest's 2 or 4, ``cargo``'s 101 --
+            falling back to 1 when it has none. A usage error and a task that exited 2
+            therefore share a status; the run summary above distinguishes them, and the
+            alternative is discarding the code every consumer's CI wants.
     """
     try:
         cfg = Config.load(root=root, strict=strict or None)

--- a/src/rhiza_task/runner.py
+++ b/src/rhiza_task/runner.py
@@ -44,11 +44,15 @@ class Result:
         name: The task name.
         status: Its outcome.
         detail: Why, for anything other than :attr:`Status.OK`.
+        code: The failing process's own exit status, carried from
+            :class:`~rhiza_task.spec.Failed` so :meth:`Run.exit_code` can propagate it.
+            0 for every outcome that is not a failure.
     """
 
     name: str
     status: Status
     detail: str = ""
+    code: int = 0
 
 
 @dataclass
@@ -79,16 +83,19 @@ class Run:
         return next((r.status for r in self.results if r.name == name), None)
 
     def exit_code(self) -> int:
-        """Return the aggregate exit status: 0 when nothing failed or was blocked, else 1.
+        """Return the aggregate exit status: 0 when nothing failed or was blocked, else non-zero.
 
-        Uniformly 1, and the example below is what says so. :class:`~rhiza_task.spec.Failed`
-        carries the failing process's own code, but :class:`Result` does not record it, so
-        nothing here *can* propagate e.g. pytest's 3 or 4 -- and this docstring claimed it
-        did until a doctest was put under it. Whether the code should be carried through
-        is issue #33; until it is decided, the behaviour and its description agree.
+        The first real failure's own code is propagated where there is one, so a caller can
+        still distinguish e.g. pytest's 2 from a gate that merely exited 1. "First real"
+        means the first :attr:`Status.FAILED` entry: a :attr:`Status.BLOCKED` dependent has
+        no process of its own, and the failure that blocked it is recorded earlier in the
+        list, so it is the one that speaks. Anything outside a shell's 1-255 range -- a
+        code of 0, or the negative signal number ``subprocess`` reports for a killed child
+        -- collapses to 1, since it cannot be handed to ``exit`` as-is.
 
         Returns:
-            0 when nothing failed or was blocked, else 1.
+            0 when nothing failed or was blocked; else the first failing task's exit status,
+            or 1 when that status is unusable.
 
         Examples:
             An empty run, and a run whose only entry is a skip, both succeed -- a skip is
@@ -101,19 +108,30 @@ class Run:
             >>> state.failed, state.exit_code()
             (False, 0)
 
-            A failure, and the dependent it blocks, are both non-zero -- and both collapse
-            to 1 rather than to pytest's own status:
+            A failure, and the dependent it blocks, are both non-zero -- and pytest's own 2
+            is what the run exits with, not a flattened 1:
 
-            >>> state.results.append(Result("test", Status.FAILED, "tests failed"))
+            >>> state.results.append(Result("test", Status.FAILED, "tests failed", 2))
             >>> state.results.append(Result("book", Status.BLOCKED, "prerequisite failed: test"))
             >>> state.failed, state.exit_code()
-            (True, 1)
+            (True, 2)
             >>> state.status_of("book") is Status.BLOCKED
             True
             >>> state.status_of("todos") is None
             True
+
+            A failure with no usable code of its own -- a guard's own verdict rather than a
+            child process's, or a blocked dependent standing alone -- is 1:
+
+            >>> Run([Result("doctor", Status.FAILED, "missing or outdated: uv")]).exit_code()
+            1
+            >>> Run([Result("book", Status.BLOCKED, "prerequisite failed: test")]).exit_code()
+            1
         """
-        return 1 if self.failed else 0
+        if not self.failed:
+            return 0
+        code = next((r.code for r in self.results if r.status is Status.FAILED), 1)
+        return code if 1 <= code <= 255 else 1
 
 
 def run(names: list[str], cfg: Config) -> Run:
@@ -181,6 +199,6 @@ def _run_one(name: str, cfg: Config, state: Run) -> None:
         else:
             state.results.append(Result(spec.name, Status.SKIPPED, str(exc)))
     except Failed as exc:
-        state.results.append(Result(spec.name, Status.FAILED, str(exc)))
+        state.results.append(Result(spec.name, Status.FAILED, str(exc), exc.code))
     else:
         state.results.append(Result(spec.name, Status.OK))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,6 +230,37 @@ def test_run_exits_one_on_failure(repo: Path, monkeypatch: pytest.MonkeyPatch) -
     assert "failed" in result.stdout
 
 
+def test_run_propagates_the_failing_task_s_own_status(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``typer.Exit`` carries the task's own 2, not a flattened 1.
+
+    The end of the chain :class:`~rhiza_task.spec.Failed` starts: a consumer's CI reads
+    this process's status and nothing else.
+
+    Args:
+        repo: The throwaway repository.
+        monkeypatch: pytest's patcher.
+    """
+    from rhiza_task.config import Config
+    from rhiza_task.spec import Failed, task
+
+    @task("t-cli-code", "fails the way pytest fails", section="Test")
+    def collection_error(cfg: Config) -> None:
+        """Fail with pytest's collection-error status.
+
+        Args:
+            cfg: Unused.
+
+        Raises:
+            Failed: Always, with code 2.
+        """
+        raise Failed(2, "tests failed")
+
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli.app, ["run", "t-cli-code"])
+    assert result.exit_code == 2
+    assert "failed" in result.stdout
+
+
 def test_root_option_targets_another_repository(repo: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
     """``--root`` operates on a repository other than the working directory.
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -144,7 +144,65 @@ def test_failed_prerequisite_blocks_its_dependents(cfg: Config) -> None:
     assert state.status_of("t-broken") == Status.FAILED
     assert state.status_of("t-dependent") == Status.BLOCKED
     assert "t-dependent" not in ORDER
-    assert state.exit_code() == 1
+    # The failure's own 2, not the blocked dependent's nothing: see the test below.
+    assert state.exit_code() == 2
+
+
+def test_a_failing_task_s_own_exit_status_is_what_the_run_exits_with(cfg: Config) -> None:
+    """A failing task's own 2 survives to the caller, rather than collapsing to a flat 1.
+
+    This is the point of :attr:`~rhiza_task.runner.Result.code`: a consumer's CI can tell
+    "tests failed" (pytest 1) from "collection errored" (2) or "usage error" (4), which is
+    what :class:`~rhiza_task.spec.Failed` has always carried and nothing used to read.
+
+    Args:
+        cfg: The resolved config.
+    """
+
+    @task("t-pytest-2", "fails the way pytest fails", section="Test")
+    def collection_error(cfg: Config) -> None:
+        """Fail with pytest's collection-error status.
+
+        Args:
+            cfg: Unused.
+
+        Raises:
+            Failed: Always, with code 2.
+        """
+        raise Failed(2, "tests failed")
+
+    @task("t-guard-verdict", "fails on its own verdict", section="Test")
+    def guard_verdict(cfg: Config) -> None:
+        """Fail without a child process behind it.
+
+        Args:
+            cfg: Unused.
+
+        Raises:
+            Failed: Always, with code 1.
+        """
+        raise Failed(1, "coverage 87.0% is below the 100% floor")
+
+    @task("t-killed", "reports a signal, not a status", section="Test")
+    def killed(cfg: Config) -> None:
+        """Fail with what ``subprocess`` reports for a child killed by SIGKILL.
+
+        Args:
+            cfg: Unused.
+
+        Raises:
+            Failed: Always, with an unusable code.
+        """
+        raise Failed(-9, "killed")
+
+    assert run(["t-pytest-2"], cfg).exit_code() == 2
+    assert run(["t-guard-verdict"], cfg).exit_code() == 1
+    # -9 is not a status a shell can report; 1 is the honest floor.
+    assert run(["t-killed"], cfg).exit_code() == 1
+
+    # The *first* real failure speaks, so a later gate's code cannot mask it.
+    both = run(["t-pytest-2", "t-guard-verdict"], cfg)
+    assert both.exit_code() == 2
 
 
 def test_skip_is_green_by_default_and_red_under_strict(repo: Config) -> None:


### PR DESCRIPTION
Closes #33, closes #38.

## #33 — `Run.exit_code()` propagates the failing task's code

`Failed.code` was set at `spec.py:61` and read nowhere: `Result` had no field for it, so
`runner.py`'s `except Failed` discarded it and every failure collapsed to `1`. A consumer's
CI could not distinguish pytest's `2` (collection errored) from `1` (tests failed).

- `Result` gains `code: int = 0`, filled from `Failed.code`.
- `exit_code()` returns the **first `FAILED` entry's** code — a `BLOCKED` dependent has no
  process of its own, and the failure that blocked it is recorded earlier.
- Falls back to `1` for anything outside a shell's 1–255 range: a code of `0`, or the
  negative signal number `subprocess` reports for a killed child.
- `cli.py`'s `Raises:` now documents the overlap with the usage-error `2`.

New tests: `test_a_failing_task_s_own_exit_status_is_what_the_run_exits_with` (pytest's 2,
a guard's own 1, `-9` → 1, and first-failure-wins) and
`test_run_propagates_the_failing_task_s_own_status` (the code survives to `typer.Exit`).
The `exit_code` doctest was rewritten to show `2` rather than the old flattened `1`.

## #38 — README Development section

Names `uv run rhiza-task all` as the pre-push check, alongside the faster `uv run pytest`
loop, and says why: pytest alone is strictly weaker than the `gates` job that fails the PR.

## Verification

`uv run rhiza-task all` → all gates ok (`fmt` skipped, no `.pre-commit-config.yaml`),
226 tests, 100% coverage floor held, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)