### PR TITLE
Gate the doctests, quieten the security gate, invoke the CLI off ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,35 @@ jobs:
       # Windows is in the matrix deliberately. The make layer needed a 40-line probe to
       # detect make falling back to cmd.exe, because its recipes were POSIX shell; every
       # command here is an argument vector, so this job is what asserts that the shell
-      # dependency is really gone.
+      # dependency is really gone. It asserts it of the vectors; the step below asserts it
+      # of an actual process.
       - name: Run tests
         run: uv run --group test --python ${{ matrix.python-version }} pytest -ra
+
+      # Because no test in the suite runs a tool -- conftest.py patches all four of uv.py's
+      # entry points and asserts on the vectors instead, which is why it finishes in under
+      # two seconds -- the Windows and macOS legs never resolved a binary, spawned a
+      # process, or compared a real path. The only end-to-end invocation anywhere was
+      # `rhiza-task all` in the `gates` job below, on ubuntu. So the platform this package's
+      # premise is aimed at was the one platform the CLI was never started on.
+      #
+      # This is deliberately a smoke step and not the gate suite: most gates provision a
+      # toolchain and would triple the matrix for little signal, because the failure mode
+      # being guarded against is "the CLI does not start, or cannot find its own tools, on
+      # this OS". `list` executes config resolution, layer detection and the registry walk;
+      # `doctor` then resolves binaries for real -- `shutil.which` (uv.exe on Windows), a
+      # real subprocess, `cfg.root` path handling -- which is the layer the suite stubs.
+      # Neither provisions anything, and `make` is optional in `doctor`'s TOOLS, so its
+      # absence on the runners is reported rather than fatal.
+      #
+      # `!cancelled()` for the reason the ruff job's two halves have it: a broken CLI and a
+      # failing test are independent findings, and reporting one at a time costs a round
+      # trip per fix.
+      - name: CLI smoke (the layer the suite stubs)
+        if: ${{ !cancelled() }}
+        run: |
+          uv run --python ${{ matrix.python-version }} rhiza-task list
+          uv run --python ${{ matrix.python-version }} rhiza-task doctor
 
   # ruff.toml is 9 KB of deliberate rule selection, and this job is not the only thing
   # enforcing it: `.pre-commit-config.yaml` carries the same ruff hooks, so `rhiza-task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,25 @@ If you find yourself wanting a real subprocess in a test, that is a signal the l
 test belongs in a task body rather than in the plumbing.
 
 The exception is the doctests: `Config.load`, `Config.field_for`, `Run.exit_code`,
-`lookup` and `Guard.check` carry executable examples that do run. They are checked by
-`rhiza-test`, so an example that goes stale fails a gate.
+`lookup` and `Guard.check` carry 39 executable examples that do run. `tests/test_doctests.py`
+is what runs them — `doctest.testmod` over every module `pkgutil` finds under
+`src/rhiza_task`, one parametrised case each, plus five cases asserting those particular
+docstrings still carry examples at all.
+
+`rhiza-test` used to be credited with this and does not do it: pytest-rhiza's
+`test_docstrings` asks whether a docstring exists and is well-formed, and `interrogate`
+asks the same presence question at 100%. Neither evaluates a `>>>`, so until #66 the 39
+examples were unexecuted by any gate — stale-proof only by discipline, in exactly the five
+places a refactor is most likely to change quietly.
+
+Two things about the shape of that file, both deliberate. It imports every module under
+`src/`, which is the one place the suite's hermeticism bends — harmless, because importing
+a task module only registers its tasks, but it is why the rule above is about what a test
+*runs* rather than what it imports. And the doctests are collected by a test rather than by
+`--doctest-modules`: in the `test` task's vector that flag would ship to consumer repos,
+where gating doctests is their call, and in `pytest.ini`'s `addopts` it would also apply to
+`rhiza-test`'s `pytest --pyargs pytest_rhiza.checks.*` — gating a dependency's doctests in
+this repo's name.
 
 ## The coverage floor is 100, and it is load-bearing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,5 +143,11 @@ When changing such code, update the comment with it. A stale comment is worse th
 `ci.yml` once asserted that `rhiza-task fmt` skipped for want of a pre-commit config, for
 several commits after that config was added.
 
