### PR TITLE
Bring test coverage to 100% and raise the floor to match

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,13 +110,20 @@ python-dotenv = "dotenv"
 # This repository's own settings, read by `rhiza-task` as layer 4 of its own resolution
 # order -- the package configuring itself with the mechanism it sells.
 #
-# The floor is raised from the shipped default of 90 because 90 is the *tool's* answer for
-# a repo it knows nothing about, and this repo can do better: the suite covers 96.5% of
-# 1070 statements, so 95 is a floor that is met with headroom and still says something. It
-# is enforced wherever `test` runs -- the `gates` job's `rhiza-task all` in CI, and every
-# local invocation -- which is what makes it a gate rather than a note.
+# The floor is 100, not the shipped default of 90 and no longer the 95 it passed through:
+# the suite now covers all 1080 statements in `src/`, and a floor below what the suite
+# already achieves is a ratchet that never catches anything. At 100 a new branch arrives
+# with the test that exercises it or the gate goes red. It is enforced wherever `test`
+# runs -- the `gates` job's `rhiza-task all` in CI, and every local invocation -- which is
+# what makes it a gate rather than a note.
+#
+# What 100 does *not* claim is that every line is meaningfully asserted -- only that none
+# is unvisited. Four lines stay excluded by `# pragma: no cover`, each carrying its reason:
+# the TYPE_CHECKING guard in spec.py, the `__main__` delegation, and two defensive `except`
+# branches (go.py's malformed total line, quality.py's unreadable file). The first two are
+# structural; the last two are testable and would be the change that retires the pragmas.
 [tool.rhiza-task]
-coverage_fail_under = 95
+coverage_fail_under = 100
 
 # The suite is organised by *behaviour*, not as a 1:1 mirror of `src/`: `test_tasks.py`,
 # `test_bundle_tasks.py`, `test_dev_tasks.py` and `test_language_layers.py` cover the
@@ -126,10 +133,11 @@ coverage_fail_under = 95
 # missing mirrors and 9 orphans, and reports disorder where there is a decision.
 #
 # `enforce = false` requires a non-empty `reason` precisely so the opt-out cannot be a
-# silent one. What the reason deliberately does *not* claim is per-module coverage: only a
-# 100% floor would guarantee that, and this repo's is 95 (see above), so the honest
-# statement is that tests are located by behaviour and covered globally. Raising the floor
-# to 100 is the change that would make a stronger claim available.
+# silent one. The reason used to stop short of claiming per-module coverage, because only a
+# 100 floor would guarantee it and this repo's was 95. The floor is 100 now (see above), so
+# the stronger claim is available and the reason makes it: there is no module a missing
+# test file could leave unexercised, because an unexercised module would put the total
+# below the floor.
 #
 # The reason says "95" and not "95%" on purpose: radon reads *every* `[tool.*]` table
 # through configparser, which treats `%` as interpolation syntax and dies on any value
@@ -137,4 +145,4 @@ coverage_fail_under = 95
 # complexity notes in spec.py, runner.py and config.py are there to answer.
 [tool.check_test_layout]
 enforce = false
-reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Coverage is enforced globally by the coverage_fail_under floor of 95 in [tool.rhiza-task], which the suite meets with headroom."
+reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Per-module coverage is guaranteed instead by the coverage_fail_under floor of 100 in [tool.rhiza-task]: at that floor no module a missing test file would have covered can go unexercised."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,3 +415,50 @@ def test_run_propagates_the_failing_tasks_exit_code(repo: Path, monkeypatch: pyt
     monkeypatch.chdir(repo)
     result = runner.invoke(cli.app, ["run", "t-cli-exits-5"])
     assert result.exit_code == 5
