### PR TITLE
Scorecard baseline, a packaging invariant, and three documentation fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# Editor defaults, so a contributor's IDE agrees with `rhiza-task fmt` before it runs
+# rather than after. ruff owns Python formatting and markdownlint owns the docs; this file
+# only settles what an editor decides on its own -- line endings, trailing whitespace, the
+# final newline, and indent width per file type.
+#
+# The upstream copy carries a `[{Makefile,*.mk,*.make}]` tab stanza. It is dropped here:
+# this repository ships no Makefile and no make fragments, deliberately, because this
+# package is what replaces that layer. See CLAUDE.md.
+root = true
+
+# Default settings for all files
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+
+# Python, reStructuredText, and text files
+[*.{py,rst,txt}]
+indent_style = space
+indent_size = 4
+
+# YAML, JSON, and other config files
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for rhiza-task.
+#
+# Pull requests that modify matching paths require an approving review from a listed
+# owner. That requirement is enforced by `require_code_owner_review` in
+# .github/rulesets/main-branch-protection.json, and it feeds the OpenSSF Scorecard
+# Code-Review and Branch-Protection checks that .github/workflows/rhiza_scorecard.yml
+# publishes.
+#
+# Repository admins can still bypass, per that ruleset's `bypass_actors` entry, so a
+# maintainer can self-merge without waiting for a second reviewer. Note what that costs:
+# Scorecard's Code-Review check counts *approved* changesets, so a bypassed merge leaves
+# it at 0 even with this file in place. Branch-Protection is the check this moves.
+#
+# One owner, not the `@Jebel-Quant/rhiza` team the upstream copy names: that team has no
+# access to this repository, and GitHub treats an owner without write access as unknown --
+# which would make `require_code_owner_review` unsatisfiable rather than strict.
+
+# Default owner for everything in the repository.
+*       @tschm

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,111 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash",
+          "merge",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "pytest (ubuntu-latest, 3.11)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (ubuntu-latest, 3.12)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (ubuntu-latest, 3.13)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (ubuntu-latest, 3.14)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (macos-latest, 3.11)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (macos-latest, 3.12)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (macos-latest, 3.13)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (macos-latest, 3.14)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (windows-latest, 3.11)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (windows-latest, 3.12)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (windows-latest, 3.13)",
+            "integration_id": 15368
+          },
+          {
+            "context": "pytest (windows-latest, 3.14)",
+            "integration_id": 15368
+          },
+          {
+            "context": "ruff (lint + format)",
+            "integration_id": 15368
+          },
+          {
+            "context": "the gates this package applies to others",
+            "integration_id": 15368
+          },
+          {
+            "context": "lowest-direct dependency floors",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/tag-protection.json
+++ b/.github/rulesets/tag-protection.json
@@ -1,0 +1,34 @@
+{
+  "name": "version-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/tags/v*"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+## Supported Versions
+
+We actively support the following versions with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| n-1     | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+
+### How to Report
+
+**Do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via one of the following methods:
+
+1. **GitHub Security Advisories** (Preferred)
+   - Go to the Security Advisories page of this repository
+   - Click "New draft security advisory"
+   - Fill in the details and submit
+
+2. **Email**
+   - Send details to the repository maintainers
+   - Include "SECURITY" in the subject line
+
+### What to Include
+
+Please include the following information in your report:
+
+- **Description**: A clear description of the vulnerability
+- **Impact**: The potential impact of the vulnerability
+- **Steps to Reproduce**: Detailed steps to reproduce the issue
+- **Affected Versions**: Which versions are affected
+- **Suggested Fix**: If you have one (optional)
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt within 48 hours
+- **Initial Assessment**: We will provide an initial assessment within 7 days
+- **Resolution Timeline**: We aim to resolve critical issues within 30 days
+- **Credit**: We will credit reporters in the security advisory (unless you prefer to remain anonymous)
+
+### Scope
+
+This security policy applies to:
+
+- The source code and configuration files in this repository
+- GitHub Actions workflows provided by this repository
+- Python utilities and scripts maintained in this repository
+
+### Out of Scope
+
+The following are generally out of scope:
+
+- Vulnerabilities in upstream dependencies (report these to the respective projects)
+- Issues that require physical access to a user's machine
+- Social engineering attacks
+- Denial of service attacks that require significant resources
+
+## Security Measures
+
+This project implements several security measures:
+
+### Code Scanning
+- **CodeQL**: Automated code scanning for Python and GitHub Actions
+- **Bandit**: Python security linter integrated in CI and pre-commit
+- **Secret Scanning**: GitHub secret scanning enabled on this repository
+
+### Supply Chain Security
+- **SLSA Provenance**: Build attestations for release artifacts (public repositories only)
+- **Locked Dependencies**: `uv.lock` ensures reproducible builds
+- **Dependabot**: Automated dependency updates with security patches (version and security updates)
+
+### Release Security
+- **OIDC Publishing**: PyPI trusted publishing without stored credentials
+- **SBOM Attestations**: CycloneDX SBOMs generated and attested for release artifacts (public repositories only)
+- **Tag Protection**: `.github/rulesets/tag-protection.json` defines immutable `v*` tags
+
+## Security Best Practices
+
+1. **Keep Updated**: Regularly update dependencies and review security advisories
+2. **Review Changes**: Review dependency update PRs before merging
+3. **Enable Security Features**: Enable CodeQL, secret scanning, and Dependabot in your repositories
+4. **Use Locked Dependencies**: Always commit `uv.lock` for reproducible builds
+5. **Configure Branch Protection**: Require PR reviews and status checks
+
+## Acknowledgments
+
+We thank the security researchers and community members who help keep this project secure.


### PR DESCRIPTION
Tier 1 of the files worth lifting from `jebel-quant/rhiza` — four files, adapted from
**v1.4.2** (`31e1a11`), the ref this repo's two reusable-workflow calls already pin.

The selection is driven by the OpenSSF Scorecard this repository already publishes via
`rhiza_scorecard.yml`: **6.7, with six checks at 0**. These files target the ones a file
can actually move.

| File | Targets |
|---|---|
| `SECURITY.md` | `Security-Policy: 0` — "security policy file not detected" |
| `.github/CODEOWNERS` | `Branch-Protection`, and partly `Code-Review` |
| `.github/rulesets/main-branch-protection.json` | `Branch-Protection: 0` |
| `.github/rulesets/tag-protection.json` | Immutable `v*` tags |
| `.editorconfig` | Nothing measured — editor hygiene |

## Read this before expecting the score to move

**A committed ruleset is inert.** GitHub rulesets take effect when imported under
*Settings → Rules*, or created through the API. A JSON file in `.github/rulesets/` protects
nothing on its own. What lands here is the definition to import and the record of intent —
worth committing, but it is not yet in force, and `Branch-Protection` stays at 0 until
someone imports it.

**`Code-Review` will stay at 0 regardless.** `bypass_actors` lets the admin self-merge (as
upstream's does), and Scorecard counts *approved* changesets. That check needs a second
reviewer — a process change, not a file. Both caveats are recorded in `CODEOWNERS` so the
next reader doesn't re-derive them.

## Adaptations — none of these were copied verbatim

**`required_status_checks` would have broken every PR.** The upstream ruleset names the
template's make-layer job contexts — `Pre-commit hooks`, `CI gate`, `Security scanning` and
three more. Not one exists in this repository, and a required check that never reports
*blocks* a pull request indefinitely rather than failing it. Replaced with the fifteen
contexts `ci.yml` actually produces: the twelve `pytest` matrix cells, `ruff (lint +
format)`, `the gates this package applies to others`, and `lowest-direct dependency floors`.

Listing the cells individually is the cost of there being no aggregate job to require —
adding a Python version to the matrix means editing this file. That is the trade for the
matrix being gated at all.

**`CODEOWNERS` owner.** Upstream names `@tschm @Jebel-Quant/rhiza`. That team has no access
to this repository, and GitHub treats an owner without write access as *unknown* — which
would leave `require_code_owner_review` unsatisfiable rather than strict. `@tschm` is the
only collaborator, so it is the only owner.

**`SECURITY.md` had two false claims.** Its "Security Measures" section asserts things, so
each was checked against this repo rather than pasted:

- **Renovate** — listed upstream as an additional updater. This repo uses dependabot only.
  Removed.
- **Tag Protection** — asserted as active. It isn't, per the caveat above. Reworded to name
  the file rather than claim the state.

Everything else verified present: CodeQL (`rhiza_codeql.yml`), bandit (pre-commit hook and
`rhiza-task security`), SLSA provenance and SBOM attestation (`rhiza_release.yml`'s attest
steps and its `cyclonedx-py` invocation), OIDC publishing (`id-token: write` into
`pypa/gh-action-pypi-publish`), and `uv.lock`.

Checking rather than pasting is upstream's own convention: rhiza carries
`tests/security/test_security_md_claims.py`, which parses that section and asserts every
claim maps to evidence. This repo has no counterpart, so the claims are held true by review
— the reason to get them right on the way in.

**`.editorconfig`** dropped its `[{Makefile,*.mk,*.make}]` tab stanza (this repo ships no
Makefile, deliberately) and its "this file is part of the jebel-quant/rhiza repository"
header, which marks template ownership and is actively wrong where nothing is synced.

## The tag ruleset cannot lock releases out

Checked rather than assumed, since it blocks `creation` of `v*`: it bypasses RepositoryRole
5 (Admin), and releases are cut by pushing a tag **by hand** — `rhiza_release.yml` documents
`git tag v1.2.3 && git push origin v1.2.3` at its head and triggers `on: push: tags:`, so
the creator is the admin, not the workflow. `v1.0.0` was created that way.

## Verification

`uv run rhiza-task all` green on the committed state — all nine gates. `markdownlint`,
`check-yaml`, `actionlint` and secret detection all cover the new files and pass; both
ruleset JSONs parse.

## Not in this PR

From the same review, deliberately left out: `.bandit` (this repo ships none *by decision* —
`.pre-commit-config.yaml:106` records why), `.rhiza/semgrep.yml` (`weekly.yml:7` records the
decision not to), `cliff.toml` (would *change* the changelog's headings rather than fix
them — the current emoji groups are git-cliff's built-in defaults), and every workflow that
runs gates as `uvx rhiza-task@<pin>`, which is circular here.

`Maintained: 0` needs no file — the reason is "project was created within the last 90 days"
and the first commit is 2026-08-18. It resolves with time.


---

# Tier 2 (added)

Three more commits, from the same review of `jebel-quant/rhiza`.

## `tests/test_rhiza_packaging.py` — assert installed version == declared

Covers an invariant nothing here gated. `rhiza-test`'s pytest-rhiza checks
tag-against-pyproject; this is pyproject-against-*installed*, a different pair, and it
catches an editable install left by a rename, a `uv sync` that never ran, or a build
backend pointed at a tree it no longer owns.

It earns its place for a reason a consumer doesn't have: **this repo dogfoods its own
CLI.** Every gate runs `uv run rhiza-task <task>` from the working tree, and `rhiza-task
version` reads installed metadata — so a stale install makes the CLI under test report a
version that isn't the one being tested, while every gate still passes.

Adapted, not copied, on three counts:

- Upstream's docstring carries a second rationale — that this is the only test a freshly
  synced project has, standing in for an empty suite. That vacuum can't exist behind 300
  tests and a 100 floor, so claiming it would be borrowed justification.
- The failure message said `re-run make install`. There is no make here.
- The `.absolute()` note explained itself through rhiza's *symlinked* copy of the file.
  Nothing here is symlinked.

Every guard is a `skip` because each names a shape where the question isn't askable (dynamic
version; a uv *virtual* project with no distribution metadata). This repo is neither, so the
assert is reached — it reports PASSED, not SKIPPED, which is what makes it worth having.
**301 tests, coverage still 100.00%.**

## The `--strict` FAQ answer had gone stale twice

Found while checking whether the ADRs had a natural home. `docs/faq.md` said this repo
avoids `--strict` because "`fmt` has no `.pre-commit-config.yaml`".

That file is here, and `fmt` runs sixteen hooks green. **This is the same assertion
`CLAUDE.md` holds up as its cautionary tale** — "`ci.yml` once asserted that `rhiza-task
fmt` skipped for want of a pre-commit config, for several commits after that config was
added". It was fixed in `ci.yml` and left standing in the FAQ, which is the more durable
place for it to mislead, because a reader consults the FAQ *to* learn what is true.

The premise was wrong too, which the example was hiding: **`rhiza-task all --strict`
passes.** Nothing `all` aggregates skips here, so the stated reason didn't hold. Verified by
running it, not by reading guards.

The rewrite separates the three kinds of skip the old text collapsed into one — `semgrep`
(no `.rhiza/semgrep.yml`, the real not-managed case), `presentation`/`marimo-validate` (no
subject, which any consumer without the bundle shares), `paper` (no `latexmk` on the
machine, not a fact about the repo). All four confirmed by running the tasks.

**Possible follow-up, left for the maintainer:** since `all --strict` is green, CI could
adopt it. That's a gating-posture change rather than a doc fix, so this PR only records that
it is available.

## Upstream ADRs — linked, not copied

I proposed copying ADR 0011 and 0005. On reading them I think copying is wrong, so they are
linked from `docs/design.md`'s Further reading instead:

- Copying takes two of eleven ADRs out of a numbered set whose cross-references — 0004
  superseded by 0011, 0006 and 0010 still standing — would dangle immediately.
- They are **rhiza's decisions to revise**. A local copy is a fork going stale from the day
  it lands, and this branch has spent three commits fixing exactly that failure mode.

A link can't go stale in that direction; it can only 404, and both were checked (200).

If you would rather have them in-tree, say so and I will vendor them with a header naming
the upstream ref — but I would not recommend it in a repo this strict about stale docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
