### PR TITLE
Promote the name normaliser to Config.field_for, document the security-gate asymmetry

### DIFF
--- a/src/rhiza_task/cli.py
+++ b/src/rhiza_task/cli.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__, runner
-from .config import DEFAULT_CI_OS_MATRIX, LAYERS, Config, _key
+from .config import DEFAULT_CI_OS_MATRIX, LAYERS, Config
 from .runner import Status
 from .spec import REGISTRY
 
@@ -106,7 +106,7 @@ def print_setting(name: str) -> None:
         typer.Exit: With status 2 when the setting does not exist.
     """
     cfg = Config.load()
-    field = _key(name)
+    field = Config.field_for(name)
     if not hasattr(cfg, field):
         err.print(f"[red]unknown setting: {name}[/red]")
         raise typer.Exit(2)

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -326,6 +326,40 @@ class Config:
         """
         return self.root / getattr(self, folder_field)
 
+    @staticmethod
+    def field_for(name: str) -> str:
+        """Normalise a make-style variable name to a field name.
+
+        Public because the spelling rule is not private to the layer readers below: the
+        ``print`` command has to answer for ``SOURCE_FOLDER`` exactly as ``.rhiza/.env``
+        does, and a second normaliser written against the same rule is a second thing to
+        keep in step. A caller outside this module asking "which field is this?" is asking
+        :class:`Config`, so it is spelled as a question :class:`Config` can be asked.
+
+        The ``RHIZA_`` prefix is optional, so it is stripped -- but only when what remains
+        is actually a field. Stripping unconditionally made ``RHIZA_CHECKS`` resolve to
+        the unknown field ``checks``, so the setting was silently dropped and
+        ``rhiza_checks`` was reachable from the environment only as ``RHIZA_RHIZA_CHECKS``.
+        Trying the whole name as a fallback fixes that without disturbing the fields whose
+        prefix *is* redundant: ``RHIZA_CI_OS_MATRIX`` still resolves to ``ci_os_matrix``,
+        and the doubled spelling keeps working for anyone who found it.
+
+        Args:
+            name: e.g. ``RHIZA_CI_OS_MATRIX``, ``SOURCE_FOLDER`` or ``rhiza-checks``.
+
+        Returns:
+            e.g. ``ci_os_matrix``, ``source_folder``, ``rhiza_checks``.
+
+        Examples:
+            >>> Config.field_for("SOURCE_FOLDER"), Config.field_for("rhiza-checks")
+            ('source_folder', 'rhiza_checks')
+        """
+        lowered = name.lower().replace("-", "_")
+        stripped = lowered.removeprefix("rhiza_")
+        if stripped in _FIELD_NAMES or lowered not in _FIELD_NAMES:
+            return stripped
+        return lowered
+
     @classmethod
     def load(cls, root: Path | None = None, **overrides: Any) -> Config:
         """Build a config by walking the six layers in order.
@@ -407,7 +441,7 @@ class Config:
 
 
 _FIELD_NAMES = frozenset(f.name for f in fields(Config))
-"""Every field name, for :func:`_key`. Built once rather than per environment variable."""
+"""Every field name, for :meth:`Config.field_for`. Built once rather than per variable."""
 
 
 def _from_env_file(path: Path) -> dict[str, Any]:
@@ -436,7 +470,7 @@ def _from_env_file(path: Path) -> dict[str, Any]:
     """
     if not path.is_file():
         return {}
-    return {_key(k): _coerce(v) for k, v in dotenv_values(path).items() if v and v.strip()}
+    return {Config.field_for(k): _coerce(v) for k, v in dotenv_values(path).items() if v and v.strip()}
 
 
 def _from_manifest(path: Path) -> dict[str, Any]:
