### PR TITLE
Close six /rhiza:quality findings: cover two pragmas, add mypy --strict, fix three stale comments, SHA-pin two workflows

### DIFF
--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,9 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
+    # SHA-pinned for the reason rhiza_scorecard.yml records at its own call: a tag is
+    # mutable, and a reusable workflow runs with the same access as one written here.
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@31e1a11237419f746770c5339f8aa468fd1c0deb # v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,13 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
+    # SHA-pinned, like every `uses:` in this repository. A tag is mutable -- it can be
+    # force-moved to a different commit without this line changing -- and a reusable
+    # workflow runs with the same access as one written here, so the argument for pinning
+    # actions applies to it unchanged. Being first-party is not the property that makes a
+    # ref trustworthy. dependabot's github-actions ecosystem moves reusable-workflow SHAs,
+    # so this needs no entry in the manual-pin note at the foot of dependabot.yml.
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@31e1a11237419f746770c5339f8aa468fd1c0deb # v1.4.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,10 @@ required `reason` argues that per-module coverage is guaranteed by the floor ins
 
 **So lowering the floor invalidates the opt-out.** The two move together, or neither moves.
 
-Four lines are excluded by `# pragma: no cover`, each carrying its reason. Two are
-structural; two are testable and retiring them would be a real improvement.
+Two lines are excluded by `# pragma: no cover`, each carrying its reason, and both are
+structural: the `TYPE_CHECKING` guard in `spec.py` and the `__main__` delegation. Neither
+is reachable under test by construction, so there is no exclusion left that a test could
+retire — a new `# pragma: no cover` should be argued for rather than added.
 
 ## Where the gates run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,14 @@ version pinned one patch above upstream — each carries the bug it prevents or 
 it records. Four blocks rank C on cyclomatic complexity and each states why the flat form
 is preferred over a decomposition that would satisfy the metric.
 
+One rule those four are held to: **if the branch count grows, the comment states a
+ceiling.** Three of them are bounded by closed sets — `_run_one` by the size of `Status`,
+`Guard` and `Guard.check` by the number of guard kinds — so their figures cannot drift far
+and "deliberate" is a complete answer. `Config.__post_init__` is one branch per validated
+setting, which is open-ended, so it names C (15) as the point where per-group helpers win.
+A growth rule without a limit is an open licence rather than a decision; `uvx radon cc src
+-a -s` is how you check, and nothing gates it.
+
 When changing such code, update the comment with it. A stale comment is worse than none:
 `ci.yml` once asserted that `rhiza-task fmt` skipped for want of a pre-commit config, for
 several commits after that config was added.

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,6 +4,19 @@ icon: material/drawing-box
 
 # Design
 
