### PR TITLE
Add the mkdocs book, its CI, and a pre-commit config so fmt measures something

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -1,0 +1,125 @@
+# Adapted from jebel-quant/rhiza's rhiza_book.yml rather than delegated to it as a stub,
+# for the reason weekly.yml gives: the reusable workflow runs its gate as
+# `uvx "$RHIZA_TASK" book` with RHIZA_TASK pinned to rhiza-task@0.3.1 -- correct for a
+# consumer, circular here, because this repository's own book would then be built by a
+# published, pre-1.0 copy of itself instead of the working tree. So the two jobs are lifted
+# and the indirection dropped: `uv run rhiza-task book` builds with the CLI under test.
+#
+# Two steps of the upstream job are also dropped rather than carried:
+#
+#   * `configure-git-auth` and `UV_EXTRA_INDEX_URL` -- this package has three public
+#     runtime dependencies and no private index, so the secrets they need do not exist
+#     here. ci.yml uses no secrets either.
+#   * `lfs: true` on checkout -- nothing in this repository is tracked by git-lfs.
+#
+# Workflow: Book
+# Purpose: Build the documentation site -- API reference, test and coverage reports, and
+#          any Marimo notebooks -- and publish it to GitHub Pages.
+#
+# Trigger: Every push, on any branch, so every commit validates that the book still
+#          builds. The deploy job publishes only from the default branch and never from a
+#          fork; other branches build and upload an artifact.
+
+name: "(RHIZA) BOOK"
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds on every commit and publishes nothing. It deliberately declares no environment,
+  # so it stays runnable on every branch even when the github-pages environment restricts
+  # deployments to one branch.
+  build:
+    name: build the book
+    if: ${{ !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The same action SHA and the same uv version as ci.yml, deliberately: a book that
+      # builds on one uv and gates that pass on another is a resolver difference nothing
+      # would catch.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      - name: Cache the MkDocs plugin cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .cache/plugin/
+          key: mkdocs-plugin-${{ runner.os }}-${{ hashFiles('mkdocs.yml', 'docs/mkdocs-base.yml', 'uv.lock', 'pyproject.toml') }}
+          restore-keys: |
+            mkdocs-plugin-${{ runner.os }}-
+
+      # `book` depends on `test`, so this step also produces the `_tests/` tree it folds in
+      # as docs/reports -- the coverage XML the badge step reads, and the HTML report and
+      # coverage pages mkdocs.yml lists under Reports.
+      - name: Build the book
+        timeout-minutes: 20
+        run: |
+          START=$(date +%s)
+          uv run rhiza-task book
+          echo "Docs build: $(($(date +%s) - START))s" >> "$GITHUB_STEP_SUMMARY"
+
+      # Downloadable from the run page, so a reviewer can open the built book for a branch
+      # that will never be published.
+      - name: Upload the book as a workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: book
+          path: _book/
+          retention-days: 30
+
+      - name: Upload the book as a Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _book/
+
+  # Publishes only from the default branch, and never from a fork. The github-pages
+  # environment is referenced here rather than in `build` so that the build stays runnable
+  # on every branch.
+  deploy:
+    name: publish to GitHub Pages
+    needs: build
+    if: ${{ github.ref_name == github.event.repository.default_branch && !github.event.repository.fork }}
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      contents: read
+      pages: write        # deploy to Pages
+      id-token: write     # verify the deployment origin
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        continue-on-error: true

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -1,0 +1,137 @@
+# Adapted from jebel-quant/rhiza's rhiza_paper.yml. Unlike the book workflow this one
+# carries no circularity to remove -- upstream's version never calls rhiza-task at all, it
+# reimplements the recipe in shell. Two things change as a result:
+#
+#   * The compile step calls `uv run rhiza-task paper` instead of inlining `latexmk`, so the
+#     workflow and a local `rhiza-task paper` cannot drift. This repository's dogfood
+#     position is that its own gates run through the CLI under test.
+#   * Upstream's "prefer basanos.tex, else the first *.tex" step is gone with it. That was a
+#     named preference for one downstream repository's paper, living in a template every
+#     consumer synced; tasks/paper.py replaced it with two conventional names -- main.tex,
+#     then paper.tex -- and then alphabetical order. Re-deriving the filename here would
+#     reintroduce exactly the duplication the task removed, so the artifact step globs for
+#     whatever PDF the task produced instead.
+#
+# The `tex_present` guard is kept even though `rhiza-task paper` skips on its own: the task
+# skipping is cheap, but installing TeX Live first is not, and this repository ships no
+# docs/paper. So the guard is about the apt-get, not about the gate.
+#
+# Workflow: Paper
+# Purpose: Compile the LaTeX paper (docs/paper/*.tex) to a PDF, publish it as a workflow
+#          artifact, and keep the latest PDF on the `paper` branch.
+
+name: "(RHIZA) PAPER"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  pull_request:
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-pdf:
+    name: compile the paper
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed to push the compiled PDF to the paper branch
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Detect docs/paper/*.tex
+        id: check_tex
+        run: |
+          if compgen -G "docs/paper/*.tex" > /dev/null 2>&1; then
+            echo "tex_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tex_present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip notice (no docs/paper/*.tex present)
+        if: ${{ steps.check_tex.outputs.tex_present != 'true' }}
+        run: echo "No docs/paper/*.tex found; skipping LaTeX compilation." >> "$GITHUB_STEP_SUMMARY"
+
+      # The same action SHA and uv version as ci.yml, so the CLI runs under the resolver the
+      # gates were tested with.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      - name: Install TeX Live
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-bibtex-extra \
+            latexmk
+
+      # `rhiza-task paper` guards on latexmk being present and on the paper folder
+      # existing, chooses the root document, and runs latexmk with -bibtex so the
+      # references converge. Everything this step used to spell out lives there.
+      - name: Compile the paper
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        run: uv run rhiza-task paper
+
+      - name: Locate the compiled PDF
+        id: pdf
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        run: |
+          pdf_path=$(find docs/paper -maxdepth 1 -name '*.pdf' | head -1)
+          if [ -z "$pdf_path" ]; then
+            echo "::error::rhiza-task paper produced no PDF under docs/paper"
+            exit 1
+          fi
+          echo "pdf_path=${pdf_path}" >> "$GITHUB_OUTPUT"
+          echo "pdf_file=$(basename "$pdf_path")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload the PDF artifact
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.pdf.outputs.pdf_file }}
+          path: ${{ steps.pdf.outputs.pdf_path }}
+          retention-days: 30
+
+      # An orphan `paper` branch holding only the current PDF, so the latest build has a
+      # stable URL that outlives the 30-day artifact retention.
+      - name: Push the PDF to the paper branch
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' && github.event_name == 'push' }}
+        run: |
+          pdf_file="${{ steps.pdf.outputs.pdf_file }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cp "${{ steps.pdf.outputs.pdf_path }}" "/tmp/${pdf_file}"
+          git fetch origin paper 2>/dev/null || true
+          if git show-ref --verify --quiet refs/remotes/origin/paper; then
+            git checkout -b paper origin/paper
+          else
+            git checkout --orphan paper
+            git rm -rf --quiet . || true
+            git reset
+          fi
+          cp "/tmp/${pdf_file}" "${pdf_file}"
+          git add "${pdf_file}"
+          git diff --staged --quiet || git commit -m "Update ${pdf_file} [skip ci]"
+          git push origin paper

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,147 @@
+# Adapted from jebel-quant/rhiza's .pre-commit-config.yaml.
+#
+# Adding this file is a deliberate reversal of the note in ci.yml's `gates` job, which
+# recorded that this repository shipped no pre-commit config on purpose -- `rhiza-task fmt`
+# skipped, and ruff got a dedicated CI job instead. Two consequences follow, and neither is
+# silent:
+#
+#   * `fmt` now runs rather than skipping, so the dogfood `rhiza-task all` in CI covers one
+#     more gate than it did. That is the point.
+#   * ci.yml's `lint` job and this config's ruff hooks now enforce the same ruff.toml. The
+#     job is no longer the only thing running ruff, so it is redundant work -- kept for now
+#     because a red check named `ruff` still says what broke without opening a log, which
+#     is the reason it was split out in the first place.
+#
+# `rhiza-task install` also installs the prek git hooks once this file exists (see
+# tasks/quality.py's install_hooks), so a commit is now gated locally too.
+#
+# Hook revisions are pinned, as everything in this repository is: a formatter that moves
+# under you turns a green pull request red without a commit.
+
+# Pin node so prek provisions a compatible runtime instead of using the system node. Some
+# npm-based hooks (markdownlint-cli) pull transitive deps that reject odd-numbered current
+# node releases (e.g. v25), failing on EBADENGINE.
+default_language_version:
+  node: "24.12.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-toml
+      # `--unsafe` is load-bearing here, not caution: docs/mkdocs-base.yml carries
+      # `!!python/name:material.extensions.emoji.to_svg` tags, which a safe load rejects
+      # outright. Upstream's `exclude: ^recipe/meta\.yaml$` is dropped -- there is no conda
+      # recipe in this repository.
+      - id: check-yaml
+        args: ['--unsafe']
+
+  - repo: local
+    hooks:
+      - id: no-python-cache-files
+        name: Prevent committing Python cache files
+        language: fail
+        # Upstream says "run 'make clean'"; there is no Makefile here, and the task that
+        # replaced that target is the one to name.
+        entry: Python cache files (__pycache__, .pyc, .pyo, .pyd) must not be committed. Run 'rhiza-task clean' to remove them.
+        files: '(/__pycache__/|\.py[cod]$)'
+
+      - id: no-rej-files
+        name: Reject .rej files
+        entry: "bash -c 'find . -type f -name \"*.rej\" | grep -q . && { echo \"ERROR: .rej files detected\"; find . -type f -name \"*.rej\"; exit 1; } || exit 0'"
+        language: system
+        pass_filenames: false
+
+  # v0.16.3, not upstream's v0.16.2: ci.yml's `lint` job pins `ruff@0.16.3`, and a hook that
+  # disagrees with the job means one of the two reports a finding the other does not. The
+  # two pins move together.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.16.3'
+    hooks:
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
+
+      - id: ruff-format
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.49.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013"]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.38.0
+    hooks:
+      # Upstream also runs `check-renovate` and validates `.rhiza/template-bundles.yml`
+      # against its schema. Both are dropped: this repository has no renovate.json and no
+      # `.rhiza/` at all, so each hook would be inert -- and an inert hook prints a
+      # "(no files to check)Skipped" line that reads like a check in the output of the gate
+      # this repository runs most.
+      - id: check-github-workflows
+        args: ["--verbose"]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      # Upstream passes `--ini .bandit`; this repository ships no `.bandit`, and bandit
+      # fails outright on a missing ini rather than falling back. The task itself already
+      # handles that -- tasks/python.py:250 passes `--ini` only when the file exists -- so
+      # the args here mirror what `rhiza-task security` actually runs: `-ll`, medium
+      # severity and above. Without it the hook is a *stricter* standard than the gate and
+      # the two disagree, which is the trap upstream's own interrogate comment describes.
+      - id: bandit
+        args: ["-ll"]
+        files: ^src/.*\.py$
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      # No `.sh` files here yet. Kept rather than dropped because the workflows carry
+      # multi-line `run:` blocks, and the first committed script should meet the same bar
+      # rather than arriving unchecked.
+      - id: shellcheck
+        files: '\.sh$'
+
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.7.4
+    hooks:
+      - id: betterleaks
+
+  # Worth more here than in most repositories: pyproject.toml's own comment records that
+  # v1.0.0 shipped with a stale uv.lock, which fails every gate naming `install` as a
+  # prerequisite -- because `uv lock --check` is the first thing `install` runs. This hook
+  # is what catches that before the tag rather than after.
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.12.3
+    hooks:
+      - id: uv-lock
+
+  # Upstream's interrogate hook is deliberately NOT carried over. It runs
+  # `--config=pyproject.toml`, and this repository has no `[tool.interrogate]` table --
+  # interrogate falls back to its own defaults for a missing table rather than failing, so
+  # the hook would enforce fail-under 80 where `rhiza-task docs-coverage` already enforces
+  # 100.0%. A weaker duplicate of a gate that already passes is exactly the disagreement
+  # upstream's own comment on that hook warns about.
+
+  # Upstream's rhiza-hooks block is also mostly dropped: `update-readme-help` regenerates a
+  # README section from `make help`, `check-makefile-targets` needs a Makefile, and
+  # `check-rhiza-config` and `check-rhiza-workflow-names` read `.rhiza/`. None of those
+  # exists here. The one that is about this repository rather than about the template is
+  # kept.
+  - repo: https://github.com/Jebel-Quant/rhiza-hooks
+    rev: v1.2.0
+    hooks:
+      # Asserts .python-version, [project.requires-python] and the
+      # `Programming Language :: Python :: X.Y` classifiers agree -- three places this
+      # repository states a version, and ci.yml's matrix mirrors the classifiers.
+      - id: check-python-version-consistency

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Docs](https://img.shields.io/badge/docs-jebel--quant.github.io-blue)](https://jebel-quant.github.io/rhiza-task/)
 
-The rhiza developer tasks as a **pinned CLI** rather than a synced make layer.
+The rhiza developer tasks as a **pinned CLI** rather than a synced make layer — **one set
+of task names across Python, Rust and Go**.
 
 ```bash
 uvx rhiza-task@1.0.0 test
 ```
+
+📖 **[Documentation](https://jebel-quant.github.io/rhiza-task/)** — the task catalogue,
+the six configuration layers, and how to add a task of your own.
 
 Sibling to [`pytest-rhiza`](https://github.com/jebel-quant/pytest-rhiza), which did the
 same thing for `.rhiza/tests`.
@@ -233,6 +238,31 @@ repo, which is the problem being deleted.
   the most.
 - **Nested uv cost.** `uvx rhiza-task test` then internally `uv run --with pytest ...`.
   Cached this should be milliseconds; measure before rolling out widely.
+
+## Documentation
+
+The [book](https://jebel-quant.github.io/rhiza-task/) expands this README rather than
+repeating it:
+
+| page | what is there that is not here |
+|---|---|
+| [Getting Started](https://jebel-quant.github.io/rhiza-task/getting_started/) | exit-code semantics, the `Makefile` shim, when `--strict` is the right setting |
+| [Tasks](https://jebel-quant.github.io/rhiza-task/tasks/) | every task in all three layers, what each guards on, and why two sit outside `all` |
+| [Configuration](https://jebel-quant.github.io/rhiza-task/configuration/) | all six layers, and every setting with its default |
+| [Language Layers](https://jebel-quant.github.io/rhiza-task/layers/) | polyglot repos, `rust:test`, and the three contracts every layer must honour |
+| [Adding a Task](https://jebel-quant.github.io/rhiza-task/adding_a_task/) | guards, outcomes, and which of the four provisioning forms to reach for |
+| [Migrating from make](https://jebel-quant.github.io/rhiza-task/migration/) | the three steps, and the fragment-relocation trap that silently drops targets |
+| [FAQ](https://jebel-quant.github.io/rhiza-task/faq/) | the failure modes, and what each one actually means |
+| [API Reference](https://jebel-quant.github.io/rhiza-task/api/) | the modules, generated from the docstrings that carry the reasoning |
+
+It is built by the `book` task itself — `mkdocs.yml` at the root is what turns that task
+from a skip into a build — and published by `.github/workflows/rhiza_book.yml` on every
+push, to Pages from `main` only.
+
+```bash
+uv run rhiza-task book     # build into _book/
+uv run rhiza-task serve    # build, then serve on http://localhost:8000
+```
 
 ## Development
 

--- a/docs/adding_a_task.md
+++ b/docs/adding_a_task.md
@@ -1,0 +1,177 @@
+---
+icon: material/puzzle-plus
+---
+
+# Adding a Task
+
+Register a module under the `rhiza_task.tasks` entry-point group — **the same mechanism the
+built-ins use**, so a project's own task is a first-class citizen rather than an override.
+
+There is one mechanism, not a built-in path and a plugin path. This is the replacement for
+make's `-include local.mk`.
+
+## Declare the entry point
+
+```toml
+# your project's pyproject.toml
+[project.entry-points."rhiza_task.tasks"]
+acme = "acme_tasks.gates"
+```
+
+## Write the task
+
+```python
+from rhiza_task.spec import Guard, task
+from rhiza_task.uv import uvx
+
+
+@task("audit", "run the in-house audit", section="Quality", needs=("install",), guards=(Guard("source_folder"),))
+def audit(cfg):
+    """Audit the source tree."""
+    uvx("my-auditor", cfg.source_folder, cwd=cfg.root)
+```
+
+That is the whole thing. The decorator has already done the registering, so the task is
+reachable by the same `lookup` the runner and the CLI use:
+
+```python
+from rhiza_task.spec import lookup
+
+spec = lookup("audit")
+print(spec.key, "-", spec.help)
+print(spec.needs, spec.guards[0].folder, spec.section)
+```
+
+```result
+audit - run the in-house audit
+('install',) source_folder Quality
+```
+
+!!! tip "That example is executed, in the README"
+    The same pair of blocks lives in the repository's `README.md`, where `rhiza-task
+    rhiza-test` **runs the fence and diffs it against the `result` block**. A change to
+    `lookup`, to `Task`, or to the decorator breaks the README rather than quietly
+    outdating it. This page is a copy for reading; the README is the copy that is checked.
+
+## `@task` parameters
+
+| parameter | what |
+|---|---|
+| `name` | the CLI name — `rhiza-task audit` |
+| `help` | the one-line description, shown by `list` and `--help` |
+| `section` | the `list` grouping (`Python`, `Quality`, `Book`, or your own) |
+| `needs` | prerequisites, run first and deduplicated across one invocation |
+| `guards` | conditions that turn the run into a `skipped` instead of a failure |
+
+## Guards
+
+A guard is the first of the three parts every recipe has. Two forms:
+
+=== "A folder must exist"
+
+    ```python
+    guards = (Guard("source_folder"),)
+    ```
+
+    Names a **setting**, not a path — so it follows the six-layer resolution and a
+    consumer can point it elsewhere.
+
+=== "A binary must be on PATH"
+
+    ```python
+    Guard(tool="latexmk", reason="latexmk not found; install a LaTeX distribution")
+    ```
+
+    The `reason` is what the user sees on the `skipped` line, so make it actionable.
+
+When a guard fails the task reports:
+
+```
+ skipped  audit  source_folder 'src' not found
+```
+
+…and `--strict` turns that into a failure.
+
+## Reaching your tool
+
+Pick the form that matches what the tool needs — the distinction is real and worth getting
+right:
+
+| use | when | example |
+|---|---|---|
+| `uvx("my-auditor", ...)` | an isolated one-shot tool | linters, scanners, formatters |
+| `uv_run("pytest", ..., withs=("pytest-cov",))` | the tool **imports your project's code** | pytest, mypy, interrogate |
+| `tool("cargo", "clippy", ...)` | a toolchain binary already on `PATH` | `cargo`, `go`, `latexmk`, `npx` |
+| `uv("sync", "--frozen", ...)` | uv itself | `venv`, `sync`, `lock --check` |
+
+All four take `cwd=` and echo the command they run, so `$ cargo clippy` is printed the same
+way `$ uvx bandit` is.
+
+```python
+from rhiza_task.uv import tool, uv_run, uvx
+
+
+@task("audit", "run the in-house audit", section="Quality", needs=("install",))
+def audit(cfg):
+    """Audit the source tree against the project's own dependencies."""
+    uv_run("my-auditor", cfg.source_folder, cwd=cfg.root, withs=("my-auditor",))
+```
+
+## Signalling an outcome
+
+Raise, rather than returning a status:
+
+```python
+from rhiza_task.spec import Failed, Skip
+
+
+@task("audit", "run the in-house audit", section="Quality")
+def audit(cfg):
+    """Audit every rule file, if there are any."""
+    rules = sorted((cfg.root / "rules").glob("*.yml"))
+    if not rules:
+        raise Skip("no rule files")
+
+    failures = [r.name for r in rules if not _check(r)]
+    if failures:
+        raise Failed(1, f"{len(failures)} rule(s) failed: {', '.join(failures)}")
+```
+
+| raise | means |
+|---|---|
+| `Skip(reason)` | nothing to measure — yellow, unless `--strict` |
+| `Failed(code, message)` | a real failure, with the exit status to propagate |
+| *nothing* | success |
+
+Pass the tool's **own** exit code to `Failed` where you have one. `run` propagates the
+first failing task's status rather than collapsing everything to 1, and that is what a
+consumer's CI reads.
+
+## A broken module will not take the gates down
+
+`load_tasks()` reports an import failure and moves on:
+
+```
+could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
+```
+
+Your gate stops running, and everyone else's keeps working.
+
+## When *not* to use an entry point
+
+A one-off that is only ever a make target belongs in `local.mk` — but that file is in
+core's `.gitignore`, so it holds **developer-local** targets only.
+
+A repo-owned target that **CI invokes** needs a committed home, and the repository's own
+`Makefile` is the only committed make surface there is:
+
+```makefile
+# Repo-owned. Nothing syncs this file.
+.PHONY: release-notes
+release-notes:
+	uv run python tools/release_notes.py
+```
+
+Use an entry point when the task is a *gate* — something `all` should include, something
+another repository might want, something that deserves a guard and a skip. Use the
+`Makefile` when it is a local convenience.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,113 @@
+---
+icon: material/code-tags
+---
+
+# API Reference
+
+The modules behind the CLI. Most users never import any of this — but
+[adding a task](adding_a_task.md) uses `spec` and `uv`, and the module docstrings are where
+the reasoning for each design decision lives.
+
+| module | reach for it when |
+|---|---|
+| [`spec`](#spec) | writing a task: `@task`, `Guard`, `Skip`, `Failed` |
+| [`uv`](#uv) | writing a task body: the four ways to reach a tool |
+| [`config`](#config) | reading a resolved setting, or adding one |
+| [`runner`](#runner) | understanding prerequisite order and outcomes |
+| [`cli`](#cli) | understanding how the registry becomes commands |
+
+---
+
+## spec
+
+The task model: the registry, the decorator, guards, outcomes, and layer resolution.
+
+::: rhiza_task.spec
+
+---
+
+## uv
+
+The ways rhiza reaches a tool, and nothing else.
+
+::: rhiza_task.uv
+
+---
+
+## config
+
+Configuration, and the resolution order that replaces make's `?=` and `+=`.
+
+::: rhiza_task.config
+
+---
+
+## runner
+
+Prerequisite resolution, guard evaluation and outcome bookkeeping.
+
+::: rhiza_task.runner
+
+---
+
+## cli
+
+The command line, generated from the registry rather than hand-maintained.
+
+::: rhiza_task.cli
+
+---
+
+## Task modules
+
+The gates themselves, each loaded through the `rhiza_task.tasks` entry-point group. Every
+module docstring names the make fragment it replaces, and records any behaviour that
+changed on purpose.
+
+### Python
+
+::: rhiza_task.tasks.python
+
+### Rust
+
+::: rhiza_task.tasks.rust
+
+### Go
+
+::: rhiza_task.tasks.go
+
+### Quality
+
+::: rhiza_task.tasks.quality
+
+### Testing extras
+
+::: rhiza_task.tasks.extras
+
+### Book and notebooks
+
+::: rhiza_task.tasks.book
+
+### Dev
+
+::: rhiza_task.tasks.doctor
+
+### GitHub helpers
+
+::: rhiza_task.tasks.github
+
+### Docker
+
+::: rhiza_task.tasks.docker
+
+### Git LFS
+
+::: rhiza_task.tasks.lfs
+
+### Paper
+
+::: rhiza_task.tasks.paper
+
+### Presentation
+
+::: rhiza_task.tasks.presentation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,8 @@
+---
+icon: material/history
+---
+
+<!-- Pulls in the root CHANGELOG.md rather than keeping a second copy under docs/.
+     `pymdownx.snippets` is configured with base_path ["."] in docs/mkdocs-base.yml,
+     which is what makes the repository root reachable from here. -->
+--8<-- "CHANGELOG.md"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,231 @@
+---
+icon: material/tune
+---
+
+# Configuration
+
+The make layer built its settings from three overlapping mechanisms: `?=` defaults in the
+fragment that owned a setting, `+=` accumulation from other fragments, and a repo-owned
+`Makefile` or `local.mk` assigning over the top. The precedence was a *consequence of
+include order* — which is why `rhiza.mk` had to explain that `-include .rhiza/make.d/*.mk`
+comes last and `-include local.mk` last of all.
+
+Here the order is explicit and testable.
+
+## Six layers
+
+Lowest precedence first — each layer overrides the ones above it:
+
+```mermaid
+flowchart TD
+    D["1 · dataclass defaults"] --> E["2 · .rhiza/.env<br/><small>developer-local</small>"]
+    E --> T["3 · rhiza.toml<br/><small>language-neutral, committed</small>"]
+    T --> M["4 · [tool.rhiza-task]<br/><small>Cargo.toml, then pyproject.toml</small>"]
+    M --> V["5 · RHIZA_* env vars"]
+    V --> F["6 · command-line flags"]
+```
+
+| # | layer | notes |
+|---|---|---|
+| 1 | dataclass defaults | the table [below](#settings) |
+| 2 | `.rhiza/.env` | kept unchanged, because it is already the file consumers edit and the reusable workflows read it too |
+| 3 | `rhiza.toml` | the language-neutral file — the only committed settings surface a Go module can have |
+| 4 | `[tool.rhiza-task]` in the manifest | `Cargo.toml`, then `pyproject.toml` |
+| 5 | `RHIZA_*`, or bare make-style variables | `RHIZA_COVERAGE_FAIL_UNDER=95` or `COVERAGE_FAIL_UNDER=95` |
+| 6 | command-line flags | `--strict`, `--root` |
+
+!!! note "`.rhiza/.env` is now developer-local"
+    rhiza no longer ships `.rhiza/.gitignore`, whose entire content was the `!.env`
+    negation that kept the file tracked. It therefore falls under the shipped
+    `.gitignore`'s `.env` rule, and **a CI checkout never contains it**. Anything CI needs
+    belongs in layer 3 or 4.
+
+### Why two files, not one
+
+Neither layer 3 nor layer 4 alone covers the three language layers: `pyproject.toml` is
+Python-only, and a repository that already moved its settings there should not have to
+move them again.
+
+`rhiza.toml` ranks *below* the manifest deliberately, so that adding it to a Python
+repository cannot silently outrank the table already there.
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.rhiza-task]
+    source_folder = "src"
+    typechecker = "ty"
+    coverage_fail_under = 95
+    license_ignore_packages = ["docutils"]
+    ```
+
+=== "rhiza.toml"
+
+    ```toml
+    # A Go module or a Rust crate, or any repo that would rather not thread
+    # settings through a manifest.
+    source_folder = "cmd"
+    coverage_fail_under = 95
+    ```
+
+=== "Cargo.toml"
+
+    ```toml
+    # Cargo ignores unknown top-level tables, so this is as harmless here as
+    # it is in pyproject.
+    [tool.rhiza-task]
+    source_folder = "src"
+    coverage_fail_under = 95
+    ```
+
+In `rhiza.toml`, settings sit at the top level; a `[tool.rhiza-task]` table is honoured too
+and wins when both are present.
+
+## Reading a resolved value
+
+`print` replaces make's `print-%` pattern rule, and collapses all six layers to the one
+value a task will actually see:
+
+```bash
+uvx rhiza-task@1.0.0 print coverage_fail_under
+uvx rhiza-task@1.0.0 print COVERAGE_FAIL_UNDER   # either spelling
+```
+
+Field names are the lowercased make variables, so the mapping to what a consumer already
+knows stays one-to-one and greppable. `print` exits 2 when the setting does not exist.
+
+## An empty value is unset
+
+In the two string-valued layers, an empty value **leaves the layer below it alone** rather
+than resolving to `""`:
+
+```bash
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.0.0 ci-os-matrix   # still the default
+```
+
+That is make's `$(or ...)` rule, and the reusable workflows depend on it: `rhiza_ci.yml`
+exports one for every caller and deliberately leaves it empty for consumers, whose own
+`.rhiza/.env` is meant to answer.
+
+## Settings
+
+### Layout and versions
+
+| setting | default | what |
+|---|---|---|
+| `source_folder` | `src` | the package tree the gates measure |
+| `tests_folder` | `tests` | the test tree |
+| `marimo_folder` | `docs/notebooks` | Marimo notebooks, exported into the book |
+| `book_output` | `_book` | where `book` writes the built site |
+| `python_version` | `3.13` | the interpreter tasks provision |
+
+### Gates and thresholds
+
+| setting | default | what |
+|---|---|---|
+| `coverage_fail_under` | `90` | the coverage floor, enforced wherever `test` runs |
+| `typechecker` | `ty` | `ty`, `mypy` or `both` |
+| `license_fail_on` | `("GPL", "LGPL", "AGPL")` | matched as **substrings** |
+| `license_ignore_packages` | `()` | packages exempt from the copyleft scan |
+| `deptry_ignore` | `()` | deptry rule codes to suppress |
+
+!!! warning "`typechecker = "both"` masks `ty`"
+    `python.mk` documented it and the behaviour is unchanged: `both` hides `ty`'s exit
+    status behind mypy's. A typo like `typechecker = "tpye"` now fails *before* any tool
+    is provisioned, rather than after — the shell `case` that used to validate this is a
+    `__post_init__` check.
+
+### Rust and Go
+
+| setting | default | what |
+|---|---|---|
+| `cargo_flags` | `()` | extra flags for every cargo invocation |
+| `go_flags` | `()` | extra flags for every go invocation |
+| `go_test_flags` | `("-race", "-shuffle=on")` | the Go idiom for a CI run — `-shuffle=on` catches tests that depend on declaration order |
+
+### Book, paper and slides
+
+| setting | default | what |
+|---|---|---|
+| `mkdocs_extra_packages` | `("mkdocstrings[python]",)` | provisioned into the zensical build |
+| `zensical_version` | `>=0.0.36` | the book builder |
+| `paper_folder` | `docs/paper` | the LaTeX root |
+| `presentation_file` | `PRESENTATION.md` | the Marp source |
+| `marp_package` | `@marp-team/marp-cli` | unpinned, as `npm install -g` was; set `@marp-team/marp-cli@4.2.3` to pin |
+
+!!! info "Why `mkdocs_extra_packages` defaults to something"
+    rhiza's `book` bundle ships `docs/mkdocs-base.yml` with `mkdocstrings` enabled
+    unconditionally, and every consumer inherits it via `INHERIT`. With this empty, `book`
+    invoked `uvx zensical build` with no `--with`, and zensical refused:
+
+    ```
+    Error: mkdocstrings plugin is enabled, but mkdocstrings is not installed.
+    ```
+
+    So the bundle shipped a config that could not build with its own default. A repository
+    that wants no plugins sets `mkdocs-extra-packages = []` in its manifest — TOML only,
+    deliberately.
+
+### Docker
+
+| setting | default | what |
+|---|---|---|
+| `docker_folder` | `docker` | the build context |
+| `docker_image` | *(empty)* | resolved in the task body when unset |
+
+`docker.mk`'s `DOCKER_FOLDER` was a `:=` rather than a `?=` — not configurable at all.
+Both are ordinary settings now, because there is no longer a cost to making one.
+`docker_image` is empty rather than a computed default because `?= $(shell basename
+$(CURDIR))` cannot be spelled as a dataclass default, and keeping it empty keeps
+`rhiza-task print docker_image` honest about the setting being unset.
+
+### Environment and CI
+
+| setting | default | what |
+|---|---|---|
+| `uv_sync_args` | `("--all-extras", "--all-groups")` | what `install` passes to `uv sync` |
+| `ci_os_matrix` | `("ubuntu-latest",)` | feeds `ci-os-matrix` |
+| `pytest_rhiza` | pinned to a tag | the `rhiza-test` provider — a gate that moves under you is not a gate |
+
+### Detected, not configured
+
+| setting | default | what |
+|---|---|---|
+| `layers` | *(detected)* | from the manifests present |
+| `rhiza_checks` | *(derived)* | follows from `layers` |
+| `strict` | `false` | turns `Skip` into failure |
+| `root` | *(cwd)* | the repository to operate on |
+
+Both `layers` and `rhiza_checks` are empty by default and filled in afterwards, because
+both depend on the repository rather than on a constant. **Setting either explicitly
+switches detection off for that field** — which is exactly what a repository carrying two
+manifests but wanting one gate set needs:
+
+```toml
+[tool.rhiza-task]
+layers = ["rust"]
+```
+
+```bash
+RHIZA_LAYERS=rust uvx rhiza-task@1.0.0 test
+```
+
+## No `+=` successor, and none needed
+
+The three accumulators — `DEPTRY_FOLDERS`, `LICENSE_IGNORE_PACKAGES`, `RHIZA_CHECKS` —
+have no replacement mechanism. Each was a bundle contributing something it owned, which a
+task body now *derives* by asking whether the contributing task is registered. See `deps`
+and `license` in `tasks/python.py`.
+
+## This repository's own settings
+
+`rhiza-task` configures itself with the mechanism it sells — layer 4:
+
+```toml
+[tool.rhiza-task]
+coverage_fail_under = 95
+```
+
+The floor is raised from the shipped default of 90 because 90 is the *tool's* answer for a
+repository it knows nothing about. This one can do better, so 95 is a floor that is met
+with headroom and still says something.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,138 @@
+---
+icon: material/drawing-box
+---
+
+# Design
+
+## The observation the package rests on
+
+Reading all ten make fragments back to back, **every recipe has the same three parts**:
+
+1. a **guard** on a folder (or a binary) existing,
+2. a **provision** via `uv run --with` or `uvx`,
+3. a long, mostly **static argument list**.
+
+So the model is declarative. A task is data — a name, a section, prerequisites, guards —
+plus a short body that assembles an argument vector.
+
+## The four that genuinely are not declarative
+
+The escape hatch exists because exactly four recipes resisted the form, and it is worth
+naming them so the exception stays bounded:
+
+| task | why |
+|---|---|
+| `test` | retry once on pytest exit **3** — the xdist teardown race — and never on 1, 2 or 4 |
+| `mutation` | run, render HTML, move the output, report the **first** status |
+| `doctor` | semantic version comparison, formerly an `awk` function inside a make recipe |
+| `book` | aggregate gates, copy reports, export notebooks, build, badge |
+
+## Modules
+
+| module | what |
+|---|---|
+| `spec.py` | `Task`, `Guard`, `Skip`/`Failed`, the `@task` registry, layer resolution |
+| `config.py` | six-layer resolution, replacing `?=` and `+=` |
+| `uv.py` | the three ways rhiza reaches a tool |
+| `runner.py` | prerequisite dedup, guards, outcome bookkeeping |
+| `cli.py` | Typer app, generated from the registry |
+| `tasks/*.py` | the gates themselves, loaded by entry point |
+
+```mermaid
+flowchart TD
+    EP["entry points<br/><small>rhiza_task.tasks</small>"] -->|import registers| REG[("REGISTRY<br/>spec.py")]
+    CFG["config.py<br/><small>six layers</small>"] --> RUN
+    REG --> CLI["cli.py<br/><small>Typer, generated</small>"]
+    REG --> RUN["runner.py<br/><small>dedup · guards · outcomes</small>"]
+    CLI --> RUN
+    RUN --> UV["uv.py"]
+    UV --> A["uv · uvx · uv run --with · tool"]
+```
+
+## How a tool gets reached
+
+Every recipe in the retired Python make layer used one of exactly three forms, and that
+distinction is preserved rather than unified, because the make layer already got it right:
+
+| form | when | examples |
+|---|---|---|
+| `uv <subcommand>` | uv itself | `venv`, `sync`, `lock --check` |
+| `uvx <tool>` | an isolated one-shot tool run | prek, deptry, bandit, semgrep, zensical, genbadge |
+| `uv run --with a --with b <tool>` | a tool run **against the project environment**, because it imports the project's own code | pytest, interrogate, mutmut, `ty`, mypy |
+
+Rust and Go add a fourth, and only a fourth: a toolchain binary already on `PATH`, because
+uv provisions neither `cargo` nor `go` and nothing here pretends otherwise. It shares the
+module's environment handling and echoing rather than being a bare `subprocess.call` in
+each language module — so `$ cargo clippy` is printed the same way `$ uvx bandit` is.
+
+!!! note "No shell, anywhere"
+    Commands are argument vectors, never shell strings. `rhiza.mk` carried a 40-line probe
+    to detect make falling back to `cmd.exe` on Windows, because its recipes were POSIX
+    shell. With no shell there is nothing to detect — and CI keeps `windows-latest` in the
+    matrix precisely to assert that the dependency is really gone.
+
+## Three things fall out for free
+
+### Double-colon rules disappear
+
+`book` depends on gates the `tests` bundle may never have contributed. In make that
+required four no-op stubs (`test:: ; @:`) so the dependency could exist at all. Here the
+runner skips unregistered prerequisites, so the question is just `"test" in REGISTRY`.
+
+### Skip is a first-class outcome
+
+Not a soft failure, not a pass — a third status. Which means `--strict` can promote every
+skip to a failure, and a consumer's CI can assert that a gate actually measured something.
+
+### Help stops being a parser
+
+`rhiza.mk` built its help by running `awk` over `$(MAKEFILE_LIST)` looking for `##` and
+`##@` comments — a parser for a documentation convention that existed only because make
+has no notion of a task description.
+
+Typer has one. Help text, sections, per-task help and the "unknown task" error all come
+from the same registry the runner uses, so **the two cannot drift**.
+
+## The bare-name shorthand is a contract
+
+`rhiza-task test` rewrites to `rhiza-task run test`. That is not sugar: the reusable
+workflows and a repo-owned forwarding `Makefile` both invoke `rhiza-task test`, and a
+consumer's muscle memory is `make test`. Requiring the extra word would put a word between
+the two for no gain.
+
+A consequence worth knowing: `rhiza-task --help` lists only the five real subcommands, and
+`list` is how you enumerate tasks.
+
+## Exit status is propagated, not collapsed
+
+`run` exits with the **first failing task's own status** — pytest's 2 or 4, `cargo`'s 101 —
+falling back to 1 when the tool has none. A usage error is also 2, so a usage error and a
+task that exited 2 share a status; the printed run summary distinguishes them.
+
+The alternative is discarding the code, which is the one thing every consumer's CI
+actually wants.
+
+## A plugin cannot take the gates down
+
+`load_tasks()` imports every module in the `rhiza_task.tasks` entry-point group, and a
+failure is **reported and skipped** rather than fatal:
+
+```
+could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
+```
+
+A broken third-party task module should not stop `test` from running.
+
+## How it is tested
+
+**No test in the suite runs uv.** Every task test patches the entry points in `uv.py` and
+asserts on the *argument vector that would have been executed*.
+
+That is exactly what the make recipes expressed in `$$`-escaped shell and could not
+assert — and it is why the suite is fast enough to be the inner loop.
+
+## Further reading
+
+- [Adding a Task](adding_a_task.md) — the entry-point mechanism, from the outside
+- [Configuration](configuration.md) — the six layers in detail
+- [API Reference](api.md) — the modules above, with signatures

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,201 @@
+---
+icon: material/help-circle
+---
+
+# FAQ & Troubleshooting
+
+## Usage
+
+### Why is my task not in `rhiza-task --help`?
+
+It is not supposed to be. `rhiza-task <task>` is rewritten to `rhiza-task run <task>`, so
+`--help` lists only the five real subcommands — `list`, `print`, `run`, `ci-os-matrix` and
+`version`.
+
+Use `rhiza-task list` to enumerate tasks, and `rhiza-task list --all` to include the
+language layers this repository does not have.
+
+### Do I have to pin the version?
+
+You should. An unpinned task layer can change under a green pull request without a commit
+touching your repository — which is the failure mode the whole package exists to remove.
+`rhiza-task@1.0.0` makes a bump a deliberate commit that carries whatever fixes it wants.
+
+### A gate says `skipped`. Is that bad?
+
+Not by itself. A task whose subject is absent skips: `fmt` with no
+`.pre-commit-config.yaml`, `marimo-validate` with no notebooks, `paper` with no LaTeX
+folder. The reason is printed next to it.
+
+It *is* bad when the subject was supposed to be there. That is what `--strict` is for:
+
+```bash
+uvx rhiza-task@1.0.0 all --strict
+```
+
+In a consumer repository `--strict` is usually the right setting, because a skip means a
+gate lost its subject and nobody noticed.
+
+### Why does this repository not use `--strict` on itself?
+
+Because several of its gates skip on purpose — `fmt` has no `.pre-commit-config.yaml` and
+`semgrep` has no `.rhiza/semgrep.yml`, both for the same "not rhiza-managed" reason.
+Asserting `--strict` here would only assert that the repository is something it is not.
+
+### `unknown task` — but `list` shows it
+
+Two likely causes:
+
+1. **It belongs to a layer you do not have.** `list --all` shows every layer's tasks; a
+   name only that layer defines needs the explicit key, `rhiza-task rust:test`.
+2. **Its module failed to import.** A plugin import error is reported and skipped rather
+   than fatal, so look for this line earlier in the output:
+
+   ```
+   could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
+   ```
+
+### How do I run the gates for another repository?
+
+```bash
+uvx rhiza-task@1.0.0 all --root ../other-repo
+```
+
+## Configuration
+
+### My setting is being ignored
+
+Check what actually resolved, rather than what you wrote:
+
+```bash
+uvx rhiza-task@1.0.0 print coverage_fail_under
+```
+
+The usual causes, in order of likelihood:
+
+| cause | fix |
+|---|---|
+| set in `rhiza.toml`, but the manifest table also sets it | the manifest wins — layer 4 outranks layer 3 |
+| set in `.rhiza/.env`, and you are looking at CI | that file is gitignored now; a CI checkout never has it |
+| set as an empty string | an empty value is *unset*, and leaves the layer below alone |
+| wrong spelling | both `source_folder` and `SOURCE_FOLDER` work; anything else does not |
+
+### Why did `.rhiza/.env` stop working in CI?
+
+rhiza no longer ships `.rhiza/.gitignore`, whose entire content was the `!.env` negation
+that kept the file tracked. It now falls under the shipped `.gitignore`'s `.env` rule, so
+it is developer-local and **a CI checkout never contains it**.
+
+Move anything CI depends on into `rhiza.toml` or `[tool.rhiza-task]`.
+
+### Why is an empty value not empty?
+
+```bash
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.0.0 ci-os-matrix   # still ["ubuntu-latest"]
+```
+
+That is make's `$(or ...)` rule, kept because the reusable workflows depend on it:
+`rhiza_ci.yml` exports one for every caller and deliberately leaves it empty for consumers,
+whose own settings are meant to answer.
+
+### My repo has two manifests and picks the wrong gates
+
+Detection returns *both* layers, Python first. Pin it:
+
+```toml
+[tool.rhiza-task]
+layers = ["rust"]
+```
+
+Setting `layers` switches detection off for that field. The other layer stays reachable as
+`rhiza-task python:test`.
+
+### `typechecker = "both"` hides errors
+
+Known, documented, and unchanged from `python.mk`: `both` masks `ty`'s exit status behind
+mypy's. Set `typechecker = "ty"` if you want `ty`'s status to matter.
+
+A typo — `typechecker = "tpye"` — now fails *before* any tool is provisioned rather than
+after, so a misconfiguration is immediate instead of a five-minute CI wait.
+
+## Gates
+
+### `test` failed, then passed on retry
+
+By design, and only for one specific case: exit code **3**, the xdist teardown race. Exit
+1, 2 and 4 are never retried, because that would be re-running a real failure and hoping.
+
+### `book` did nothing
+
+It skips without a `mkdocs.yml` at the repository root. That file's presence is what turns
+`book` from a skip into a build.
+
+If it built but the reports are missing, run the gates that produce them first — `_tests/`
+is written by `test`, and `book` copies it into `docs/reports/`.
+
+### `zensical: mkdocstrings plugin is enabled, but mkdocstrings is not installed`
+
+The `mkdocs_extra_packages` setting is what provisions plugins into the isolated zensical
+run, and its default is exactly `("mkdocstrings[python]",)` for this reason. If you
+overrode it, add back what your `mkdocs.yml` enables:
+
+```toml
+[tool.rhiza-task]
+mkdocs-extra-packages = ["mkdocstrings[python]", "mkdocs-jupyter"]
+```
+
+A repository that wants no plugins at all sets `mkdocs-extra-packages = []`.
+
+### `deptry` reports a dependency as both unused and missing
+
+The package's import name differs from its distribution name, and deptry runs isolated via
+`uvx` so it cannot import the package to discover the mapping. Declare it:
+
+```toml
+[tool.deptry.package_module_name_map]
+python-dotenv = "dotenv"
+```
+
+### `interrogate` or `bandit` disagrees with CI
+
+Run the gate, not the tool. Thresholds, exclusions and arguments live in the task and in
+the repository's config; a bare `uvx interrogate` measures something else and will report
+failures CI does not have.
+
+## Design
+
+### Why not a Taskfile, `just`, or `nox`?
+
+go-task is a genuinely better make, and its remote includes would attack the same root
+problem — but that feature is experimental and env-var-gated, and it would be the single
+load-bearing dependency of the whole multi-repo task layer, whereas `uvx pkg@version` is
+boring and already used ~15 times per repository. The four procedural recipes would also
+stay embedded shell in YAML.
+
+`just` and `poe` do not apply: a Justfile or a noxfile still has to be copied into every
+repository, which is the problem being deleted.
+
+### Why is there no `install-uv` task?
+
+It cannot exist. A process launched by `uvx rhiza-task` runs *because* uv exists, so
+nothing in this package can be the thing that provisions uv — it would already be too late.
+A runner shipping no uv adds an `astral-sh/setup-uv` step instead.
+
+### Does a Rust crate really need Python now?
+
+Yes, and it is the package's least comfortable trade. `rust.mk` and `go.mk` needed only
+make; the Rust and Go layers here are Python calling `cargo` and `go`. It buys the version
+pin and deletes ~1200 synced lines per consumer, and it costs a Python runtime in a
+repository that may have had no other reason for one.
+
+### Is Windows supported?
+
+Yes, and it is in the CI matrix specifically to prove it. Commands are argument vectors,
+never shell strings, so the 40-line probe `rhiza.mk` needed to detect make falling back to
+`cmd.exe` has nothing left to detect.
+
+### How expensive is the nested uv call?
+
+`uvx rhiza-task test` internally runs `uv run --with pytest ...`. Cached, this should be
+milliseconds — but it is an open question rather than a measured claim, and worth measuring
+before a wide rollout.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,187 @@
+---
+icon: material/rocket-launch
+---
+
+# Getting Started
+
+## Nothing to install
+
+`uvx` provisions the CLI per invocation, so there is no install step and no entry in your
+project's dependencies:
+
+```bash
+uvx rhiza-task@1.0.0 list          # what is available
+uvx rhiza-task@1.0.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.0.0 test --strict # fail rather than skip when a gate measures nothing
+```
+
+!!! tip "Pin the version"
+    `rhiza-task@1.0.0` rather than `rhiza-task`. The pin is the whole point of the
+    package — an unpinned task layer is a layer that can change under a green pull
+    request without a commit touching your repository. Bumping it is then a deliberate
+    commit that carries whatever the new version wants.
+
+The only prerequisite is [uv](https://github.com/astral-sh/uv). A CI runner that ships no
+uv adds an `astral-sh/setup-uv` step; there is deliberately no `install-uv` task, because
+it would have to provision the runtime that every task already runs under.
+
+## The first run
+
+Start by asking what this repository has:
+
+```bash
+uvx rhiza-task@1.0.0 list
+```
+
+```
+ task                section         needs                 does
+ all                 Python          fmt deps test         run every gate, as
+                                     docs-coverage         CI does
+                                     security license
+                                     typecheck rhiza-test
+ coverage            Python          install               measure coverage and
+                                                           write
+                                                           _tests/coverage.xml
+ deps                Python          install               run deptry over the
+                                                           contributed folders
+ …
+```
+
+The listing is generated from the same registry the runner uses, so help and behaviour
+cannot drift. By default it shows **this** repository's language layers plus the
+language-neutral tasks — a Go module is not helped by being shown `mutation` and
+`marimo-validate`. Add `--all` for the question the make layer could not answer: what the
+other layers call things.
+
+Then run the aggregate:
+
+```bash
+uvx rhiza-task@1.0.0 all
+```
+
+## `run`, and the bare shorthand
+
+`rhiza-task <task>` is shorthand for `rhiza-task run <task>`:
+
+```bash
+uvx rhiza-task@1.0.0 test          # shorthand
+uvx rhiza-task@1.0.0 run test      # the same thing
+uvx rhiza-task@1.0.0 run fmt test  # several, in order, prerequisites deduplicated
+```
+
+This is a compatibility contract rather than sugar. The reusable workflows and a
+repo-owned forwarding `Makefile` both invoke `rhiza-task test`, and a consumer's muscle
+memory is `make test`; requiring the extra word would gain nothing.
+
+Because of that rewrite, `rhiza-task --help` lists only the five real subcommands —
+`list`, `print`, `run`, `ci-os-matrix` and `version`. The tasks themselves are arguments to
+`run`, and `list` is how you enumerate them.
+
+| flag | on | what |
+|---|---|---|
+| `--strict` | `run` | treat a skipped gate as a failure |
+| `--root <path>` | `run` | operate on another repository |
+| `--all` | `list` | include the other languages' layers |
+
+## Skip, and why `--strict` exists
+
+A task whose subject is absent **skips** rather than fails. `fmt` with no
+`.pre-commit-config.yaml`, `marimo-validate` with no notebooks, `paper` with no LaTeX
+folder — each reports `skipped` and a reason:
+
+```
+ skipped  fmt  no .pre-commit-config.yaml
+```
+
+Skip being a first-class outcome is what lets one aggregate serve repositories that have
+different bundles installed. But a skip is also how a gate silently stops measuring
+anything — so `--strict` turns every skip into a failure:
+
+```bash
+uvx rhiza-task@1.0.0 all --strict
+```
+
+!!! note "Which one belongs in your CI"
+    `--strict` is the right setting in a **consumer** repository, where a skip means a
+    gate lost its subject and nobody noticed. This repository runs its own dogfood job
+    *without* it, because several of its gates skip on purpose — asserting otherwise
+    would only assert that it is something it is not.
+
+## Exit codes
+
+`run` propagates the **first failing task's own exit status** rather than collapsing
+everything to 1 — pytest's 2 or 4, `cargo`'s 101 — falling back to 1 when the tool has
+none. A usage error is 2.
+
+| status | meaning |
+|---|---|
+| `0` | everything passed (or skipped, without `--strict`) |
+| `2` | usage error — unknown task, invalid configuration — *or* a task that itself exited 2 |
+| *other* | the first failing task's own code |
+
+A usage error and a task that exited 2 therefore share a status. The run summary printed
+above the exit distinguishes them, and the alternative — discarding the code — is the one
+thing every consumer's CI actually wants.
+
+## The pre-push loop
+
+For this repository, and for any project that adopts the same layout:
+
+```bash
+uv sync --all-groups
+uv run pytest              # the fast inner loop
+uv run rhiza-task all      # run before pushing: every gate, as CI runs them
+```
+
+`uv run pytest` alone is strictly weaker than the check that will fail a pull request:
+`all` adds deptry, the coverage floor, interrogate, bandit, the copyleft scan, the
+typechecker and `rhiza-test` on top of the suite. A green pytest is not yet a green PR.
+
+## Keeping `make test` working
+
+Task names are unchanged from the retired make layer, so a repository that wants
+`make test` to keep working owns that `Makefile` itself and forwards each target — one
+rule:
+
+```makefile
+# Repo-owned. Nothing syncs this file, and nothing overwrites it.
+RHIZA_TASK := rhiza-task@1.0.0
+
+.PHONY: test fmt typecheck all
+test fmt typecheck all:
+	uvx $(RHIZA_TASK) $@
+```
+
+That `Makefile` is now yours: a repo-owned target CI invokes has a committed home, and no
+sync will shadow it.
+
+## In CI
+
+The gates run as one step, and `ci-os-matrix` feeds a GitHub Actions matrix input from the
+same configuration the tasks read:
+
+```yaml
+- uses: astral-sh/setup-uv@v10
+  with:
+    version: "0.11.16"
+    enable-cache: true
+
+- name: Gates
+  run: uvx rhiza-task@1.0.0 all --strict
+```
+
+```bash
+uvx rhiza-task@1.0.0 ci-os-matrix
+```
+
+```
+["ubuntu-latest"]
+```
+
+Set `ci_os_matrix` to widen it — see [Configuration](configuration.md).
+
+## Next
+
+- [Tasks](tasks.md) — the full catalogue, and what each one guards on
+- [Configuration](configuration.md) — the six layers, and every setting
+- [Language Layers](layers.md) — polyglot repositories, and `rhiza-task rust:test`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,142 @@
+---
+icon: material/console-line
+hide:
+  - toc
+---
+
+# rhiza-task
+
+**The rhiza developer tasks, as a pinned CLI** — not a synced make layer.
+
+[![PyPI](https://img.shields.io/pypi/v/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
+[![Python](https://img.shields.io/pypi/pyversions/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
+[![CI](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml/badge.svg)](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Jebel-Quant/rhiza-task/blob/main/LICENSE)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
+---
+
+**Quick links:** [📦 PyPI](https://pypi.org/project/rhiza-task/) • [📚 Repository](https://github.com/jebel-quant/rhiza-task) • [🐛 Issues](https://github.com/jebel-quant/rhiza-task/issues) • [🌱 rhiza](https://github.com/jebel-quant/rhiza) • [🧪 pytest-rhiza](https://github.com/jebel-quant/pytest-rhiza)
+
+---
+
+## 📋 Overview
+
+```bash
+uvx rhiza-task@1.0.0 test
+```
+
+There is nothing to install and nothing to sync. One command runs a project's gates, and
+which gates those are is decided by the manifest in the repository — `pyproject.toml`,
+`Cargo.toml` or `go.mod`.
+
+`rhiza-task` is the sibling of [`pytest-rhiza`](https://github.com/jebel-quant/pytest-rhiza),
+which did the same thing for `.rhiza/tests`.
+
+## 🎯 The problem it deletes
+
+The pain was never make's syntax — it was **distribution by copying**, which make
+structurally cannot fix, because `include` cannot reach a remote file. Every consumer got a
+full copy of the task layer at a template tag, and everything downstream was damage
+control.
+
+Version pinning becomes a *dependency* pin, which is a real mechanism instead of "copy
+files at tag v1.3.3 and hope nobody edited them."
+
+| before, per consumer repo | after |
+|---|---|
+| `.rhiza/rhiza.mk` — 200 lines, synced | *gone* |
+| `.rhiza/make.d/*.mk` — 1023 lines in 15 files, synced | *gone* |
+| `exclude:` entries in `template.yml`, because a deletion alone is undone by the next sync | not needed |
+| targets shadowed in the repo `Makefile` | `[tool.rhiza-task]` |
+| ~40 lines of GNU-make guard and Windows POSIX-shell probe | gone — no make, no shell |
+| `install-uv` — 30 lines of `bootstrap.mk` shell | gone — `uvx` provisions the runtime |
+| `Makefile` | repo-owned, if a repo wants one |
+
+## 🚀 Three commands
+
+<div class="grid cards" markdown>
+
+-   :material-format-list-bulleted:{ .lg .middle } **See what is available**
+
+    ---
+
+    Tasks, grouped by section, with prerequisites and a one-line description.
+
+    ```bash
+    uvx rhiza-task@1.0.0 list
+    ```
+
+    [→ The task catalogue](tasks.md)
+
+-   :material-check-all:{ .lg .middle } **Run every gate**
+
+    ---
+
+    The aggregate CI runs: format, deps, test, docs, security, licence, types.
+
+    ```bash
+    uvx rhiza-task@1.0.0 all
+    ```
+
+    [→ Getting started](getting_started.md)
+
+-   :material-tune:{ .lg .middle } **Read a resolved setting**
+
+    ---
+
+    Six configuration layers, collapsed to the one value a task will actually see.
+
+    ```bash
+    uvx rhiza-task@1.0.0 print coverage_fail_under
+    ```
+
+    [→ Configuration](configuration.md)
+
+</div>
+
+## 🧩 One set of names, three languages
+
+`test` is pytest in a Python project, `cargo nextest` in a crate and `go test` in a
+module. That gate-parity contract is what lets a reusable workflow call `typecheck`
+without knowing the language.
+
+```mermaid
+flowchart LR
+    M{which manifest?}
+    M -- "pyproject.toml" --> P[python layer]
+    M -- "Cargo.toml" --> R[rust layer]
+    M -- "go.mod" --> G[go layer]
+    P --> T["test · typecheck · coverage<br/>security · deps · license"]
+    R --> T
+    G --> T
+```
+
+The make layer answered "which one?" at *sync* time, by copying exactly one of
+`python.mk`, `rust.mk` and `go.mk` into a repository. A pinned CLI carries all three, so
+the answer is the manifest that is present — and the layers you do *not* have stay
+addressable as `rhiza-task rust:test`.
+
+[→ How the layers resolve](layers.md)
+
+## 📐 Why it is small
+
+Reading all ten make fragments back to back, **every recipe has the same three parts**: a
+guard on a folder existing, a provision via `uv run --with` or `uvx`, and a long, mostly
+static argument list. So the model is declarative, with an escape hatch for the four
+recipes that genuinely are not.
+
+[→ The design](design.md) · [→ Adding your own task](adding_a_task.md)
+
+## 📖 Where to go next
+
+| If you want to… | Read |
+|---|---|
+| run this against your project for the first time | [Getting Started](getting_started.md) |
+| know what every task does, and when it skips | [Tasks](tasks.md) |
+| change a threshold, a folder or a typechecker | [Configuration](configuration.md) |
+| understand polyglot repositories and `rust:test` | [Language Layers](layers.md) |
+| add a project-specific gate | [Adding a Task](adding_a_task.md) |
+| retire a synced make layer | [Migrating from make](migration.md) |
+| know why it is not a Taskfile | [FAQ](faq.md) |

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -1,0 +1,137 @@
+---
+icon: material/layers-triple
+---
+
+# Language Layers
+
+`test` is pytest in a Python project, `cargo nextest` in a crate and `go test` in a
+module. That is the **gate-parity contract**, and it is what lets a reusable workflow call
+`typecheck` without knowing the language.
+
+## How the answer is chosen
+
+The make layer answered "which language?" at **sync** time, by copying exactly one of
+`python.mk`, `rust.mk` and `go.mk` into a repository. A pinned CLI carries all three, so
+the answer has to come from the repository itself — and it does, from the **manifest
+present**:
+
+| manifest | layer |
+|---|---|
+| `pyproject.toml` | `python` |
+| `Cargo.toml` | `rust` |
+| `go.mod` | `go` |
+
+```mermaid
+flowchart TD
+    S{"layers set<br/>explicitly?"}
+    S -- yes --> U["use it verbatim<br/><small>detection off for that field</small>"]
+    S -- no --> D["scan for manifests"]
+    D --> L["layers, in order:<br/>python · rust · go"]
+    L --> R["lookup(name, layers)"]
+    U --> R
+```
+
+A repository with two manifests gets **both** layers, in that order. Python comes first
+because it is the layer a polyglot repository is most likely to have grown *into*: a crate
+or a module that acquires a `pyproject.toml` has acquired a Python package, and the gates
+that package needs are the ones that would otherwise stop running.
+
+## Shadowing, and reaching the layer that lost
+
+A layered task shadows a neutral one of the same name, and the layers are tried in order —
+so a crate with a Python binding package gets a single answer rather than an ambiguity:
+
+```python
+from rhiza_task.spec import lookup
+from rhiza_task.tasks import python, rust  # importing is what registers
+
+lookup("test", ["python", "rust"]).key  # 'python:test'
+lookup("test", ["rust", "python"]).key  # 'rust:test'
+```
+
+`layer:name` addresses one layer explicitly, and is the **only** way to reach the layer
+that did not win:
+
+```bash
+uvx rhiza-task@1.0.0 rust:test
+```
+
+Pinning the layer list does the same thing globally:
+
+```toml
+[tool.rhiza-task]
+layers = ["rust"]
+```
+
+Setting `layers` explicitly switches detection off for that field — which is exactly what
+a repository carrying two manifests but wanting one gate set needs.
+
+## Seeing the other layers
+
+`list` shows this repository's layers plus the language-neutral tasks — a Go module is not
+helped by being shown `mutation` and `marimo-validate`, and that is also what the make
+layer showed, having synced exactly one fragment.
+
+`--all` answers the question the make layer could not:
+
+```bash
+uvx rhiza-task@1.0.0 list --all   # what the layers you do not have call things
+```
+
+## A missing name is `None`, not an error
+
+A neutral task answers to its bare name whatever the layers are, and **a name no active
+layer has resolves to nothing rather than raising**. That is what lets `book` depend on
+gates a repository may not have:
+
+```python
+needs = ("test", "benchmark", "stress", "hypothesis-test")
+```
+
+In make this required `book.mk` to declare four no-op double-colon stubs —
+`test:: ; @:` and friends — so that the dependency could exist at all. The runner skips
+unregistered prerequisites, so all four are gone.
+
+## What every layer must deliver
+
+Three contracts hold across all three layers, and they are the reason a
+language-independent workflow works at all.
+
+### `coverage` writes `_tests/coverage.xml`
+
+At that exact path, in every layer, because it is what `book`'s badge step reads and what
+CI uploads:
+
+| layer | how |
+|---|---|
+| Python | pytest's `--cov` report flags |
+| Rust | `cargo llvm-cov --cobertura` |
+| Go | a coverage profile piped through `gocover-cobertura`, plus the floor check `go test` has no flag for |
+
+### `rhiza_checks` derives from the layers
+
+Not configured — derived. The neutral checks, plus:
+
+| layer | adds |
+|---|---|
+| python | `test_pyproject`, `test_docstrings` |
+| rust | `test_cargo_toml` |
+| go | `test_go_module` |
+
+Setting `rhiza_checks` explicitly switches that derivation off, exactly as with `layers`.
+
+### `install-uv` is not a task, and cannot be one
+
+It would have to provision the runtime that every task already runs under. A CI runner
+that ships no uv adds an `astral-sh/setup-uv` step instead — a workflow can simply say so,
+where `bootstrap.mk` needed 30 lines of shell to curl the installer into `./bin` because
+make could not assume uv existed.
+
+## The cost, stated plainly
+
+`rust.mk` and `go.mk` needed only make. The Rust and Go layers here are **Python calling
+`cargo` and `go`**, so a crate now needs uv to run its gates.
+
+That is the trade the whole package makes, and the Rust and Go layers are where it costs
+the most. It buys the pin, and the deletion of 1200 synced lines per consumer; it costs a
+Python runtime in a repository that may have had no other reason for one.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,163 @@
+---
+icon: material/swap-horizontal
+---
+
+# Migrating from the make layer
+
+## What is being deleted
+
+| before, per consumer repo | after |
+|---|---|
+| `.rhiza/rhiza.mk` — 200 lines, synced | *gone* |
+| `.rhiza/make.d/*.mk` — 1023 lines in 15 files, synced | *gone* |
+| `exclude:` entries in `template.yml`, because a deletion alone is undone by the next sync | not needed |
+| targets shadowed in the repo `Makefile` | `[tool.rhiza-task]` |
+| ~40 lines of GNU-make guard and Windows POSIX-shell probe | gone — no make, no shell |
+| `install-uv` — 30 lines of `bootstrap.mk` shell | gone — `uvx` provisions the runtime |
+| `Makefile` | repo-owned, if a repo wants one |
+
+Task names are **unchanged**, which is what makes this a mechanical migration rather than a
+rewrite.
+
+## The three steps
+
+### 1. Replace the synced layer with direct calls
+
+Either invoke the CLI directly in CI and locally:
+
+```bash
+uvx rhiza-task@1.0.0 all --strict
+```
+
+…or keep `make test` working with a repo-owned `Makefile` that forwards — one rule:
+
+```makefile
+# Repo-owned. Nothing syncs this file, and nothing overwrites it.
+RHIZA_TASK := rhiza-task@1.0.0
+
+.PHONY: test fmt typecheck all
+test fmt typecheck all:
+	uvx $(RHIZA_TASK) $@
+```
+
+### 2. Exclude the make layer in `template.yml`
+
+Exactly as `.rhiza/tests` already is:
+
+```yaml
+exclude:
+  - .rhiza/make.d
+  - .rhiza/rhiza.mk
+```
+
+A deletion alone is undone by the next sync, which is why the exclusion — not the
+`rm` — is the step that matters.
+
+### 3. Relocate your own fragments **first**
+
+!!! danger "This is the step that bites"
+    Deleting `rhiza.mk` removes the `-include .rhiza/make.d/*.mk` that was reaching your
+    own fragments, so **repo-owned fragments stop being loaded without anything saying
+    so**. No error, no warning — the targets simply are not there any more.
+
+Do this before step 1. Each repo-owned fragment goes to one of two places:
+
+| the fragment holds… | it belongs in… |
+|---|---|
+| developer-local convenience targets | `local.mk` (gitignored) |
+| anything CI invokes | the repository's own `Makefile` (committed) |
+
+## Moving your settings
+
+Whatever you used to set by editing a synced `.mk` file or shadowing a target now goes in
+one table:
+
+=== "before"
+
+    ```makefile
+    # in the repo Makefile, shadowing the synced target
+    COVERAGE_FAIL_UNDER := 95
+    SOURCE_FOLDER := src
+    TYPECHECKER := ty
+    LICENSE_IGNORE_PACKAGES += docutils
+    ```
+
+=== "after"
+
+    ```toml
+    [tool.rhiza-task]
+    coverage_fail_under = 95
+    source_folder = "src"
+    typechecker = "ty"
+    license_ignore_packages = ["docutils"]
+    ```
+
+Field names are the lowercased make variables, so the mapping stays one-to-one and
+greppable. A Go module — which has no manifest to hide a table in — uses `rhiza.toml`
+instead. See [Configuration](configuration.md).
+
+!!! warning "`.rhiza/.env` is now developer-local"
+    rhiza no longer ships the `.rhiza/.gitignore` whose entire content was the `!.env`
+    negation keeping that file tracked. It now falls under the shipped `.gitignore`'s
+    `.env` rule, so **a CI checkout never contains it**. Anything CI depends on must move
+    to `rhiza.toml` or the manifest table.
+
+## The `+=` accumulators
+
+`DEPTRY_FOLDERS`, `LICENSE_IGNORE_PACKAGES` and `RHIZA_CHECKS` have **no successor, and
+need none**. Each was a bundle contributing something it owned, which a task body now
+*derives* by asking whether the contributing task is registered.
+
+If you accumulated onto one of these from your own fragment, the equivalent is either the
+plain list setting (`license_ignore_packages`) or [your own task](adding_a_task.md).
+
+## Two behaviour changes to know about
+
+Both are deliberate, and both are recorded in their module docstring — the convention for
+any change that is not a straight port:
+
+| task | change |
+|---|---|
+| `lfs-install` | configures the repository and **reports** how to install the binary, rather than downloading one |
+| `presentation` | reaches Marp through `npx --yes` |
+
+And one that is not a change so much as a name losing its special status: `paper.mk`
+preferred a file called `basanos.tex` — one downstream repository's paper, named in a
+template every consumer synced. It is now `main.tex`, then `paper.tex`, then alphabetical
+order.
+
+## After the migration
+
+Add `--strict` in CI once the migration is quiet:
+
+```bash
+uvx rhiza-task@1.0.0 all --strict
+```
+
+A skip in a consumer repository means a gate lost its subject, and `--strict` is what turns
+that from a yellow line nobody reads into a red build. Check the run summary first — some
+skips will be correct for your repository, and those are the ones to fix by adding the
+missing config, not by dropping the flag.
+
+## Why not a Taskfile (or `just`)
+
+Considered and rejected.
+
+**go-task** is a genuinely better make, and its **remote includes** would even attack the
+same root problem. But that feature is experimental and env-var-gated, and it would become
+the single load-bearing dependency of the whole multi-repo task layer — whereas
+`uvx pkg@version` is boring and already used around fifteen times per repository. The four
+procedural recipes would also stay embedded shell inside YAML, improving the syntax
+*around* the mess without removing it, and keeping the Windows problem.
+
+**`just` and `poe`** do not apply: a Justfile or a noxfile still has to be copied into
+every repository, which is the problem being deleted.
+
+## Open questions
+
+- **Python as a prerequisite for a Rust repo.** `rust.mk` and `go.mk` needed only make;
+  the Rust and Go layers here are Python calling `cargo` and `go`, so a crate now needs uv
+  to run its gates. That is the trade the whole package makes, and the layer where it costs
+  the most.
+- **Nested uv cost.** `uvx rhiza-task test` then internally `uv run --with pytest ...`.
+  Cached this should be milliseconds; measure before rolling out widely.

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -1,0 +1,97 @@
+# Theme, markdown extensions and plugins, split out of mkdocs.yml so that the top-level
+# file holds only what identifies *this* project -- the same split rhiza's `book` bundle
+# ships as docs/mkdocs-base.yml and every consumer picks up via `INHERIT`.
+#
+# Lifted rather than inherited, for the reason weekly.yml gives for lifting its jobs: this
+# repository is not rhiza-managed, so there is no sync to deliver the file, and a book that
+# depends on one would not build from a fresh checkout.
+
+docs_dir: docs
+site_dir: _book
+
+# This file lives inside docs_dir, so the build copies it into the site as an asset. That
+# is cosmetic and deliberately left alone: `exclude_docs` is the mkdocs answer and zensical
+# does not implement it (verified against 0.0.36 -- the excluded page is still written), so
+# adding it would be config that reads as working and is not. Every rhiza book publishes
+# this file for the same reason.
+
+# ----------------------------------------------------------------------------
+# Theme
+# ----------------------------------------------------------------------------
+theme:
+  name: material
+  language: en
+  features:
+    - announce.dismiss
+    - content.code.annotate
+    - content.code.copy
+    - content.code.select
+    - content.footnote.tooltips
+    - content.tabs.link
+    - content.tooltips
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.path
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+
+# ----------------------------------------------------------------------------
+# Markdown extensions
+# ----------------------------------------------------------------------------
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+      combine_header_slug: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+  # base_path is the repository root, which is what lets docs/changelog.md pull in the
+  # root CHANGELOG.md rather than keeping a second copy under docs/.
+  - pymdownx.snippets:
+      base_path: ["."]
+
+# ----------------------------------------------------------------------------
+# Plugins
+# ----------------------------------------------------------------------------
+plugins:
+  - search

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,231 @@
+---
+icon: material/format-list-bulleted
+---
+
+# Tasks
+
+Every task is `rhiza-task <name>`. The catalogue below is the registry the CLI generates
+its own help from — `rhiza-task list` is the authoritative version for *your* repository,
+and `rhiza-task list --all` adds the layers you do not have.
+
+## The shape every task shares
+
+Reading all ten make fragments back to back, every recipe turned out to have the same
+three parts:
+
+```mermaid
+flowchart LR
+    G["guard<br/><small>does the subject exist?</small>"] -->|absent| S([skipped])
+    G -->|present| P["provision<br/><small>uv run --with / uvx</small>"]
+    P --> A["argument vector<br/><small>long, mostly static</small>"]
+    A --> R([ok / failed])
+```
+
+That is why a **guard** and a **skip** appear all over this page: they are the model, not
+special cases.
+
+## Python
+
+| task | needs | does |
+|---|---|---|
+| `install` | — | create the venv and sync dependencies |
+| `test` | `install` | run all tests |
+| `coverage` | `install` | measure coverage and write `_tests/coverage.xml` |
+| `typecheck` | `install` | run `ty` and/or `mypy` (`typechecker = ty \| mypy \| both`) |
+| `security` | `install` | run the bandit security scan |
+| `deps` | `install` | run deptry over the contributed folders |
+| `license` | `install` | scan for copyleft licences |
+| `docs-coverage` | `install` | check docstring coverage with interrogate |
+| `all` | `fmt deps test docs-coverage security license typecheck rhiza-test` | run every gate, as CI does |
+
+`test` and `coverage` share one argument builder, so the two cannot drift: both write
+`_tests/coverage.xml`, `_tests/coverage.json`, `_tests/html-coverage/` and
+`_tests/html-report/report.html`. That fixed path is a contract — it is what `book`'s
+badge step reads and what CI uploads.
+
+!!! info "`test` retries once, on exit 3 only"
+    Exit 3 is the xdist teardown race. A retry on 1, 2 or 4 would be re-running a real
+    failure and hoping, so it never happens.
+
+## Rust
+
+| task | needs | does |
+|---|---|---|
+| `install` | — | install the toolchain and fetch dependencies |
+| `cargo-tools` | — | install the cargo subcommands the gates need |
+| `test` | `install cargo-tools` | run the test suite with nextest, then the doctests |
+| `coverage` | `install cargo-tools` | measure coverage and write `_tests/coverage.xml` |
+| `typecheck` | `install` | lint with clippy, warnings as errors |
+| `security` | `install cargo-tools` | scan dependencies for known advisories |
+| `deps` | `install cargo-tools` | report unused dependencies |
+| `license` | `install cargo-tools` | run the licence compliance scan |
+| `docs-coverage` | `install` | fail on any undocumented public item |
+| `all` | `fmt test docs-coverage security deps license typecheck rhiza-test` | run every gate, as CI does |
+
+## Go
+
+| task | needs | does |
+|---|---|---|
+| `install` | — | install the toolchain and download dependencies |
+| `go-tools` | — | install the Go tools the gates need |
+| `test` | `install` | run the test suite |
+| `coverage` | `install go-tools` | measure coverage and write `_tests/coverage.xml` |
+| `typecheck` | `install go-tools` | vet and lint (the compiler already type-checks) |
+| `security` | `install go-tools` | scan dependencies for known vulnerabilities |
+| `deps` | `install` | report dependency drift |
+| `license` | `install go-tools` | run the licence compliance scan |
+| `docs-coverage` | `install go-tools` | fail on any undocumented exported item |
+| `all` | `fmt test docs-coverage security deps license typecheck rhiza-test` | run every gate, as CI does |
+
+Go has no coverage-floor flag, so `coverage` pipes a profile through `gocover-cobertura`
+and checks the floor itself.
+
+## Quality
+
+| task | needs | does |
+|---|---|---|
+| `fmt` | — | run the pre-commit hooks over all files |
+| `semgrep` | — | run the semgrep static analysis rules |
+| `rhiza-test` | `install` | run the rhiza repository checks |
+| `test-pyproject` | `install` | run the `pyproject.toml` structure checks, verbosely |
+| `todos` | — | list every TODO, FIXME and HACK comment |
+
+`fmt` skips without a `.pre-commit-config.yaml`, and `semgrep` without a
+`.rhiza/semgrep.yml`. Neither is a defect — see [Skip is an outcome](#skip-is-an-outcome).
+
+`rhiza-test` runs the checks that used to live in a synced `.rhiza/tests/` folder, now
+provisioned as [`pytest-rhiza`](https://github.com/jebel-quant/pytest-rhiza). Which checks
+run is derived from the language layer, not configured: the neutral ones, plus
+`test_pyproject` and `test_docstrings` for Python, `test_cargo_toml` for Rust,
+`test_go_module` for Go.
+
+## Testing extras
+
+| task | needs | does |
+|---|---|---|
+| `benchmark` | `install` | run the performance benchmarks |
+| `hypothesis-test` | `install` | run the property-based tests |
+| `stress` | `install` | run the stress and load tests |
+| `mutation` | `install` | run mutation testing with mutmut |
+
+`mutation` is one of the four genuinely procedural recipes: it runs, renders HTML, moves
+the output and reports the **first** status rather than the last.
+
+## Book
+
+| task | needs | does |
+|---|---|---|
+| `book` | `test benchmark stress hypothesis-test` | build the companion book |
+| `serve` | `book` | build the book and serve it on port 8000 |
+| `marimo` | `install` | start the Marimo editor |
+| `marimo-validate` | `install` | check that every Marimo notebook runs |
+
+`book` aggregates the report-producing gates, copies `_tests/` into `docs/reports/`,
+exports every Marimo notebook to `docs/notebooks/*.html`, builds the site with
+[zensical](https://github.com/squidfunk/zensical), and generates a coverage badge. It
+skips entirely without a `mkdocs.yml`.
+
+Its prerequisite list is also where make's no-op stubs came from: `book.mk` had to declare
+`test:: ; @:`, `benchmark:: ; @:`, `stress:: ; @:` and `hypothesis-test:: ; @:` so that
+`book` could depend on gates the `tests` bundle may never have contributed. The runner
+skips unregistered prerequisites, so all four stubs are gone.
+
+`serve` uses Python's own HTTP server rather than an editor's built-in one, because the
+JetBrains server refuses to serve gitignored directories and `_book` is one.
+
+## Dev
+
+| task | needs | does |
+|---|---|---|
+| `doctor` | — | check local prerequisites |
+| `clean` | — | remove build artifacts and stale local branches |
+
+`doctor` is the third procedural escape — it compares semantic versions, which used to be
+an `awk` function inside a make recipe.
+
+## Bundle-owned sections
+
+The last five sections are the bundle-owned fragments. **None is a gate**: no `all` names
+them and no workflow invokes them. Each is guarded on the CLI it wraps and skips when that
+tool is absent, with `--strict` for a caller who wants the hard failure instead.
+
+### GitHub Helpers
+
+| task | does |
+|---|---|
+| `view-prs` | list open pull requests |
+| `view-issues` | list open issues |
+| `failed-workflows` | list recent failing workflow runs |
+| `workflow-status` | show recent runs for the release workflow |
+| `latest-release` | show information about the latest GitHub release |
+| `whoami` | check github auth status |
+
+### Docker
+
+| task | needs | does |
+|---|---|---|
+| `docker-build` | — | build the Docker image |
+| `docker-run` | `docker-build` | run the Docker container |
+| `docker-clean` | — | remove the Docker image |
+
+### Git LFS
+
+| task | does |
+|---|---|
+| `lfs-install` | configure git-lfs for this repository |
+| `lfs-pull` | download the LFS files for the current branch |
+| `lfs-track` | list the patterns tracked by git-lfs |
+| `lfs-status` | show the status of LFS files |
+
+!!! warning "`lfs-install` changed behaviour on purpose"
+    It configures the repository and *reports* how to install the binary, rather than
+    downloading one. The module docstring says so, which is the convention for every
+    deliberate behaviour change.
+
+### Paper
+
+| task | does |
+|---|---|
+| `paper` | compile the LaTeX paper to PDF |
+| `paper-clean` | remove the latexmk build artifacts |
+
+`paper.mk` preferred a file called `basanos.tex` — one downstream repository's paper, named
+in a template every consumer synced. That is now two conventional names, `main.tex` and
+`paper.tex`, then alphabetical order.
+
+### Presentation
+
+| task | does |
+|---|---|
+| `presentation` | generate the HTML slides with Marp |
+| `presentation-pdf` | generate the PDF slides with Marp |
+| `presentation-serve` | serve the slides with Marp's live preview |
+
+`presentation` reaches Marp through `npx --yes` — also a deliberate change, also recorded
+in the module docstring.
+
+## Skip is an outcome
+
+`skipped` is not a soft failure and not a pass. It is the third status, and it is what
+makes one aggregate work across repositories with different bundles installed:
+
+```
+      ok  install
+      ok  typecheck
+ skipped  fmt  no .pre-commit-config.yaml
+```
+
+Because it is first-class, `--strict` can promote every skip to a failure — which is how a
+consumer's CI asserts that a gate actually measured something rather than quietly finding
+nothing to do.
+
+## `all` is not everything
+
+`all` is the aggregate CI runs, and two registered tasks sit outside it on purpose, so a
+reader can tell "skipped deliberately" from "forgotten":
+
+- **`semgrep`** — no `all` names it. Upstream rhiza runs it on a weekly cadence, not per
+  pull request.
+- **the bundle-owned sections** — none is a gate, as above.
+
+Anything else registered *is* in `all` for its layer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,66 @@
+# Theme, markdown extensions and plugins live in docs/mkdocs-base.yml; this file holds
+# only what identifies this project. `rhiza-task book` is what builds it, via
+# `uvx zensical build -f mkdocs.yml` -- so the presence of this file is also what turns
+# that task from a skip into a build.
+INHERIT: docs/mkdocs-base.yml
+
+site_name: rhiza-task
+# Quoted: the value contains ": ", which YAML would otherwise read as a nested mapping.
+site_description: "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer."
+site_author: Jebel Quant Research
+site_url: https://jebel-quant.github.io/rhiza-task/
+repo_url: https://github.com/jebel-quant/rhiza-task
+repo_name: jebel-quant/rhiza-task
+copyright: Copyright &copy; 2026 Jebel Quant Research
+
+nav:
+  - Home: index.md
+  - Getting Started: getting_started.md
+  - Tasks: tasks.md
+  - Configuration: configuration.md
+  - Language Layers: layers.md
+  - Guides:
+      - Adding a Task: adding_a_task.md
+      - Migrating from make: migration.md
+      - FAQ & Troubleshooting: faq.md
+  - Reference:
+      - Design: design.md
+      - API Reference: api.md
+      - Changelog: changelog.md
+  # Written by `rhiza-task book`, which copies `_tests/` here after the gates produce it.
+  # Both paths are gitignored, so these entries resolve in a built book and not in a bare
+  # checkout -- the same trade every rhiza consumer's book makes.
+  - Reports:
+      - Test Report: reports/html-report/report.html
+      - Coverage Report: reports/html-coverage/index.html
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jebel-quant/rhiza-task
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/rhiza-task/
+
+theme:
+  icon:
+    logo: material/console-line
+
+plugins:
+  # `paths: [src]` rather than relying on an installed copy: the book builds under
+  # `uvx zensical`, which has no project environment, so the handler has to be pointed at
+  # the tree. mkdocstrings itself is provisioned by the `mkdocs_extra_packages` setting,
+  # whose default is exactly `mkdocstrings[python]` for this reason.
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            separate_signature: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+            docstring_section_style: table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
 version = "1.0.0"
-description = "The rhiza developer tasks, as a pinned CLI instead of a synced make layer"
+description = "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Jebel Quant Research" }]


### PR DESCRIPTION
`book` has always been able to build a documentation site — it skips without a `mkdocs.yml`, and there was none. So the one repository that *ships* the task was the one repository where it was unreachable. This adds the config and the pages, the CI to publish them, and a pre-commit config that stops `fmt` skipping too.

## What is here

| commit | what |
|---|---|
| `feat(book)` | `mkdocs.yml` + 11 pages + `docs/mkdocs-base.yml` |
| `ci` | `rhiza_book.yml` and `rhiza_paper.yml`, lifted from rhiza |
| `build` | `.pre-commit-config.yaml`, adapted from rhiza |
| `docs` | docs badge, a Documentation section, and a wider package description |

## The book

Structured as rhiza's `book` bundle does it: `docs/mkdocs-base.yml` holds theme, markdown extensions and plugins; `mkdocs.yml` `INHERIT`s it and carries only what identifies this project. The base file is **lifted rather than inherited**, for the reason `weekly.yml` gives for lifting its jobs — this repository is not rhiza-managed, so nothing syncs it, and a book depending on a sync would not build from a fresh checkout.

The pages expand the README rather than restating it — exit-code semantics, every setting with its default, the three cross-layer contracts, and an API reference generated from the docstrings that already carry the reasoning.

## Two workflows, both de-circularised where needed

`rhiza_book.yml` upstream runs `uvx "$RHIZA_TASK" book` with `RHIZA_TASK` pinned to `rhiza-task@0.3.1` — correct in a consumer, wrong here: this repository's own book would be built by a published, pre-1.0 copy of itself instead of the working tree. It runs `uv run rhiza-task book`.

`rhiza_paper.yml` had no circularity, because upstream never calls the CLI at all — it reimplements the recipe in shell. The compile step now calls `uv run rhiza-task paper`, which also retires upstream's "prefer `basanos.tex`" step: `tasks/paper.py` already replaced that with `main.tex` → `paper.tex` → alphabetical, and re-deriving the filename in YAML would reintroduce the duplication the task removed.

## The pre-commit config reverses a documented decision

`ci.yml`'s `gates` job records that this repository shipped no pre-commit config *on purpose*. That note is now out of date, and deliberately so:

```
$ uv run rhiza-task all --strict
      ok  fmt  install  deps  test  docs-coverage
      ok  security  license  typecheck  rhiza-test  all
```

Nine gates, **no skips**, and `--strict` passes — which it could not before, because the `fmt` skip would have failed it. `actionlint` and `check-github-workflows` also now cover the workflows, which nothing was checking.

Each deviation from rhiza's config is forced by something this repo lacks, and commented in the file: ruff repinned to `v0.16.3` to match `ci.yml`'s job, bandit's `--ini .bandit` dropped for `-ll` (no `.bandit` here, and bandit fails on a missing ini), and `check-renovate`, the template-bundles schema check, the `interrogate` hook and four of five `rhiza-hooks` dropped as inert or as weaker duplicates of gates that already pass.

## Verified

- `rhiza-task all --strict` — green, no skips
- `rhiza-task book` — zensical reports `No issues found`; the API page renders with every symbol resolved and no unresolved `:::` markers
- 238 tests pass, coverage 96.57% against the 95 floor
- `prek run --all-files` — all 15 hooks pass, nothing rewritten

## Three things for the reviewer to decide

1. **`ci.yml`'s `ruff` job is now redundant work** — it and the hooks enforce the same `ruff.toml`. Left alone on purpose: a red check named `ruff` still localises a failure without opening a log, which is why it was split out. Removing it is a judgement call, not a cleanup.
2. **`ci.yml:64`'s comment is now stale** — it argues *against* adding a pre-commit config. Not edited here, because the right rewrite depends on (1).
3. **The Pages homepage only resolves once this merges** and Pages is enabled with "GitHub Actions" as the source. The repository About already points at `https://jebel-quant.github.io/rhiza-task/`.

## Not addressed

`id: ruff` is a deprecated alias — prek prints `ruff (legacy alias)`; the current id is `ruff-check`. Copied as upstream has it rather than diverging quietly; worth a one-line fix in both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