+One placement rule the convention has to bend to: a suppression comment's reason goes
+*above* the line, never after the marker. bandit reads everything following `# nosec` as a
+comma-separated list of test IDs, so `# nosec B404 - fixed argument vectors` cost six
+`Test in comment:` warnings per occurrence. For the same reason the prose explaining it
+must not spell the marker itself — bandit scans every comment for it, wherever it sits.
+
 Docstring coverage is enforced at **100% over `src/` *and* `tests/`** — test functions and
 fixtures need docstrings too, with an `Args:` section for every parameter.

--- a/src/rhiza_task/tasks/doctor.py
+++ b/src/rhiza_task/tasks/doctor.py
@@ -16,7 +16,12 @@ from __future__ import annotations
 
 import re
 import shutil
-import subprocess  # nosec B404 - fixed argument vectors
+
+# The version probe below is a fixed argument vector, with no shell -- which is what bandit's B404
+# asks about. The reason sits here rather than on the suppression comment itself: bandit reads
+# everything after that marker as a comma-separated list of test IDs, so a trailing explanation
+# becomes one `Test in comment:` warning per word.
+import subprocess  # nosec B404
 from dataclasses import dataclass
 
 from ..config import Config

--- a/src/rhiza_task/tasks/go.py
+++ b/src/rhiza_task/tasks/go.py
@@ -15,7 +15,12 @@ whatever the developer's ``GOPATH`` happens to be.
 from __future__ import annotations
 
 import shutil
-import subprocess  # nosec B404 - fixed argument vector, never shell=True
+
+# The one call below is a fixed argument vector, and `shell=True` appears nowhere -- which is what
+# bandit's B404 asks about. The reason sits here rather than on the suppression comment itself:
+# bandit reads everything after that marker as a comma-separated list of test IDs, so a trailing
+# explanation becomes one `Test in comment:` warning per word.
+import subprocess  # nosec B404
 from pathlib import Path
 
 from ..config import Config

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 
 import re
 import shutil
-import subprocess  # nosec B404 - fixed argument vectors
+
+# The hook-path probe below is a fixed argument vector, with no shell -- which is what bandit's
+# B404 asks about. The reason sits here rather than on the suppression comment itself: bandit
+# reads everything after that marker as a comma-separated list of test IDs, so a trailing
+# explanation becomes one `Test in comment:` warning per word.
+import subprocess  # nosec B404
 from pathlib import Path
 
 from ..config import Config

--- a/src/rhiza_task/uv.py
+++ b/src/rhiza_task/uv.py
@@ -36,7 +36,12 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess  # nosec B404 - fixed argument vectors, never shell=True
+
+# Every call in this module is a fixed argument vector, and `shell=True` appears nowhere -- which
+# is what bandit's B404 asks about. The reason sits here rather than on the suppression comment
+# itself: bandit reads everything after that marker as a comma-separated list of test IDs, so a
+# trailing explanation becomes one `Test in comment:` warning per word.
+import subprocess  # nosec B404
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -82,7 +87,14 @@ def _run(argv: Sequence[str], cwd: Path, env: Mapping[str, str] | None = None) -
     merged.pop("VIRTUAL_ENV", None)
     merged.setdefault("UV_NO_MODIFY_PATH", "1")
     print(f"{BLUE}$ {' '.join(argv)}{RESET}", file=sys.stderr, flush=True)