+## Where the evidence comes from
+
+Comments through `src/` cite **[jointview](https://github.com/Jebel-Quant/jointview)** by
+name when they explain why something is shaped the way it is. It is a small public
+consumer of the rhiza template in the same organisation, and it is named rather than
+generalised on purpose: it is the repository whose `.rhiza/.env`, `RHIZA_CHECKS` list and
+60-line Makefile override supplied the requirements this package had to meet.
+
+So a comment saying "jointview sets `ty` in `.rhiza/.env` for that reason" is reporting a
+setting that exists in a repository you can go and read, not sketching a hypothetical
+consumer. Where a design decision here looks arbitrary, that is usually where to look for
+the reason.
+
 ## The observation the package rests on
 
 Reading all ten make fragments back to back, **every recipe has the same three parts**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,10 +126,10 @@ python-dotenv = "dotenv"
 # what makes it a gate rather than a note.
 #
 # What 100 does *not* claim is that every line is meaningfully asserted -- only that none
-# is unvisited. Four lines stay excluded by `# pragma: no cover`, each carrying its reason:
-# the TYPE_CHECKING guard in spec.py, the `__main__` delegation, and two defensive `except`
-# branches (go.py's malformed total line, quality.py's unreadable file). The first two are
-# structural; the last two are testable and would be the change that retires the pragmas.
+# is unvisited. Two lines stay excluded by `# pragma: no cover`, each carrying its reason:
+# the TYPE_CHECKING guard in spec.py and the `__main__` delegation. Both are structural --
+# unreachable under test by construction rather than merely awkward to reach -- so every
+# exclusion left is one no test could retire, and a third would need that argument made.
 [tool.rhiza-task]
 coverage_fail_under = 100
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,11 +139,21 @@ coverage_fail_under = 100
 # without a commit touching this repository, and the dogfood `all` in CI is where that
 # would land first and read as unrelated. Pinning it makes the choice this repo's own.
 #
-# The choice itself is `ty` alone rather than `both`: it is Astral's, like `uv` and `ruff`
-# which every gate here already provisions, and `src/` is fully annotated and passes it
-# clean. Adding `mypy --strict` is the reasonable other answer, and `both` is a one-word
-# edit to this line if the extra signal turns out to be worth the second resolve.
-typechecker = "ty"
+# The value is `both` because the second resolve paid for itself. `ty` alone was the
+# setting here first -- it is Astral's, like `uv` and `ruff` which every gate already
+# provisions -- and the note in its place said adding `mypy --strict` was the reasonable
+# other answer whenever the extra signal proved worth it. It was: run against the project's
+# own environment, `mypy --strict` found `Config.path` returning `Any` from a function
+# declared `-> Path`, because `getattr` is typed `Any` and `ty` does not report the widening.
+# One real finding in twenty modules is a low yield and exactly the kind `ty` is still young
+# enough to miss, so the pair stays until `ty` grows the check.
+#
+# Worth knowing before reading a failure here: run `mypy --strict src` through `uvx`, with
+# no project environment, and it reports ten errors rather than none -- four unresolvable
+# imports and five untyped Typer decorators that follow from them. Those are artefacts of
+# the invocation, not of the source. The task runs it under `uv run`, where the
+# dependencies are present and the count is zero.
+typechecker = "both"
 
 # The suite is organised by *behaviour*, not as a 1:1 mirror of `src/`: `test_tasks.py`,
 # `test_bundle_tasks.py`, `test_dev_tasks.py` and `test_language_layers.py` cover the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,10 +159,12 @@ typechecker = "ty"
 # test file could leave unexercised, because an unexercised module would put the total
 # below the floor.
 #
-# The reason says "95" and not "95%" on purpose: radon reads *every* `[tool.*]` table
+# The reason spells that floor "100" and never "100%": radon reads *every* `[tool.*]` table
 # through configparser, which treats `%` as interpolation syntax and dies on any value
-# containing one -- so a percent sign here breaks `radon cc src`, the command the
-# complexity notes in spec.py, runner.py and config.py are there to answer.
+# containing one -- so a percent sign anywhere in this string breaks `radon cc src`, the
+# command the complexity notes in spec.py, runner.py and config.py are there to answer.
+# The constraint outlives the number, so it is stated as a rule rather than about one
+# value: whatever the floor becomes, write it bare in here.
 [tool.check_test_layout]
 enforce = false
 reason = "Tests are grouped by behaviour, not mirrored 1:1 -- the twelve task modules share one shape and are covered as groups. Per-module coverage is guaranteed instead by the coverage_fail_under floor of 100 in [tool.rhiza-task]: at that floor no module a missing test file would have covered can go unexercised."

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -232,6 +232,18 @@ class Config:
     # defaulting, typechecker, coverage_fail_under. It is a flat sequence, one field per
     # step, with no interaction between the steps; the count grows with the number of
     # validated settings and not with the depth of anything. Deliberate.
+    #
+    # Unlike the other three C blocks here, that growth rule needs a stated ceiling, and
+    # the ceiling is **C (15)**. `_run_one` is bounded by the size of `Status` and
+    # `Guard.check` by the number of guard kinds -- closed sets, so their figures cannot
+    # drift far. "One branch per validated setting" is not a closed set: every future
+    # setting adds one, and a justification with no limit is an open licence rather than a
+    # decision. At 15 -- roughly three more settings -- the flat form stops paying for
+    # itself, and the answer is per-group helpers (`_validate_layers`,
+    # `_validate_typechecker`, `_validate_coverage`) called in sequence from here, which
+    # keeps the readable one-field-per-step order while bounding each block.
+    #
+    # `uvx radon cc src -a -s` is the check; nothing gates it, so this is discipline.
     def __post_init__(self) -> None:
         """Normalise the list fields, then validate the enumerated and numeric ones.
 

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -324,7 +324,13 @@ class Config:
         Returns:
             The absolute path.
         """
-        return self.root / getattr(self, folder_field)
+        # The annotation is load-bearing under `mypy --strict`: `getattr` is typed to return
+        # `Any`, `Path / Any` is `Any` too, and returning that from a `-> Path` function is
+        # what `no-any-return` reports. Naming the type here is also the honest spelling --
+        # every field this reaches ends in `_folder` and holds a `str`, which is the same
+        # assumption `folders` above encodes in its `dict[str, str]`.
+        value: str = getattr(self, folder_field)
+        return self.root / value
 
     @staticmethod
     def field_for(name: str) -> str:

--- a/src/rhiza_task/tasks/go.py
+++ b/src/rhiza_task/tasks/go.py
@@ -341,7 +341,10 @@ def _total_coverage(cfg: Config) -> float | None:
         if line.startswith("total:"):
             try:
                 return float(line.split()[-1].rstrip("%"))
-            except ValueError:  # pragma: no cover - a malformed total line
+            except ValueError:
+                # A total line whose last field is not a number reads the same as no total
+                # line at all: None, and the caller warns that the floor went unenforced.
+                # Guessing a number here would be worse than admitting the miss.
                 return None
     return None
 

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -173,7 +173,12 @@ def todos(cfg: Config) -> None:
     for path in sorted(_walk(cfg.root)):
         try:
             lines = path.read_text(errors="replace").splitlines()
-        except OSError:  # pragma: no cover - unreadable file
+        except OSError:
+            # Skip, not fail: a file the gate cannot open is not a TODO, and one unreadable
+            # path in a tree must not cost the report every hit after it. `errors="replace"`
+            # already absorbs undecodable *bytes*, so what reaches here is the file that
+            # could not be opened at all -- a permission bit, a dangling symlink, a name the
+            # OS accepted and cannot serve.
             continue
         for number, line in enumerate(lines, start=1):
             if TODO_PATTERN.search(line):

--- a/tests/test_language_layers.py
+++ b/tests/test_language_layers.py
@@ -526,6 +526,26 @@ class TestGoGates:
         go_tasks.coverage(Config.load(root=module))
         assert "floor not enforced" in capsys.readouterr().out
 
+    def test_a_malformed_total_reads_as_no_total(
+        self, module: Path, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A total line whose number will not parse is the same miss as no total line.
+
+        ``go tool cover`` prints ``-`` for a profile covering no statements, so this is the
+        empty-package case rather than a hypothetical. Guessing a number would be worse
+        than reporting that the floor went unenforced.
+
+        Args:
+            module: A Go module root.
+            recorder: The command recorder.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(go_tasks, "_cobertura", lambda *a: None)
+        monkeypatch.setattr(go_tasks, "capture", lambda *a, **k: "total:\t(statements)\t-\n")
+        go_tasks.coverage(Config.load(root=module))
+        assert "floor not enforced" in capsys.readouterr().out
+
     def test_the_cobertura_conversion_is_a_pipe(self, module: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """gocover-cobertura reads stdin and writes stdout, and still runs without a shell.
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -436,6 +436,48 @@ class TestQuality:
         quality.todos(cfg)
         assert "0 item(s) found" in capsys.readouterr().out
 
+    def test_todos_skips_an_unreadable_file_without_losing_the_rest(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """One unopenable path costs its own hits, not every hit after it.
+
+        Patched rather than provoked with a permission bit: ``chmod`` does not deny the
+        owner a read on Windows, and Windows is in the matrix deliberately.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        (cfg.root / "src" / "locked.py").write_text("# TODO: never seen\n")
+        (cfg.root / "src" / "open.py").write_text("# TODO: still reported\n")
+        real = Path.read_text
+
+        def read_text(self: Path, *args: object, **kwargs: object) -> str:
+            """Raise for the locked file, and read everything else normally.
+
+            Args:
+                self: The path being read.
+                *args: Passed through.
+                **kwargs: Passed through.
+
+            Returns:
+                The file's text.
+
+            Raises:
+                PermissionError: When the path is the locked file.
+            """
+            if self.name == "locked.py":
+                raise PermissionError(self.name)
+            return real(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", read_text)
+        quality.todos(cfg)
+        out = capsys.readouterr().out
+        assert "src/open.py:1" in out
+        assert "locked.py" not in out
+        assert "1 item(s) found" in out
+
 
 class TestMutation:
     """test.mk's ``mutation``, and its exit-status subtlety."""


### PR DESCRIPTION
All six findings from a `/rhiza:quality` run, one commit each. Nothing here changes what
the package does: five commits are documentation accuracy and supply-chain consistency, and
the sixth adds a typechecker that found one real defect.

> **Branch name predates the last three commits.** It says `72-73-74`; the PR closes
> 72–77. Renaming would close and reopen the PR, so it stays.

## Add mypy --strict, and fix the one thing it finds (#75)

`typechecker` was `ty`, with a note saying `mypy --strict` was the reasonable other answer
whenever the extra signal proved worth a second resolve. Measured rather than left open:

`mypy --strict` found `Config.path` returning `Any` from a function declared `-> Path` —
`getattr` is typed `Any`, so `self.root / getattr(...)` is `Any` too, and `ty` does not
report the widening. The fix names the type in a local, which is also the honest spelling:
every field that method reaches ends in `_folder` and holds a `str`, the same assumption the
`folders` property already encodes in its `dict[str, str]`.

One finding across twenty modules is a low yield and exactly the class `ty` is young enough
to miss, so the pair stays. `typecheck` needed no code change — the task already loops over
`("ty", "mypy")` and provisions each with `uv run --with`.

**One trap worth knowing**, recorded in the manifest because it cost time to establish:
`uvx mypy --strict src` with no project environment reports **ten** errors, not zero — four
unresolvable imports and five untyped Typer decorators that follow from them. All artefacts
of the invocation. The task runs mypy under `uv run`, where the count is zero.

## Retire the two testable `pragma: no cover` (#74)

CLAUDE.md classified the four pragmas in `src/`: two structural, two "testable and retiring
them would be a real improvement". These are the two testable ones.

Every pragma is a hole in the argument the 100 floor exists to make — the floor is what
justifies the `[tool.check_test_layout]` opt-out, whose `reason` claims no module a missing
test file would have covered can go unexercised, and an excluded line is one the floor stops
guaranteeing.

Both tests stay hermetic; neither runs a tool:

- **`quality.py`** patches `Path.read_text` to raise for one file, asserting a *later* file's
  TODO is still reported. Patched rather than provoked with a permission bit deliberately:
  `chmod` does not deny the owner a read on Windows, and Windows is in the matrix on purpose,
  so the obvious test would pass everywhere and assert nothing where it matters.
- **`go.py`** feeds `total:\t(statements)\t-`, which is what `go tool cover` actually prints
  for a profile covering no statements — the empty-package case, not a hypothetical.

| | before | after |
|---|---|---|
| tests | 298 | **300** |
| statements in `src/` | 1082 | **1086** |
| coverage | 100.00% | **100.00%** |
| `pragma: no cover` | 4 | **2** |

The +4 statements are the excluded lines, now counted *and* covered. The two that remain are
unreachable under test by construction.

## Fix the stale premise about the opt-out reason (#73)

`pyproject.toml` opened a comment with `The reason says "95" and not "95%" on purpose`. The
reason says neither — it spells the floor `100`, and has since the floor moved.

The constraint it records is real: radon reads *every* `[tool.*]` table through configparser,
which dies on `%` as interpolation syntax, so a percent sign there breaks `radon cc src` —
the command the complexity notes in `spec.py`, `runner.py` and `config.py` exist to answer.
Only the premise had gone false.

Restated as a rule about the string rather than a claim about one value: whatever the floor
becomes, write it bare. Swapping 95 for 100 would have fixed today's sentence and left the
next floor change to break it again.

## Give `Config.__post_init__`'s growth rule a ceiling (#76)

Three of the four C-ranked blocks are bounded by closed sets — `_run_one` by the size of
`Status`, `Guard.check` by the number of guard kinds — so "deliberate" is a complete answer.
`__post_init__`'s is "one branch per validated setting", which is open-ended: every future
setting adds a branch under a rationale that never expires.

It now names **C (15)** — about three more settings — past which per-group helpers win.

Comment-only on purpose. The measurements say the code is fine (average complexity A (3.07)
over 134 blocks, every module A on maintainability), and decomposing one of the four while
the other three defend the flat form would make the file argue against itself. What was
missing was the limit, not the refactor. Generalised in CLAUDE.md as the rule the four are
held to: **if the branch count grows, the comment states a ceiling.**

## SHA-pin the two reusable workflow calls (#77)

Fifteen of the seventeen `uses:` refs were 40-character SHAs with a version comment; the two
reusable workflows from `jebel-quant/rhiza` resolved `@v1.4.2`. Both now pin
`31e1a11237419f746770c5339f8aa468fd1c0deb`.

A tag is mutable — force-movable to a different commit without either line changing — and a
reusable workflow runs with the same access as one written here (the scorecard call carries
`id-token: write` and `security-events: write`). Being first-party is not what makes a ref
trustworthy. The exposure was small; the inconsistency was the real cost, since two lines
quietly answering the convention differently is how it stops being one.

No entry in dependabot.yml's manual-pin note, deliberately: that note lists pins dependabot
*cannot* reach, and the github-actions ecosystem does move reusable-workflow SHAs.

> For anyone repeating this: for an annotated tag the tag object and the commit differ.
> `gh api repos/.../git/ref/tags/v1.4.2` returns the tag object SHA, which a `uses:` ref will
> not resolve. `gh api repos/.../commits/v1.4.2` gives the right one.

## Give the jointview references an antecedent (#72)

Six comments in `src/` justify a decision by reference to `jointview`, and nothing said what
jointview is — `grep -rin jointview` over README.md, CLAUDE.md, `docs/` and CHANGELOG.md
returned nothing. That turns the house convention against itself: the comments are dense
because the rule is "say why", so a reader follows one and finds the *why* unreachable.

The name is kept rather than generalised. jointview is a real public repository in this
organisation, and its `.rhiza/.env`, `RHIZA_CHECKS` list and Makefile override are where
these requirements came from — a comment saying "jointview sets `ty` in `.rhiza/.env`"
reports a setting that can be gone and read. What was missing was the antecedent, not the
specificity. The six comments are unchanged; they now resolve.

## Verification

`uv run rhiza-task all` green on the committed state after every commit — `fmt`, `deps`,
`test`, `docs-coverage`, `security`, `license`, `typecheck` (now both checkers),
`rhiza-test`. Also re-ran, and confirmed unchanged:

- test-layout checker — still passes on the documented opt-out
- doc-example checker with `--run` in the project environment — 39/39 doctests execute, 0
  failed, README python fences still match their `result` blocks
- `uvx radon cc src -a -s` — average A (3.07), the same four C blocks, every module A on MI,
  confirming the C (15) ceiling leaves the headroom the comment claims
- `actionlint` — passes on both edited workflows

Two edits reach beyond the issues as filed, both to stop documentation going stale the way
#73 did. CLAUDE.md and `pyproject.toml` each asserted "four lines … two are testable", which
#74 falsifies; both now say two. That sentence was a standing invitation to do exactly what
#74 does, so leaving it would have recreated the defect being closed.

**Not verified locally:** the `quality.py` test's whole point is Windows behaviour, and it
only ran on darwin here. The 12-cell matrix is where that gets proven — worth a look at the
Windows legs before merging.

Closes #72
Closes #73
Closes #74
Closes #75
Closes #76
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
