### PR TITLE
Assert the installed version, and fix two stale documentation claims

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -149,3 +149,19 @@ assert — and it is why the suite is fast enough to be the inner loop.
 - [Adding a Task](adding_a_task.md) — the entry-point mechanism, from the outside
 - [Configuration](configuration.md) — the six layers in detail
 - [API Reference](api.md) — the modules above, with signatures
+
+### Upstream decision records
+
+This page argues the design from the code. The decision that *created* the package was
+taken in the template's repository, and its records are worth reading alongside — linked
+rather than copied, because they are `jebel-quant/rhiza`'s decisions to revise, and a
+local copy would be a fork going stale from the day it landed:
+
+- [ADR 0011 — Replace the Synced Make Layer with a Pinned CLI](https://github.com/Jebel-Quant/rhiza/blob/main/docs/adr/0011-replace-the-synced-make-layer-with-a-pinned-cli.md)
+  is why this package exists. It supersedes ADR 0004's modular-Makefile split, and its
+  context section is the case against a synced make layer stated from the template's side:
+  make cannot `include` a remote file, so every consumer held a full copy at whatever tag
+  it last synced, version pinning was a copy rather than a dependency, and the recipes were
+  untestable — `make -n` proves the text of a command, never that its flags are right.
+- [ADR 0005 — Separate rhiza Template Repository from rhiza-cli](https://github.com/Jebel-Quant/rhiza/blob/main/docs/adr/0005-separate-rhiza-template-from-cli.md)
+  is the earlier split that made a pinned CLI thinkable in the first place.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,9 +38,19 @@ gate lost its subject and nobody noticed.
 
 ### Why does this repository not use `--strict` on itself?
 
-Because several of its gates skip on purpose — `fmt` has no `.pre-commit-config.yaml` and
-`semgrep` has no `.rhiza/semgrep.yml`, both for the same "not rhiza-managed" reason.
-Asserting `--strict` here would only assert that the repository is something it is not.
+On `all`, it could: every gate `all` aggregates passes here, so `rhiza-task all --strict`
+is green.
+
+What skips is outside `all`, and for three different reasons worth separating:
+
+- `semgrep` has no `.rhiza/semgrep.yml`. This is the genuine "not rhiza-managed" case.
+- `presentation` has no `PRESENTATION.md`, and `marimo-validate` no `docs/notebooks`. These
+  skip for want of a *subject*, which any consumer that has not adopted the bundle shares.
+- `paper` skips on a machine without `latexmk` — a fact about the machine, not about this
+  repository.
+
+So a registry-wide `--strict` would assert that this is a consumer carrying every bundle,
+which it is not. `all --strict` is a narrower claim, and a true one.
 
 ### `unknown task` — but `list` shows it
 

--- a/tests/test_rhiza_packaging.py
+++ b/tests/test_rhiza_packaging.py
@@ -1,0 +1,92 @@
+"""The declared version and the installed one must agree.
+
+Adapted from `jebel-quant/rhiza`'s `bundles/python-core/tests/test_rhiza_packaging.py` at
+v1.4.2, and adapted rather than copied because upstream's file carries two rationales and
+only one of them applies here.
+
+The one that does: ``pyproject.toml`` declares a version and the environment installs one,
+and those drift. An editable install left behind by a rename, a ``uv sync`` that never ran,
+a build backend pointed at a tree it no longer owns -- each surfaces here as a version
+mismatch rather than as a confusing ``ImportError`` several files later.
+
+That matters more in this repository than in a consumer, because this repository *dogfoods
+its own CLI*. Every gate runs as ``uv run rhiza-task <task>``, resolved from the working
+tree, and ``rhiza-task version`` reads the installed distribution's metadata. So a stale
+install does not merely sit there: it makes the CLI under test report a version that is not
+the one being tested, and every gate still passes.
+
+The rationale that does **not** carry over is upstream's second one -- that this is the only
+test a freshly synced project has, standing in for an empty suite that would let ``test``
+pass while measuring nothing. That vacuum cannot exist here: the suite is 300 tests behind a
+100% coverage floor. This file is one narrow invariant, not a floor.
+
+Deliberately self-contained, as upstream is: no fixtures, so it cannot depend on what
+pytest-rhiza contributes to ``rhiza-task rhiza-test``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from pathlib import Path
+
+import pytest
+
+# `tests/` sits at the project root, so this file's grandparent is the root.
+#
+# `.absolute()`, not `.resolve()`. Nothing here is a symlink today, so the two agree -- but
+# upstream's copy *is* symlinked into `bundles/python-core/tests/`, where `.resolve()`
+# follows the link and computes a root with no pyproject.toml in it. The suite then skips
+# for a plausible-looking wrong reason instead of running, which is the worst outcome
+# available to a test whose failure mode is already a skip.
+_ROOT = Path(__file__).absolute().parent.parent
+
+
+def _project_table() -> dict:
+    """Return the ``[project]`` table from pyproject.toml, skipping when unusable.
+
+    Returns:
+        The parsed ``[project]`` table.
+    """
+    pyproject = _ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        pytest.skip("no pyproject.toml at the project root")
+    with pyproject.open("rb") as handle:
+        table = tomllib.load(handle).get("project")
+    if not isinstance(table, dict):
+        pytest.skip("pyproject.toml declares no [project] table")
+    return table
+
+
+def test_the_installed_version_matches_pyproject() -> None:
+    """The distribution installed in the environment must match the declared version.
+
+    Every guard here is a ``skip`` rather than a failure, because each names a project shape
+    in which the question is not askable rather than one in which the answer is wrong: a
+    dynamic version has no static value to compare, and a ``uv`` *virtual* project (no
+    ``[build-system]``) installs no distribution metadata at all. This repository is neither
+    -- it declares ``version = "1.0.0"`` statically and builds a real wheel -- so here the
+    assert is reached and the skips are the inherited generality, not slack.
+    """
+    project = _project_table()
+
+    name = project.get("name")
+    if not isinstance(name, str) or not name.strip():
+        pytest.skip("[project].name is missing or not a plain string")
+
+    declared = project.get("version")
+    if not isinstance(declared, str):
+        pytest.skip("[project].version is dynamic -- there is no static value to compare")
+
+    try:
+        found = installed_version(name)
+    except PackageNotFoundError:
+        pytest.skip(f"{name!r} is not installed as a distribution (a virtual project has no metadata)")
+
+    assert found == declared, (
+        f"pyproject.toml declares version {declared!r} but the installed {name!r} reports {found!r}. "
+        f"The environment is stale, or the build backend is picking up a different tree -- re-run "
+        f"`uv run rhiza-task install`, and check [build-system] and the packages it is told to "
+        f"include if that does not fix it."
+    )


### PR DESCRIPTION
Tier 2 of the files worth lifting from `jebel-quant/rhiza` (v1.4.2). Follows #79, which
merged while these were being written — hence a separate branch.

One test, and two documentation fixes that the review turned up on the way.

## `tests/test_rhiza_packaging.py` — installed version must equal declared

Covers an invariant nothing here gated. `rhiza-test`'s pytest-rhiza checks
tag-against-pyproject; this is pyproject-against-**installed**, a different pair. It catches
an editable install left by a rename, a `uv sync` that never ran, or a build backend pointed
at a tree it no longer owns.

It earns its place for a reason a consumer doesn't have: **this repo dogfoods its own CLI.**
Every gate runs `uv run rhiza-task <task>` resolved from the working tree, and `rhiza-task
version` reports installed metadata — so a stale install makes the CLI under test claim a
version that is not the one being tested, while every gate still passes.

Adapted, not copied, on three counts:

- Upstream's module docstring carries a second rationale — that this is the only test a
  freshly synced project has, standing in for an empty suite that lets `test` pass while
  measuring nothing. That vacuum cannot exist behind 300 tests and a 100 floor, so claiming
  it would be borrowed justification.
- The failure message said `re-run make install`. There is no make here.
- The `.absolute()` note explained itself through rhiza's **symlinked** copy of this file.
  Nothing here is symlinked, so the note now says why `.absolute()` is still right rather
  than describing a layout this repo doesn't have.

Every guard is a `skip`, because each names a shape where the question isn't askable — a
dynamic version, or a `uv` *virtual* project with no distribution metadata. This repo is
neither, so the assert is reached: the test reports PASSED rather than SKIPPED, which is what
makes it worth having rather than decorative.

**301 tests, coverage still 100.00%.**

## The `--strict` FAQ answer had gone stale twice

Found while checking whether the ADRs had a natural home. `docs/faq.md` explained that this
repo avoids `--strict` because "`fmt` has no `.pre-commit-config.yaml`".

That file is here, and `fmt` runs sixteen hooks green. **This is the same assertion
`CLAUDE.md` holds up as its own cautionary tale** — "`ci.yml` once asserted that `rhiza-task
fmt` skipped for want of a pre-commit config, for several commits after that config was
added". It was fixed in `ci.yml` and left standing in the FAQ, which is the more durable
place for it to mislead: a reader consults the FAQ *to* learn what is true.

The premise was wrong too, which the stale example was hiding: **`rhiza-task all --strict`
passes.** Nothing `all` aggregates skips here, so the reason given for not using it did not
hold. Verified by running it rather than by reading the guards.

The rewrite separates the three kinds of skip the old text collapsed into one, all four
confirmed by running the tasks:

| Task | Skips because | Kind of fact |
|---|---|---|
| `semgrep` | no `.rhiza/semgrep.yml` | the genuine "not rhiza-managed" case |
| `presentation`, `marimo-validate` | no subject | shared by any consumer without the bundle |
| `paper` | no `latexmk` | about the machine, not the repo |

The conclusion survives, narrowed: a registry-wide `--strict` would assert this is a
consumer carrying every bundle. `all --strict` is a different claim, and a true one.

**Possible follow-up, deliberately not taken here:** since `all --strict` is green, CI could
adopt it. That is a gating-posture change rather than a doc fix, so this PR only records that
it is available.

## Upstream ADRs — linked, not copied

I proposed copying ADR 0011 and 0005. Having read them, copying is the wrong call, so they
are linked from `docs/design.md`'s Further reading instead:

- Copying takes two of eleven ADRs out of a numbered set whose cross-references — 0004
  superseded by 0011, 0006 and 0010 still standing — dangle immediately.
- They are **rhiza's decisions to revise.** A local copy is a fork going stale from the day
  it lands, and the last two PRs here spent five commits fixing exactly that failure mode.

A link cannot go stale in that direction; it can only 404, and both were checked (HTTP 200).
ADR 0011 is worth the pointer regardless — it is the decision that created this package, and
both `CLAUDE.md` and `design.md` re-argue its case without citing it.

If you would rather have them in-tree, say so and I will vendor them with a header naming the
upstream ref — but I would not recommend it in a repo this strict about stale docs.

## Verification

`uv run rhiza-task all` green on the committed, rebased state — all nine gates. Both new
external links return 200.

## Housekeeping

`chore/scorecard-baseline` still exists on the remote and now carries these same three
commits, pushed after #79 merged. They are rebased onto `main` here, so that branch is
redundant and safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