-    return subprocess.call(list(argv), cwd=cwd, env=merged)  # noqa: S603  # nosec B603
+    # `list(argv)` on its own line, not inlined into the call below. Inlined, the line held
+    # two call nodes, and bandit runs every test against each: B603 fired on the subprocess
+    # call and was suppressed, then returned None for `list(...)` and -- seeing B603 named in
+    # the line's suppression comment -- warned `encountered (B603), but no failed test` on
+    # every clean run. The suppression is live: B603 is a real finding here, low severity and
+    # so below `bandit -ll`'s threshold. Hence one call per line rather than a deletion.
+    command = list(argv)
+    return subprocess.call(command, cwd=cwd, env=merged)  # noqa: S603  # nosec B603
 
 
 def uv(*args: str, cwd: Path, check: bool = True, env: Mapping[str, str] | None = None) -> int:

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,87 @@
+"""The executable documentation: the 39 ``>>>`` examples in ``src/``, actually evaluated.
+
+Five docstrings carry the load-bearing contracts as examples -- ``Run.exit_code``'s eleven
+*are* the exit-code specification (signal collapse, BLOCKED standing alone, pytest's 2
+surviving unflattened), ``Guard.check``'s ten enumerate every way a guard goes unsatisfied
+and the exact line the runner prints, ``Config.load``'s nine document the layer-resolution
+order. Nothing ran them. ``rhiza-test`` runs pytest-rhiza's ``test_docstrings`` and
+``docs-coverage`` runs interrogate, and both ask whether a docstring *exists and is
+well-formed*; neither evaluates an example. So the examples in the places a reader goes to
+learn the contract -- and a refactor is most likely to change quietly -- could go stale at
+100% on every gate.
+
+This module is that gate. It is a test rather than ``--doctest-modules`` in ``pytest.ini``
+or in the ``test`` task's argument vector, for two reasons:
+
+* the task ships to consumer repositories, where whether to gate doctests is their call;
+* ``addopts`` applies to every pytest this repo runs, including ``rhiza-test``'s
+  ``pytest --pyargs pytest_rhiza.checks.*`` -- which would gate a *dependency's* doctests
+  in this repo's name, and turn this repo red for an upstream release.
+
+It is also the one place the suite's hermeticism bends: importing every module under
+``src/`` is not patching anything. That is harmless here -- importing a task module only
+registers its tasks -- but it is why the rule in CLAUDE.md is about what a test *runs*
+rather than what it imports.
+"""
+
+from __future__ import annotations
+
+import doctest
+import importlib
+import pkgutil
+
+import pytest
+
+import rhiza_task
+
+MODULES = tuple(sorted(info.name for info in pkgutil.walk_packages(rhiza_task.__path__, "rhiza_task.")))
+"""Every module under ``src/rhiza_task``, discovered rather than listed.
+
+A list would be a second place to remember, and the failure it permits is silent: a new
+module's examples simply never run. ``walk_packages`` recurses into ``tasks/``, so the
+twelve task modules are covered by the same parametrisation.
+"""
+
+LOAD_BEARING = (
+    ("rhiza_task.config", "Config.field_for"),
+    ("rhiza_task.config", "Config.load"),
+    ("rhiza_task.runner", "Run.exit_code"),
+    ("rhiza_task.spec", "Guard.check"),
+    ("rhiza_task.spec", "lookup"),
+)
+"""The five docstrings whose examples are the specification, as (module, qualname).
+
+Named explicitly, because the test above is otherwise satisfied by a repository with no
+examples at all: a module with nothing to run reports ``0 of 0`` and passes. That is the
+same "green gate that measured nothing" failure the ``RHIZA_DOCTEST_FOLDERS`` tests in
+``test_tasks.py`` exist to prevent.
+"""
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_every_example_still_evaluates(name: str) -> None:
+    """Run one module's doctests, and fail with what the examples reported.
+
+    Parametrised per module rather than looped, so a stale example names the module it is in
+    without a reader opening the log.
+
+    Args:
+        name: The module to run.
+    """
+    result = doctest.testmod(importlib.import_module(name), verbose=False)
+    assert not result.failed, f"{result.failed} of {result.attempted} examples failed in {name}"
+
+
+@pytest.mark.parametrize(("module_name", "qualname"), LOAD_BEARING)
+def test_the_contracts_are_still_documented_by_example(module_name: str, qualname: str) -> None:
+    """Assert one named docstring still carries at least one example.
+
+    Args:
+        module_name: The module the docstring lives in.
+        qualname: The function or method, e.g. ``Run.exit_code``.
+    """
+    module = importlib.import_module(module_name)
+    found = {test.name: test for test in doctest.DocTestFinder().find(module)}
+    test = found.get(f"{module_name}.{qualname}")
+    assert test is not None, f"{module_name}.{qualname} has no docstring for doctest to find"
+    assert test.examples, f"{module_name}.{qualname} carries no doctest examples"


