### PR TITLE
build: pin this repo's typechecker rather than inheriting the default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,18 @@ python-dotenv = "dotenv"
 [tool.rhiza-task]
 coverage_fail_under = 100
 
+# `ty` is already the shipped default (`typechecker` in config.py), so this line changes
+# nothing today. It is here because *this* package owns that default: a future release
+# that flipped it to `mypy` or `both` would change how this repository is typechecked
+# without a commit touching this repository, and the dogfood `all` in CI is where that
+# would land first and read as unrelated. Pinning it makes the choice this repo's own.
+#
+# The choice itself is `ty` alone rather than `both`: it is Astral's, like `uv` and `ruff`
+# which every gate here already provisions, and `src/` is fully annotated and passes it
+# clean. Adding `mypy --strict` is the reasonable other answer, and `both` is a one-word
+# edit to this line if the extra signal turns out to be worth the second resolve.
+typechecker = "ty"
+
 # The suite is organised by *behaviour*, not as a 1:1 mirror of `src/`: `test_tasks.py`,
 # `test_bundle_tasks.py`, `test_dev_tasks.py` and `test_language_layers.py` cover the
 # twelve task modules as groups, because what is worth asserting about them is the shape


### PR DESCRIPTION
One line in `[tool.rhiza-task]`, plus the note explaining why it is there.

```toml
typechecker = "ty"
```

## This changes no behaviour

`typechecker` already resolves to `ty` from `config.py`'s default. `rhiza-task print
typechecker` reported `ty` before this line existed and reports `ty` after it, and
`rhiza-task typecheck` runs the same `uv run --with ty ty check src` either way.

## Why write it down anyway

Because *this package* owns that default. A later `rhiza-task` release that flipped it
to `mypy` or `both` would change how this repository is typechecked without any commit
here touching it — and the dogfood `rhiza-task all` in the `gates` job is exactly where
that would first show up, as an unrelated-looking failure in a PR about something else.
Pinning it makes the choice this repo's own, which is the same reasoning already applied
to `coverage_fail_under` directly above it.

`ty` alone rather than `both` is deliberate: it is Astral's, like the `uv` and `ruff`
every gate here already provisions, and `src/` is fully annotated and passes it clean.
Adding `mypy --strict` is the reasonable other answer and stays a one-word edit to this
line if the extra signal turns out to be worth the second resolve.

## Verification

- `rhiza-task print typechecker` → `ty`, so it resolves through the config layer rather
  than falling back.
- `rhiza-task typecheck` → `All checks passed!`
- `rhiza-task fmt` → green, including the `check toml` and `Validate pyproject.toml`
  hooks.

Came out of a `/rhiza:quality` run on `b4aef5d`, which scored the repo 9.6/10 and flagged
type safety as the one subcategory resting on an implicit default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)