@@ -532,32 +566,8 @@ def _from_environ(environ: Mapping[str, str]) -> dict[str, Any]:
         Parsed settings.
 
     """
-    settings = ((_key(k), v) for k, v in environ.items())
+    settings = ((Config.field_for(k), v) for k, v in environ.items())
     return {k: _coerce(v) for k, v in settings if k in _FIELD_NAMES and v.strip()}
-
-
-def _key(name: str) -> str:
-    """Normalise a make-style variable name to a field name.
-
-    The ``RHIZA_`` prefix is optional, so it is stripped -- but only when what remains is
-    actually a field. Stripping unconditionally made ``RHIZA_CHECKS`` resolve to the
-    unknown field ``checks``, so the setting was silently dropped and ``rhiza_checks`` was
-    reachable from the environment only as ``RHIZA_RHIZA_CHECKS``. Trying the whole name
-    as a fallback fixes that without disturbing the fields whose prefix *is* redundant:
-    ``RHIZA_CI_OS_MATRIX`` still resolves to ``ci_os_matrix``, and the doubled spelling
-    keeps working for anyone who found it.
-
-    Args:
-        name: e.g. ``RHIZA_CI_OS_MATRIX``, ``SOURCE_FOLDER`` or ``rhiza-checks``.
-
-    Returns:
-        e.g. ``ci_os_matrix``, ``source_folder``, ``rhiza_checks``.
-    """
-    lowered = name.lower().replace("-", "_")
-    stripped = lowered.removeprefix("rhiza_")
-    if stripped in _FIELD_NAMES or lowered not in _FIELD_NAMES:
-        return stripped
-    return lowered
 
 
 def _coerce(value: str) -> Any:

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -244,6 +244,23 @@ def security(cfg: Config) -> None:
     missing ini as a usage error, so a project without one gets a red gate reporting a
     configuration problem as if it were a security finding.
 
+    ``security`` does not mean the same thing in all three layers, and the asymmetry is
+    inherited rather than introduced here. Rust runs ``cargo deny check advisories`` and Go
+    runs ``govulncheck ./...`` -- both scan *dependencies* against an advisory database.
+    Bandit is SAST: it lints the source this repository owns and never looks at what is
+    installed. So Python, which has the largest advisory surface of the three, is the one
+    layer whose ``security`` gate is not a dependency scan.
+
+    No ``pip-audit`` here is a decision taken upstream, not an omission: ``jebel-quant/rhiza``
+    dropped it in #1416 along with rhiza-tools, and pins its absence with a test
+    (``tests/docs/test_doc_consistency.py`` -- "pip-audit is deliberately not wired up;
+    this pins the fact the gate depends on"). This module is owned by this repository and
+    nothing syncs it, so adding a scan here is *possible* -- but it would put a gate in
+    consumers' CI that the template they also follow says is not there, and a transitive
+    advisory with no fix available would then fail a run the template would have passed.
+    Closing the gap belongs upstream, where both halves move together. Recorded here so
+    the next reader does not have to rediscover which of the two it is.
+
     Args:
         cfg: The resolved config.
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from rhiza_task.config import Config, _coerce, _key
+from rhiza_task.config import Config, _coerce
 
 
 def test_defaults_need_no_files(tmp_path: Path) -> None:
@@ -404,7 +404,7 @@ def test_key_strips_the_prefix_only_when_a_field_remains(var: str, expected: str
         var: The variable name as a consumer spells it.
         expected: The field it must resolve to.
     """
-    assert _key(var) == expected
+    assert Config.field_for(var) == expected
 
 
 def test_rhiza_checks_is_settable_from_the_env_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #55, closes #53. #56 needed no change — see below.

## #55 — the one private cross-module import

`cli.py` imported `config._key`, contradicting the underscore that declares it off-surface. It is now `Config.field_for`, a staticmethod, and the internal layer readers (`_from_env_file`, `_from_environ`) call it by that name too. The docstring says why the rule cannot stay private: `print` has to answer for `SOURCE_FOLDER` exactly as `.rhiza/.env` does, and a second normaliser written against the same rule is a second thing to keep in step. `cli.py` now imports nothing underscored, and no underscore-prefixed name crosses a module boundary anywhere in `src/`.

A doctest on `field_for` pins the two spellings it has to normalise.

## #53 — documented, not wired up

Chose the "record the asymmetry" resolution the issue offers. `tasks/python.py`'s `security` docstring now states that Rust and Go scan *dependencies* (`cargo deny check advisories`, `govulncheck ./...`) while bandit is SAST over own source, that Python has the largest advisory surface of the three, and that the absent `pip-audit` is an upstream decision — `jebel-quant/rhiza` #1416 dropped it and pins its absence with a test.

No `pip-audit` invocation added. Adding one would put a gate in consumers' CI that the template they also follow says is not there, and a transitive advisory with no fix available would fail a run the template passes. Closing the gap belongs upstream, where both halves move together.

## #56 — already satisfied

All four C-ranked blocks already carry the comment the issue asks for; the assessment spotted `config.py`'s and missed the other two. `2e6f6d3` ("docs: say why the four C-complexity blocks are shaped as they are") is on `main` and covers `spec.py:63` (`Guard` and `Guard.check` in one comment, since the class figure *is* check's) and `runner.py:163` (`_run_one`). No block changed rank here — still the same four, average still A (3.07) over 134 blocks.

## Gates

`fmt`, `install`, `typecheck`, `rhiza-test`, `docs-coverage`, `test`, `coverage`, `security` all ok. Coverage held at 100.0% against the 100.0% floor.