+
+
+def test_version_prints_the_package_version(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``version`` is what a consumer's CI echoes to record which pin it ran.
+
+    Args:
+        repo: The throwaway repository.
+        monkeypatch: pytest's patcher.
+    """
+    from rhiza_task import __version__
+
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli.app, ["version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_list_survives_a_config_it_cannot_resolve(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``list`` is what you run *because* something is wrong, so it must still print.
+
+    A config error resolving the layers falls back to showing every layer -- a superset,
+    where the alternative is showing nothing at the moment the user most needs the list.
+
+    Args:
+        repo: The throwaway repository.
+        monkeypatch: pytest's patcher.
+    """
+    (repo / ".rhiza").mkdir()
+    (repo / ".rhiza" / ".env").write_text("TYPECHECKER=tpye\n")
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli.app, ["list"])
+    assert result.exit_code == 0
+    # Every layer, not just Python's: the fallback is deliberately a superset.
+    for expected in ("cargo-tools", "go-tools", "test"):
+        assert expected in result.stdout
+
+
+def test_the_module_entry_point_exposes_main() -> None:
+    """``python -m rhiza_task`` works in a checkout with no console script installed.
+
+    Importing the module is enough to assert the wiring: ``__name__`` is
+    ``rhiza_task.__main__`` rather than ``__main__``, so the guard does not fire and no
+    CLI runs.
+    """
+    from rhiza_task import __main__ as entry
+
+    assert entry.main is cli.main

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -463,3 +463,35 @@ def test_an_empty_env_value_leaves_the_default_alone(tmp_path: Path, monkeypatch
     """
     monkeypatch.setenv("RHIZA_MKDOCS_EXTRA_PACKAGES", "")
     assert Config.load(root=tmp_path).mkdocs_extra_packages != ()
+
+
+def test_a_list_valued_override_is_tupled(tmp_path: Path) -> None:
+    """A caller passing a list gets a tuple, as the TOML readers already produce.
+
+    The string case is make's -- ``LICENSE_FAIL_ON=GPL LGPL`` is one space-separated
+    variable -- and is covered above. This is the other shape a ``tuple[str, ...]`` field
+    can arrive as: a Python list, from a programmatic caller or a ``--root`` override,
+    which must normalise the same way so that no task has to accept both.
+
+    Args:
+        tmp_path: pytest's temporary directory.
+    """
+    cfg = Config(root=tmp_path, license_fail_on=["GPL", "AGPL"], deptry_ignore=["DEP002"])
+    assert cfg.license_fail_on == ("GPL", "AGPL")
+    assert cfg.deptry_ignore == ("DEP002",)
+
+
+def test_a_settings_table_that_is_not_a_table_is_ignored(tmp_path: Path) -> None:
+    """``rhiza-task = "..."`` is a typo, not a settings table, and must not crash the load.
+
+    The readers select ``tool.rhiza-task`` out of the parsed document, and nothing
+    guarantees what they find is a table. Falling back to no settings keeps a misplaced
+    key from taking every gate down with it.
+
+    Args:
+        tmp_path: pytest's temporary directory.
+    """
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n\n[tool]\nrhiza-task = "oops"\n')
+    cfg = Config.load(root=tmp_path)
+    assert cfg.coverage_fail_under == 90
+    assert cfg.source_folder == "src"

--- a/tests/test_language_layers.py
+++ b/tests/test_language_layers.py
@@ -321,6 +321,77 @@ class TestRustGates:
             "cargo-machete",
         ]
 
+    def test_cargo_tools_bootstraps_binstall_from_source(
+        self, crate: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Only binstall is built from source, because it is what installs the rest.
+
+        Args:
+            crate: A Rust project root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+            tmp_path: pytest's temporary directory.
+        """
+        cargo_bin = tmp_path / "empty-cargo-bin"
+        cargo_bin.mkdir()
+        monkeypatch.setattr(rust_tasks, "_cargo_bin", lambda: cargo_bin)
+        monkeypatch.setattr(rust_tasks, "have", lambda _: False)
+
+        rust_tasks.cargo_tools(Config.load(root=crate))
+        cargo = [c.flags for c in recorder.calls if c.tool == "cargo"]
+        assert cargo[0] == ["install", "cargo-binstall", "--locked"]
+        assert cargo[1][0] == "binstall"
+
+    def test_security_checks_the_advisory_database(self, crate: Path, recorder: Recorder) -> None:
+        """The Rust analogue of govulncheck: dependencies, not the crate's own source.
+
+        Args:
+            crate: A Rust project root.
+            recorder: The command recorder.
+        """
+        rust_tasks.security(Config.load(root=crate))
+        assert recorder.find("cargo").flags == ["deny", "check", "advisories"]
+
+    def test_license_checks_the_allow_list(self, crate: Path, recorder: Recorder) -> None:
+        """The allow-list lives in deny.toml, which is why no ``license_fail_on`` appears here.
+
+        Args:
+            crate: A Rust project root.
+            recorder: The command recorder.
+        """
+        rust_tasks.license_(Config.load(root=crate))
+        assert recorder.find("cargo").flags == ["deny", "check", "licenses"]
+
+    def test_deps_reports_unused_dependencies(self, crate: Path, recorder: Recorder) -> None:
+        """cargo-machete is the deptry of the Rust layer.
+
+        Args:
+            crate: A Rust project root.
+            recorder: The command recorder.
+        """
+        rust_tasks.deps(Config.load(root=crate))
+        assert recorder.find("cargo").flags == ["machete"]
+
+    def test_cargo_bin_follows_cargo_s_own_variables(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The two variables cargo reads, in cargo's order, then its default.
+
+        Resolved rather than assumed, because the whole point of the probe is that this
+        directory is often not on PATH.
+
+        Args:
+            monkeypatch: pytest's patcher.
+            tmp_path: pytest's temporary directory.
+        """
+        monkeypatch.setenv("CARGO_INSTALL_ROOT", str(tmp_path / "install-root"))
+        monkeypatch.setenv("CARGO_HOME", str(tmp_path / "home"))
+        assert rust_tasks._cargo_bin() == tmp_path / "install-root" / "bin"
+
+        monkeypatch.delenv("CARGO_INSTALL_ROOT")
+        assert rust_tasks._cargo_bin() == tmp_path / "home" / "bin"
+
+        monkeypatch.delenv("CARGO_HOME")
+        assert rust_tasks._cargo_bin() == Path.home() / ".cargo" / "bin"
+
     def test_a_gate_without_a_manifest_skips(self, tmp_path: Path) -> None:
         """The guard is the manifest, because cargo finds the sources from it.
 
@@ -528,3 +599,100 @@ class TestGoGates:
         monkeypatch.setattr(go_tasks.shutil, "which", lambda name: f"/usr/local/bin/{name}")
         go_tasks.security(Config.load(root=module))
         assert recorder.calls[-1].tool == "govulncheck"
+
+    def test_install_without_go_says_where_to_get_it(self, module: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing toolchain is a failure with an address, as the Rust layer does it.
+
+        Args:
+            module: A Go module root.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(go_tasks, "have", lambda _: False)
+        with pytest.raises(Failed, match=r"go\.dev"):
+            go_tasks.install(Config.load(root=module))
+
+    def test_install_warns_when_there_is_no_module_file(
+        self,
+        tmp_path: Path,
+        recorder: Recorder,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No go.mod means nothing to download -- a warning, not a download of nothing.
+
+        Args:
+            tmp_path: An empty directory pinned to the Go layer.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(go_tasks, "have", lambda _: True)
+        go_tasks.install(Config.load(root=tmp_path, layers=("go",)))
+        assert "no go.mod" in capsys.readouterr().out
+        assert recorder.calls == []
+
+    def test_typecheck_vets_then_lints(self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The compiler already type-checks, so this layer's ``typecheck`` is vet plus lint.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(go_tasks.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+        go_tasks.typecheck(Config.load(root=module))
+        assert [(c.tool, c.flags) for c in recorder.calls] == [
+            ("go", ["vet", "./..."]),
+            ("golangci-lint", ["run"]),
+        ]
+
+    def test_typecheck_passes_the_configured_go_flags(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``go_flags`` reaches vet, as it reaches every other go invocation.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(go_tasks.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+        go_tasks.typecheck(Config.load(root=module, go_flags=("-tags=integration",)))
+        assert recorder.find("go").flags == ["vet", "./...", "-tags=integration"]
+
+    def test_docs_coverage_sets_the_exit_status(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Undocumented exports are revive's job, and ``-set_exit_status`` makes it a gate.
+
+        Without that flag revive prints its findings and exits 0, which is a report rather
+        than a gate.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(go_tasks.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+        go_tasks.docs_coverage(Config.load(root=module))
+        assert recorder.find("revive").flags == ["-config", "revive.toml", "-set_exit_status", "./..."]
+
+    def test_a_failed_cobertura_conversion_propagates_its_status(
+        self, module: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The one recipe that needs a pipe still reports the converter's own status.
+
+        Args:
+            module: A Go module root.
+            monkeypatch: pytest's patcher.
+        """
+        reports = module / "_tests"
+        reports.mkdir()
+        profile = reports / "coverage.out"
+        profile.write_text("mode: atomic\n")
+
+        monkeypatch.setattr(go_tasks.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+        monkeypatch.setattr(go_tasks.subprocess, "call", lambda *a, **k: 2)
+        with pytest.raises(Failed, match="gocover-cobertura failed") as excinfo:
+            go_tasks._cobertura(Config.load(root=module), profile, reports / "coverage.xml")
+        assert excinfo.value.code == 2

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -70,6 +70,21 @@ class TestInstall:
         with pytest.raises(Skip, match="pyproject"):
             python.install(Config.load(root=tmp_path))
 
+    def test_reuses_an_existing_virtualenv(
+        self, cfg: Config, recorder: Recorder, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A second run does not recreate the environment, and names the one it reused.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            capsys: pytest's output capture.
+        """
+        (cfg.root / ".venv").mkdir()
+        python.install(cfg)
+        assert "venv" not in recorder.tools()
+        assert str(cfg.root / ".venv") in capsys.readouterr().out
+
 
 class TestTest:
     """python.mk's ``test`` -- the recipe that justified a real language."""
@@ -205,6 +220,23 @@ class TestCoverage:
         state = runner.run(["coverage"], cfg)
         assert state.status_of("coverage") is runner.Status.SKIPPED
         assert "pytest" not in recorder.tools()
+
+    def test_clears_stale_coverage_data_first(self, cfg: Config, recorder: Recorder) -> None:
+        """Leftover data from an interrupted run must not be merged into this one.
+
+        Both shapes go: the plain ``.coverage`` file and the per-process
+        ``.coverage.<host>.<pid>`` shards that xdist leaves behind.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / ".coverage").write_text("stale")
+        (cfg.root / ".coverage.host.4711").write_text("stale")
+        python.coverage(cfg)
+        assert not (cfg.root / ".coverage").exists()
+        assert not (cfg.root / ".coverage.host.4711").exists()
+        assert (cfg.root / "_tests" / "html-coverage").is_dir()
 
 
 class TestTypecheck:
@@ -363,6 +395,21 @@ class TestQuality:
         quality.rhiza_test(relocated)
         assert recorder.find("pytest").kwargs["env"] == {"RHIZA_DOCTEST_FOLDERS": "utils"}
 
+    def test_fmt_skips_without_a_config(self, cfg: Config, recorder: Recorder) -> None:
+        """No ``.pre-commit-config.yaml`` is a skip with a reason, not a failure.
+
+        This is the outcome that lets one aggregate serve repositories with different
+        bundles installed -- and the one ``--strict`` promotes when a consumer wants a
+        missing config to be a red build.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        with pytest.raises(Skip, match=r"\.pre-commit-config\.yaml"):
+            quality.fmt(cfg)
+        assert recorder.calls == []
+
     def test_todos_reports_file_and_line(self, cfg: Config, capsys: pytest.CaptureFixture[str]) -> None:
         """A TODO is reported with a repo-relative path and a line number.
 
@@ -408,6 +455,30 @@ class TestMutation:
             extras.mutation(cfg)
         assert recorder.tools() == ["mutmut", "mutmut", "mutmut"]
         assert [c.flags[0] for c in recorder.calls] == ["run", "html", "results"]
+
+    def test_relocates_the_generated_html_report(self, cfg: Config, recorder: Recorder) -> None:
+        """The report lands in ``html/`` at the root, and belongs under ``_tests``.
+
+        The previous run's report is removed rather than merged, so the folder describes
+        one run.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        generated = cfg.root / "html"
+        generated.mkdir()
+        (generated / "index.html").write_text("<html></html>")
+        previous = cfg.root / "_tests" / "mutation" / "html"
+        previous.mkdir(parents=True)
+        (previous / "stale.html").write_text("stale")
+
+        extras.mutation(cfg)
+
+        moved = cfg.root / "_tests" / "mutation" / "html"
+        assert (moved / "index.html").is_file()
+        assert not (moved / "stale.html").exists()
+        assert not generated.exists()
 
 
 class TestHypothesis:
@@ -584,3 +655,48 @@ class TestSecurity:
         """
         python.security(cfg)
         assert "--ini" not in recorder.find("bandit").flags
+
+
+class TestPythonDocsCoverage:
+    """python.mk's ``docs-coverage``."""
+
+    def test_measures_both_folders_the_gate_claims(self, cfg: Config, recorder: Recorder) -> None:
+        """Both the source and the test tree are measured, at a 100% floor.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.docs_coverage(cfg)
+        call = recorder.find("interrogate")
+        assert call.flags[:5] == ["-vv", "--fail-under", "100", "--ignore-init-method", "--ignore-magic"]
+        assert call.flags[5:] == ["src", "tests"]
+
+    def test_omits_a_folder_that_is_not_there(self, cfg: Config, recorder: Recorder) -> None:
+        """A repository with no test folder is measured on what it has.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        shutil.rmtree(cfg.root / "tests")
+        python.docs_coverage(cfg)
+        assert recorder.find("interrogate").flags[5:] == ["src"]
+
+
+class TestPyprojectStructure:
+    """quality.mk's ``test-pyproject``: one check, reported loudly."""
+
+    def test_runs_only_the_pyproject_check_verbosely(self, cfg: Config, recorder: Recorder) -> None:
+        """A narrower, louder view of the one module ``rhiza-test`` also runs.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        quality.test_pyproject(cfg)
+        call = recorder.find("pytest")
+        assert call.flags[:3] == ["--pyargs", "pytest_rhiza.checks.test_pyproject", "-v"]
+        for loud in ("--tb=long", "--showlocals", "-rA", "--durations=0", "--no-header"):
+            assert loud in call.flags
+        assert call.kwargs["withs"] == (cfg.pytest_rhiza,)

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -7,6 +7,7 @@ string, and the reason rhiza.mk needs a Windows shell probe that this package do
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -167,3 +168,130 @@ def test_bin_resolution_prefers_the_override(monkeypatch: pytest.MonkeyPatch) ->
     assert uv_module._bin("uv", "RHIZA_UV_BIN") == "/opt/uv"
     monkeypatch.delenv("RHIZA_UV_BIN")
     assert uv_module._bin("definitely-not-a-tool", "RHIZA_NOPE") == "definitely-not-a-tool"
+
+
+def test_tool_runs_a_toolchain_binary_off_path(
+    spy: list[dict[str, object]], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``tool`` is the fourth form: a binary uv does not provision.
+
+    rust.mk and go.mk add exactly this one shape -- ``$(CARGO) nextest run``, ``$(GO)
+    test`` -- because uv provisions neither cargo nor go. It shares this module's echoing
+    and environment handling rather than being a bare ``subprocess.call`` per language
+    module.
+
+    Args:
+        spy: The subprocess spy.
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(uv_module.shutil, "which", lambda name: f"/fake/{name}")
+    uv_module.tool("cargo", "clippy", "--", "-Dwarnings", cwd=tmp_path)
+    assert spy[0]["argv"] == ["/fake/cargo", "clippy", "--", "-Dwarnings"]
+
+
+def test_tool_falls_back_to_the_bare_name(
+    spy: list[dict[str, object]], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unresolvable name is still passed, so the OS produces the error.
+
+    Args:
+        spy: The subprocess spy.
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(uv_module.shutil, "which", lambda name: None)
+    uv_module.tool("go", "vet", "./...", cwd=tmp_path)
+    assert spy[0]["argv"] == ["go", "vet", "./..."]
+
+
+def test_tool_propagates_the_toolchain_s_own_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``cargo``'s 101 reaches the caller, rather than collapsing to 1.
+
+    Args:
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(uv_module.subprocess, "call", lambda *a, **k: 101)
+    with pytest.raises(Failed, match="cargo clippy failed") as excinfo:
+        uv_module.tool("cargo", "clippy", cwd=tmp_path)
+    assert excinfo.value.code == 101
+    assert uv_module.tool("cargo", "clippy", cwd=tmp_path, check=False) == 101
+
+
+def test_tool_failure_names_the_binary_not_its_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool reached by absolute path still reports under its own name.
+
+    The Go layer resolves its helpers to ``$GOBIN/<tool>``, so without this the message
+    would be a path a reader has to parse.
+
+    Args:
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(uv_module.subprocess, "call", lambda *a, **k: 3)
+    with pytest.raises(Failed, match="govulncheck") as excinfo:
+        uv_module.tool("/home/runner/go/bin/govulncheck", cwd=tmp_path)
+    assert excinfo.value.code == 3
+    assert "/home/runner" not in str(excinfo.value)
+
+
+def test_capture_returns_stripped_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The one recipe that needs a value back: ``go list -m``.
+
+    Without the module's own path, go-licenses walks the project's own packages and fails
+    a freshly synced project for having no LICENSE of its own.
+
+    Args:
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(uv_module.shutil, "which", lambda name: f"/fake/{name}")
+    monkeypatch.setattr(
+        uv_module.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, "example.com/demo\n", ""),
+    )
+    assert uv_module.capture("go", "list", "-m", cwd=tmp_path) == "example.com/demo"
+
+
+def test_capture_is_empty_when_the_tool_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-zero status yields no value, so the caller can warn rather than guess.
+
+    Args:
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+    monkeypatch.setattr(
+        uv_module.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 1, "half a line", "boom"),
+    )
+    assert uv_module.capture("go", "list", "-m", cwd=tmp_path) == ""
+
+
+def test_capture_is_empty_when_the_tool_is_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An absent binary is an empty value, not an OSError escaping the gate.
+
+    Args:
+        tmp_path: Working directory.
+        monkeypatch: pytest's patcher.
+    """
+
+    def absent(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        """Raise as the OS does for a missing executable.
+
+        Args:
+            *_args: Ignored.
+            **_kwargs: Ignored.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            OSError: Always.
+        """
+        raise OSError(2, "No such file or directory")
+
+    monkeypatch.setattr(uv_module.subprocess, "run", absent)
+    assert uv_module.capture("definitely-not-a-tool", cwd=tmp_path) == ""


### PR DESCRIPTION
Coverage was 96.57% with 37 uncovered statements. All 37 were reachable, so this is **30 tests and no change to `src/`** — nothing was rewritten to make a metric move — plus the floor raise that turns the result into a guarantee.

Closes #54.

## Where the gaps were

| module | was | now | what the new tests pin |
|---|---|---|---|
| `uv.py` | 84% | 100% | `tool()`'s resolution, echo and status propagation; `capture()`'s success, non-zero and OSError paths |
| `rust.py` | 90% | 100% | binstall bootstrap, `cargo deny` advisories/licenses, `cargo machete`, `_cargo_bin()`'s variable precedence |
| `go.py` | 94% | 100% | missing-toolchain failure, absent `go.mod` warning, vet+lint, revive's `-set_exit_status`, failed cobertura conversion |
| `python.py` | 96% | 100% | venv reuse, stale `.coverage` shard cleanup, `docs-coverage` folder selection |
| `cli.py` | 95% | 100% | `version`, and `list` surviving a config it cannot resolve |
| `config.py` | 99% | 100% | list→tuple coercion, and a `rhiza-task` key that is not a table |
| `quality.py` | 98% | 100% | `fmt`'s skip, and `test-pyproject` (previously untested) |
| `extras.py` | 95% | 100% | mutation's HTML report relocation |
| `__main__.py` | 0% | 100% | `python -m rhiza_task` wiring |

Three clusters are worth calling out, because they are the ones that mattered rather than the ones that were merely red:

- **`uv.py` was the thinnest-tested and highest-consequence module in the package.** `tool()` and `capture()` are where an argument vector finally meets a real subprocess — the one place the suite's "no test runs uv" design leaves a seam.
- **Two failure paths carry a status a consumer's CI reads**: a missing Go toolchain, and a failed cobertura conversion. Both now assert the propagated code, not just that something raised.
- **The skip and fallback branches are the point of the design and were the least exercised**: `fmt` skipping without a config, and `list` still printing when the config will not resolve.

## Design kept, not bent

The tests patch at the uv/`subprocess` seam and assert on argument vectors, so **still no test in the suite runs a toolchain**. Each went into the behaviour group that already owned its gate (`TestInstall`, `TestCoverage`, `TestQuality`, `TestMutation`, `TestRustGates`, `TestGoGates`) rather than into a new file, with two new classes only for the two gates that had no tests at all.

## The floor moved, and it is a real ratchet

`coverage_fail_under` 95 → **100**. At 95 with a 100% suite, coverage could fall five points before a gate noticed. Verified as a ratchet rather than a coincidence:

```
$ pytest tests/test_spec.py --cov-fail-under=100
FAIL Required test coverage of 100% not reached. Total coverage: 49.44%
```

This also unlocks the claim the `[tool.check_test_layout]` comment explicitly anticipated — it recorded that *"only a 100% floor would guarantee that, and this repo's is 95 … Raising the floor to 100 is the change that would make a stronger claim available."* The reason now makes it: no module a missing mirror test would have covered can go unexercised, because that module would put the total below the floor.

Two constraints respected while editing those tables: no `%` appears in any `[tool.*]` value, because radon reads every one through configparser and dies on interpolation syntax (`radon cc src` re-run to confirm); and the floor's comment now records what 100 does **not** mean.

## What 100% does not claim

Four lines stay excluded by pre-existing `# pragma: no cover`, and the new comment says so rather than letting the number imply otherwise:

| site | kind |
|---|---|
| `spec.py:36` `TYPE_CHECKING` guard | structural |
| `__main__.py:5` `__main__` delegation | structural |
| `go.py:339` malformed total line | **testable** |
| `quality.py:171` unreadable file | **testable** |

Retiring the last two is the change that would make this 100% unqualified. Not done here, because it edits `src/` and this PR deliberately does not.

## Verified

- `rhiza-task test` — 268 passed, `Required test coverage of 100% reached. Total coverage: 100.00%`
- `rhiza-task all` — green (`fmt` skips: this branch is off `main` and predates the pre-commit config in #57)
- `ruff check` / `format --check` — clean, after four D403 fixes where docstrings started with a lowercase tool name
- `check_test_layout.py` — exit 0 against the rewritten opt-out reason

## Note for whoever merges both

This branches off `main`, independently of #57, so the two can merge in either order. Both touch `pyproject.toml` but different lines — #57 the `description`, this one the coverage floor — so expect at most a trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