### PR DESCRIPTION
Closes #66, closes #67, closes #68 — the three findings from the last `/rhiza:quality` run. `uv run rhiza-task all` is green, coverage still 100%.

## #66 — the 39 doctests now run

Five docstrings carry the load-bearing contracts as examples: `Run.exit_code`'s eleven *are* the exit-code specification, `Guard.check`'s ten enumerate every unsatisfied guard and the exact line the runner prints, `Config.load`'s nine document the layer-resolution order. Nothing executed them. `rhiza-test` and `docs-coverage` both ask whether a docstring *exists and is well-formed*; neither evaluates a `>>>`, so an example could go stale at 100% on every gate.

`tests/test_doctests.py` is the gate — `doctest.testmod` over every module `pkgutil` finds under `src/rhiza_task`, one parametrised case each, plus five cases asserting those particular docstrings still carry examples at all (a module with nothing to run reports `0 of 0` and passes — the same "green gate that measured nothing" failure the `RHIZA_DOCTEST_FOLDERS` tests guard against). Both failure modes were verified by hand: flipping an expected value in `Run.exit_code` fails, and deleting `field_for`'s examples fails.

**Deviation from the issue's suggested fix, on purpose.** Neither `--doctest-modules` shape was used. In the `test` task's argument vector the flag ships to consumer repos, where gating doctests is their call. In `pytest.ini`'s `addopts` it also applies to `rhiza-test`'s `pytest --pyargs pytest_rhiza.checks.*` — I tried it, and it does collect a *dependency's* doctest, which would turn this repo red for an upstream pytest-rhiza release. A test file avoids both and still runs everywhere the suite runs, including all twelve CI cells.

## #67 — the security gate is silent

18 warning lines on every clean run, both causes comment placement:

- bandit reads everything after `# nosec` as a comma-separated list of test IDs, so `# nosec B404 - fixed argument vectors` cost six `Test in comment:` lines each. The reasons are what a reviewer wants, so they move above the import rather than being dropped — and the prose must not spell the marker itself, since bandit scans every comment for it wherever it sits.
- `nosec encountered (B603), but no failed test on uv.py:85` was **not** a stale suppression. Removing it surfaces a real B603, hidden from the gate only by `bandit -ll`'s severity floor. The cause was two call nodes on one line: bandit runs every test against each node, so B603 fired on `subprocess.call` and was suppressed, then returned `None` for the inlined `list(argv)` and reported the line's suppression as unused. Hoisting `list(argv)` to its own line keeps the suppression precise.

`uvx bandit -r src -ll -q` now prints nothing at all.

## #68 — the CLI starts on Windows and macOS

`ci.yml` gains a smoke step on every matrix leg: `rhiza-task list`, then `rhiza-task doctor`. `list` covers config resolution, layer detection and the registry walk; `doctor` resolves binaries for real — `shutil.which` (`uv.exe` on Windows), a real subprocess, `cfg.root` path handling — which is precisely the layer the suite stubs. Neither provisions a toolchain, and `make` is optional in `doctor`'s `TOOLS`, so its absence on a runner is reported rather than fatal. `if: !cancelled()` for the reason the ruff job's two halves have it.

## Also

`CLAUDE.md` credited `rhiza-test` with running the doctests, which is the claim #66 disproves — that paragraph now describes what actually runs them, and the house-style section records the suppression-comment placement rule so the warnings do not come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)