### PR TITLE
Close the four /quality findings: Rust/Go e2e, mutation, complexity gate, wider smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,26 @@ jobs:
       # `!cancelled()` for the reason the ruff job's two halves have it: a broken CLI and a
       # failing test are independent findings, and reporting one at a time costs a round
       # trip per fix.
+      #
+      # `todos` is the third command for a reason `list` and `doctor` cannot cover between
+      # them: both stop short of a task *body*. `list` walks the registry and `doctor`
+      # resolves binaries, but neither enters a `run` -- so the layer where `cfg.root` path
+      # handling, `Path.relative_to(...).as_posix()` and the guard evaluation compose into a
+      # real invocation was still ubuntu-only, because `rhiza-task all` in the `gates` job
+      # runs there and nowhere else.
+      #
+      # `todos` specifically because it provisions nothing: it reads the tree and prints.
+      # That keeps this a smoke step rather than the gate suite, which is the same reason
+      # the note above gives for not running the gates here -- most provision a toolchain
+      # and would triple the matrix for little signal. `as_posix` in the task is what makes
+      # its output identical on Windows, so a regression there shows up as a diff a reader
+      # can see rather than a crash.
       - name: CLI smoke (the layer the suite stubs)
         if: ${{ !cancelled() }}
         run: |
           uv run --python ${{ matrix.python-version }} rhiza-task list
           uv run --python ${{ matrix.python-version }} rhiza-task doctor
+          uv run --python ${{ matrix.python-version }} rhiza-task todos
 
   # ruff.toml is 9 KB of deliberate rule selection, and this job is not the only thing
   # enforcing it: `.pre-commit-config.yaml` carries the same ruff hooks, so `rhiza-task
@@ -146,6 +161,101 @@ jobs:
       # would only assert that this repo is something it is not.
       - name: rhiza-task all
         run: uv run rhiza-task all
+
+      # `complexity` is deliberately outside `all` -- tasks/python.py says why, in one line:
+      # `all` is what every consumer's CI invokes, so adding a prerequisite to it would fail
+      # builds in repositories that changed nothing. So this repository opts in by naming it
+      # here, which is the mechanism a consumer would use too.
+      #
+      # It is what turns the ceiling in config.py's `__post_init__` note from discipline into
+      # a gate. That note commits to a number -- C (15) -- and until this step nothing read
+      # it back; `uvx radon cc src -a -s` was a command a human had to remember to run. The
+      # figure is currently 13, so there is real headroom, which is exactly when a gate is
+      # worth adding rather than after it has been crossed.
+      #
+      # `!cancelled()` for the reason the ruff job's two halves have it: a complexity finding
+      # and a gate failure are independent, and reporting one at a time costs a round trip.
+      - name: rhiza-task complexity
+        if: ${{ !cancelled() }}
+        run: uv run rhiza-task complexity
+
+  # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
+  # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four
+  # entry points and the tests assert on what would have run. That is the point of the
+  # package and not a shortcut -- but it means a vector that is well-formed and *wrong*, a
+  # flag cargo rejects or a subcommand renamed upstream, passes every gate in this
+  # repository and breaks in the first consumer that has the toolchain installed.
+  #
+  # `rhiza-task all` in the `gates` job covers the Python eight end-to-end. These two jobs
+  # are the missing half, and they matter because "one set of task names across Python, Rust
+  # and Go" is the package's headline claim -- the half with no end-to-end assertion was the
+  # half being advertised.
+  #
+  # No toolchain action, deliberately: ubuntu-latest ships rustup, cargo, clippy and go
+  # already, and what is under test is whether the vector is a command the real binary
+  # accepts -- not whether it accepts it on one pinned version. A pin belongs here the day a
+  # vector turns out to be version-sensitive, and not before; adding one now would be a
+  # third place to bump for no signal.
+  #
+  # Scope is deliberately the tasks whose prerequisites provision nothing. `go:typecheck`
+  # wants five `go install`s and `rust:test` wants cargo-binstall plus four cargo
+  # subcommands; each would add minutes per run to assert one more vector. The failure mode
+  # being guarded against is "the vector is not the command the tool accepts", and one real
+  # invocation per tool catches it.
+  go-layer:
+    name: go tasks against a real toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # A throwaway module rather than a fixture committed here: it must live outside this
+      # repository, because a go.mod inside it would make `detect_layers` report this
+      # repository as a Go project and change what every other gate resolves.
+      - name: Build a throwaway Go module
+        run: |
+          mkdir -p "$RUNNER_TEMP/gomod"
+          cd "$RUNNER_TEMP/gomod"
+          printf 'module example.com/demo\n\ngo 1.21\n' > go.mod
+          printf 'package demo\n\n// Add returns the sum of a and b.\nfunc Add(a, b int) int {\n\treturn a + b\n}\n' > demo.go
+          printf 'package demo\n\nimport "testing"\n\nfunc TestAdd(t *testing.T) {\n\tif Add(1, 2) != 3 {\n\t\tt.Fatal("Add is wrong")\n\t}\n}\n' > demo_test.go
+
+      # `go:test` addresses the layer explicitly, which is the only way to reach a layer
+      # `lookup` did not pick -- and here it also documents which of the three `test` tasks
+      # is under test. It pulls in `go:install`, so this one command exercises `go mod
+      # download`, the hook-install skip on a repo with no .pre-commit-config.yaml, and `go
+      # test ./... -race -shuffle=on`.
+      - name: rhiza-task go:test
+        run: uv run rhiza-task go:test --root "$RUNNER_TEMP/gomod"
+
+  rust-layer:
+    name: cargo tasks against a real toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # `cargo new` rather than hand-written files, so the fixture is whatever the installed
+      # cargo considers a valid crate rather than whatever was true when this was written.
+      # Outside the repository for the reason the Go job gives about go.mod.
+      # Not `$RUNNER_TEMP/crate`: cargo takes the package name from the directory name and
+      # rejects `crate`, which is a Rust keyword. Caught by running this for real rather than
+      # by reading it.
+      - name: Build a throwaway crate
+        run: cargo new --lib "$RUNNER_TEMP/demo-crate"
+
+      # `rust:typecheck` pulls in `rust:install`, and the interesting vector there is not
+      # clippy: a fresh `cargo new` has no Cargo.lock, so `cargo fetch --locked` fails and
+      # the unlocked fallback runs. That fallback is rust.mk's `|| $(CARGO) fetch`, carried
+      # over rather than rediscovered, and this is the only place it executes for real.
+      - name: rhiza-task rust:typecheck
+        run: uv run rhiza-task rust:typecheck --root "$RUNNER_TEMP/demo-crate"
 
   # The floors in pyproject.toml -- typer>=0.15, rich>=13.0, python-dotenv>=1.0 -- are a
   # claim, and `--frozen` everywhere else means nothing tests it: the lockfile resolves

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -50,6 +50,46 @@ jobs:
       - name: Run the gates
         run: uv run rhiza-task test
 
+  # The complement of the 100 coverage floor, which pyproject.toml is careful to say does
+  # not claim what it looks like it claims: at 100 no statement is *unvisited*, and nothing
+  # asserts that any of them is meaningfully *asserted*. A floor that the suite already
+  # reaches cannot ratchet further, so mutation score is the only signal left on assertion
+  # quality -- and `mutation` was a registered, guarded, fully implemented gate that no
+  # workflow invoked.
+  #
+  # Weekly rather than per-PR, and non-blocking, for two reasons that pull the same way:
+  # mutmut re-runs the suite once per mutant, and a surviving mutant is a prompt to write an
+  # assertion rather than a reason to hold a PR. `mutation` is not a prerequisite of `all`
+  # either, so nothing else picks it up.
+  mutation:
+    name: mutation score
+    runs-on: ubuntu-latest
+    # Non-blocking on purpose: this reports, it does not gate. Remove this line to make a
+    # surviving mutant fail the run, and expect to write assertions before it is green.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # `uv run`, not `uvx rhiza-task@<pin>`, for the reason the job above gives: the CLI
+      # under test has to be the one in the tree.
+      - name: Run mutmut
+        run: uv run rhiza-task mutation
+
+      # The task moves mutmut's HTML report to _tests/mutation/html and reports the run's
+      # remembered status, so the report exists precisely when mutants survived -- which is
+      # when it is worth reading. `always()` because a red step is the interesting case.
+      - name: Upload the mutation report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-report
+          path: _tests/mutation
+          if-no-files-found: ignore
+
   # The README carries six badges and a dozen links -- to PyPI, to sibling repos, to the
   # uv and Ruff endpoints. Nothing else notices when one of them rots.
   link-check:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ keep working owns that `Makefile` itself and forwards each target to `uvx rhiza-
 | Python | `install` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Rust | `install` `cargo-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Go | `install` `go-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
-| Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` |
+| Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` `complexity` |
 | Testing extras | `benchmark` `hypothesis-test` `stress` `mutation` |
 | Book | `book` `serve` `marimo` `marimo-validate` |
 | Dev | `doctor` `clean` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,7 @@ exports one for every caller and deliberately leaves it empty for consumers, who
 | setting | default | what |
 |---|---|---|
 | `coverage_fail_under` | `90` | the coverage floor, enforced wherever `test` runs |
+| `complexity_max` | `15` | the cyclomatic-complexity ceiling `complexity` enforces |
 | `typechecker` | `ty` | `ty`, `mypy` or `both` |
 | `license_fail_on` | `("GPL", "LGPL", "AGPL")` | matched as **substrings** |
 | `license_ignore_packages` | `()` | packages exempt from the copyleft scan |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -89,9 +89,21 @@ and checks the floor itself.
 | `rhiza-test` | `install` | run the rhiza repository checks |
 | `test-pyproject` | `install` | run the `pyproject.toml` structure checks, verbosely |
 | `todos` | — | list every TODO, FIXME and HACK comment |
+| `complexity` | — | fail on a block above the cyclomatic-complexity ceiling |
 
 `fmt` skips without a `.pre-commit-config.yaml`, and `semgrep` without a
 `.rhiza/semgrep.yml`. Neither is a defect — see [Skip is an outcome](#skip-is-an-outcome).
+
+`complexity` is the one task in this section that is Python-only: it runs `radon`, so it is
+registered in the `python` layer even though it reads like a neutral gate. It measures every
+block in `source_folder` and fails when one scores above
+[`complexity_max`](configuration.md#gates-and-thresholds) (default `15`).
+
+It is deliberately **not** a prerequisite of `all`. `all` is the aggregate a consumer's CI
+invokes, so adding a gate to it would fail builds in repositories that changed nothing —
+name `complexity` in a workflow step to opt in, as this repository's `ci.yml` does. A repo
+whose blocks are larger should raise the ceiling rather than skip the gate; 15 suits a
+codebase that already argues its complex blocks in comments.
 
 `rhiza-test` runs the checks that used to live in a synced `.rhiza/tests/` folder, now
 provisioned as [`pytest-rhiza`](https://github.com/jebel-quant/pytest-rhiza). Which checks

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -154,6 +154,17 @@ class Config:
 
     coverage_fail_under: int = 90
 
+    # The ceiling the ``complexity`` gate enforces, as radon's own cyclomatic-complexity
+    # number rather than its A-F rank. A number and not a rank because rank C spans 11-20,
+    # which is too coarse to hold a decision: this repository's four deliberate C blocks
+    # sit at 12-14, and a gate that accepted the whole of C would accept 20 without anyone
+    # choosing it. 15 is what src/rhiza_task/config.py's own note commits to.
+    #
+    # Above the default rather than at it is the normal case for a consumer: 15 is a
+    # ceiling for a codebase that already argues its C blocks in comments, and a repo that
+    # does not should either raise it or not run the gate.
+    complexity_max: int = 15
+
     # ty | mypy | both. python.mk documents that ``both`` masks ty's exit status behind
     # mypy's, and jointview sets ``ty`` in .rhiza/.env for that reason. The shell ``case``
     # whose fourth branch validated this is replaced by __post_init__, so a typo now fails
@@ -227,23 +238,27 @@ class Config:
 
     root: Path = field(default_factory=Path.cwd)
 
-    # radon scores this method C (12): one branch per field that needs normalising or
+    # radon scores this method C (13): one branch per field that needs normalising or
     # checking -- str and list coercion, layer defaulting and membership, rhiza_checks
-    # defaulting, typechecker, coverage_fail_under. It is a flat sequence, one field per
-    # step, with no interaction between the steps; the count grows with the number of
-    # validated settings and not with the depth of anything. Deliberate.
+    # defaulting, typechecker, coverage_fail_under, complexity_max. It is a flat sequence,
+    # one field per step, with no interaction between the steps; the count grows with the
+    # number of validated settings and not with the depth of anything. Deliberate.
     #
     # Unlike the other three C blocks here, that growth rule needs a stated ceiling, and
     # the ceiling is **C (15)**. `_run_one` is bounded by the size of `Status` and
     # `Guard.check` by the number of guard kinds -- closed sets, so their figures cannot
     # drift far. "One branch per validated setting" is not a closed set: every future
     # setting adds one, and a justification with no limit is an open licence rather than a
-    # decision. At 15 -- roughly three more settings -- the flat form stops paying for
+    # decision. At 15 -- roughly two more settings -- the flat form stops paying for
     # itself, and the answer is per-group helpers (`_validate_layers`,
     # `_validate_typechecker`, `_validate_coverage`) called in sequence from here, which
     # keeps the readable one-field-per-step order while bounding each block.
     #
-    # `uvx radon cc src -a -s` is the check; nothing gates it, so this is discipline.
+    # 12 became 13 when `complexity_max` arrived -- the setting that configures the gate
+    # now watching this number, which is the point rather than an irony: `rhiza-task
+    # complexity` is what turns the paragraph above from discipline into a gate, so the
+    # next setting to cross 15 fails a build instead of going unnoticed. `uvx radon cc src
+    # -a -s` remains the way to read the figure by hand.
     def __post_init__(self) -> None:
         """Normalise the list fields, then validate the enumerated and numeric ones.
 
@@ -262,8 +277,9 @@ class Config:
 
         Raises:
             ValueError: When ``typechecker`` is not one of ty, mypy, both,
-                ``coverage_fail_under`` is outside 0-100, ``layers`` names a layer that
-                does not exist, or a ``*_folder`` escapes :attr:`root`.
+                ``coverage_fail_under`` is outside 0-100, ``complexity_max`` is below 1,
+                ``layers`` names a layer that does not exist, or a ``*_folder`` escapes
+                :attr:`root`.
         """
         for f in fields(self):
             if str(f.type).replace(" ", "") != "tuple[str,...]":
@@ -288,6 +304,9 @@ class Config:
             raise ValueError(msg)
         if not 0 <= int(self.coverage_fail_under) <= 100:
             msg = f"coverage_fail_under must be a percentage (got {self.coverage_fail_under!r})"
+            raise ValueError(msg)
+        if int(self.complexity_max) < 1:
+            msg = f"complexity_max must be at least 1 (got {self.complexity_max!r})"
             raise ValueError(msg)
 
         self._validate_folders()

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -278,8 +278,8 @@ class Config:
         Raises:
             ValueError: When ``typechecker`` is not one of ty, mypy, both,
                 ``coverage_fail_under`` is outside 0-100, ``complexity_max`` is below 1,
-                ``layers`` names a layer that does not exist, or a ``*_folder`` escapes
-                :attr:`root`.
+                ``layers`` names a layer that does not exist, :attr:`root` is not an
+                existing directory, or a ``*_folder`` escapes it.
         """
         for f in fields(self):
             if str(f.type).replace(" ", "") != "tuple[str,...]":
@@ -309,7 +309,37 @@ class Config:
             msg = f"complexity_max must be at least 1 (got {self.complexity_max!r})"
             raise ValueError(msg)
 
+        # Two calls rather than two more `if`s, and not only for tidiness: this method is
+        # the one whose branch count has a stated ceiling, so validation that needs its own
+        # branches goes in a helper where it costs nothing here. A call is not a decision
+        # point, so `__post_init__` stays at C (13) with both of these in front of it.
+        self._validate_root()
         self._validate_folders()
+
+    def _validate_root(self) -> None:
+        """Reject a :attr:`root` that is not an existing directory.
+
+        Every other setting is validated here and this one was not, so a mistyped ``--root``
+        travelled all the way into a task body and surfaced as whatever the first tool did
+        with a working directory that is not there: ``FileNotFoundError`` from
+        ``subprocess._execute_child`` for a gate that shells out, ``NotADirectoryError`` from
+        ``Path._scandir`` for one that walks the tree. Both are tracebacks through a private
+        stdlib frame, and neither names the flag the user got wrong.
+
+        The two cases are separated because they are different mistakes: a path that is not
+        there is usually a typo, and a path that is a file is usually a missing ``dirname``.
+
+        Deliberately not folded into :meth:`_validate_folders`. That method asks whether a
+        *setting* escapes the root, which presupposes there is a root to escape -- so this
+        has to run first, and merging them would make one message answer two questions.
+
+        Raises:
+            ValueError: When ``root`` does not exist, or exists and is not a directory.
+        """
+        if not self.root.is_dir():
+            reason = "is not a directory" if self.root.exists() else "does not exist"
+            msg = f"root {str(self.root)!r} {reason}"
+            raise ValueError(msg)
 
     def _validate_folders(self) -> None:
         """Reject a ``*_folder`` setting that resolves outside :attr:`root`.

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -3,10 +3,15 @@
 python.mk is 312 lines, over half of the synced make. Most of it converts to the
 declarative form in :mod:`rhiza_task.spec`; ``test`` is the one recipe that does not, and
 it is written out in full below.
+
+``complexity`` is the one task here with no make ancestor. It lives in this module because
+radon is a Python tool and the gate is therefore Python-layer, even though its section is
+``Quality`` alongside the neutral gates it reads like.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
 
 from ..config import Config
@@ -351,6 +356,94 @@ def docs_coverage(cfg: Config) -> None:
     )
 
 
+@task(
+    "complexity",
+    "fail on a block above the cyclomatic-complexity ceiling",
+    section="Quality",
+    layer="python",
+    guards=(Guard("source_folder"),),
+)
+def complexity(cfg: Config) -> None:
+    """Fail when any block's cyclomatic complexity exceeds :attr:`Config.complexity_max`.
+
+    The one task here that is not a python.mk port. It exists because this repository's own
+    convention -- a C-ranked block carries a comment arguing why the flat form is preferred
+    -- committed to a *number* in ``config.py``, and nothing read it back. A stated ceiling
+    that only a human checks is the same shape as a doctest no gate executes: correct today,
+    stale-proof only by discipline, in the one place growth is expected.
+
+    Why the report goes through a file rather than a pipe: radon's verdict is a number per
+    block, so the gate has to read its output, and ``-O`` is how radon hands output to
+    something other than a terminal. That keeps the invocation a fixed argument vector with
+    no shell and no capturing variant of :func:`~rhiza_task.uv.uvx` -- the same reason every
+    other call in this package is one.
+
+    ``closures`` is deliberately not walked. radon only fills it under ``--show-closures``,
+    which is not passed, so a nested function's complexity is already counted in its
+    parent's -- walking the empty list would suggest a coverage this gate does not have.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When radon produced no report, so nothing was measured.
+        Failed: When at least one block is above the ceiling.
+    """
+    report = cfg.root / "_tests" / "complexity.json"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    # Stale data first, for the reason `test` unlinks `.coverage*`: a report left by an
+    # earlier run would be read as this run's verdict if radon failed to write.
+    report.unlink(missing_ok=True)
+
+    uvx("radon", "cc", cfg.source_folder, "--json", "--output-file", str(report), cwd=cfg.root)
+    if not report.is_file():
+        raise Skip("radon wrote no report")
+
+    over = _over_ceiling(json.loads(report.read_text()), cfg.complexity_max)
+    for label, score in over:
+        print(f"{label}: {score}")
+    if over:
+        raise Failed(1, f"{len(over)} block(s) above the complexity ceiling of {cfg.complexity_max}")
+    print(f"[INFO] no block above the complexity ceiling of {cfg.complexity_max}")
+
+
+def _over_ceiling(measured: dict[str, object], ceiling: int) -> list[tuple[str, int]]:
+    """Return the blocks above ``ceiling``, worst first.
+
+    radon keys its JSON by path, and the value is either a list of blocks or -- for a file
+    it could not parse -- a dict carrying an ``error``. The dict is skipped rather than
+    raised on: an unparseable file is ruff's finding to report, and failing the complexity
+    gate for it would put one syntax error behind two red gates.
+
+    Args:
+        measured: radon's parsed ``cc --json`` output.
+        ceiling: The highest complexity a block may have.
+
+    Returns:
+        ``(label, complexity)`` pairs, highest complexity first, then by label so the
+        ordering is total and the output is diffable between runs.
+    """
+    over: list[tuple[str, int]] = []
+    for path, blocks in measured.items():
+        if not isinstance(blocks, list):
+            continue
+        for block in blocks:
+            score = int(block["complexity"])
+            if score <= ceiling:
+                continue
+            qualified = f"{block['classname']}.{block['name']}" if block.get("classname") else block["name"]
+            over.append((f"{path}:{block['lineno']} {qualified}", score))
+    return sorted(over, key=lambda item: (-item[1], item[0]))
+
+
+# `complexity` is deliberately *not* a prerequisite below, and the reason is semver rather
+# than doubt about the gate. `all` is the aggregate every consumer's CI invokes, so adding a
+# prerequisite to it fails builds in repositories that changed nothing -- a breaking change
+# shipped as a feature. A consumer opts in by naming it, in `all`'s own `[tool.rhiza-task]`
+# repo or in a workflow step, and this repository does the latter in ci.yml's `gates` job.
+#
+# Stated here for the reason ci.yml states the same thing about `semgrep`: a reader has to
+# be able to tell "outside `all` on purpose" from "forgotten".
 @task(
     "all",
     "run every gate, as CI does",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,6 +272,18 @@ def test_invalid_coverage_threshold_fails_at_load(tmp_path: Path) -> None:
         Config.load(root=tmp_path, coverage_fail_under=900)
 
 
+@pytest.mark.parametrize("value", [0, -1])
+def test_invalid_complexity_ceiling_fails_at_load(tmp_path: Path, value: int) -> None:
+    """A complexity ceiling below 1 is rejected: no block can score less than 1.
+
+    Args:
+        tmp_path: The repository root.
+        value: A ceiling no block could ever satisfy.
+    """
+    with pytest.raises(ValueError, match="complexity_max must be at least 1"):
+        Config.load(root=tmp_path, complexity_max=value)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,6 +284,36 @@ def test_invalid_complexity_ceiling_fails_at_load(tmp_path: Path, value: int) ->
         Config.load(root=tmp_path, complexity_max=value)
 
 
+def test_a_root_that_does_not_exist_fails_at_load(tmp_path: Path) -> None:
+    """A mistyped ``--root`` is a usage error, not a traceback from inside a task.
+
+    Without this the path reached a task body and surfaced as whatever the first tool did
+    with a missing working directory -- ``FileNotFoundError`` from ``subprocess`` for a gate
+    that shells out, ``NotADirectoryError`` from ``Path._scandir`` for one that walks.
+
+    Args:
+        tmp_path: A directory to hang a non-existent child off, so the path is absolute and
+            the test cannot collide with anything real.
+    """
+    with pytest.raises(ValueError, match="does not exist"):
+        Config.load(root=tmp_path / "nope")
+
+
+def test_a_root_that_is_a_file_fails_at_load(tmp_path: Path) -> None:
+    """A root that exists but is a file is a different mistake, and says so.
+
+    Usually a missing ``dirname``, where "does not exist" would be actively misleading --
+    the path is right there.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text('[project]\nname = "d"\nversion = "0"\n')
+    with pytest.raises(ValueError, match="is not a directory"):
+        Config.load(root=manifest)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,6 +6,7 @@ the make recipes said in ``$$``-escaped shell.
 
 from __future__ import annotations
 
+import json
 import shutil
 from dataclasses import replace
 from pathlib import Path
@@ -742,3 +743,207 @@ class TestPyprojectStructure:
         for loud in ("--tb=long", "--showlocals", "-rA", "--durations=0", "--no-header"):
             assert loud in call.flags
         assert call.kwargs["withs"] == (cfg.pytest_rhiza,)
+
+
+class TestComplexity:
+    """The one Python-layer gate with no make ancestor.
+
+    Every other test here asserts the vector and stops, because the vector is the contract.
+    This gate reads a *value* back -- radon's per-block numbers -- so ``uvx`` is patched to
+    behave like radon and write a report, and the assertions are about the verdict the task
+    reaches from it. Same reason ``capture`` is patched for the Go coverage gate.
+    """
+
+    @staticmethod
+    def _radon(monkeypatch: pytest.MonkeyPatch, payload: object | None) -> list[tuple[str, ...]]:
+        """Patch ``uvx`` to write ``payload`` to the file the task's vector names.
+
+        Args:
+            monkeypatch: pytest's patcher.
+            payload: The object to serialise as radon's report, or None to write nothing --
+                which is how a radon that produced no output is simulated.
+
+        Returns:
+            The argument vectors the task passed, tool name first, in invocation order.
+        """
+        seen: list[tuple[str, ...]] = []
+
+        def fake(tool: str, *args: str, cwd: Path, **kwargs: object) -> int:
+            """Record the vector and stand in for radon's ``--output-file``.
+
+            Args:
+                tool: The tool name.
+                *args: Its arguments.
+                cwd: Working directory, unused.
+                **kwargs: Ignored.
+
+            Returns:
+                0, as a successful radon does.
+            """
+            seen.append((tool, *args))
+            if payload is not None:
+                Path(args[args.index("--output-file") + 1]).write_text(json.dumps(payload))
+            return 0
+
+        monkeypatch.setattr(python, "uvx", fake)
+        return seen
+
+    @staticmethod
+    def _block(name: str, score: int, line: int = 10, classname: str | None = None) -> dict[str, object]:
+        """Build one entry shaped like radon's JSON blocks.
+
+        Args:
+            name: The block's own name.
+            score: Its cyclomatic complexity.
+            line: The line it starts on.
+            classname: The owning class, for a method; omitted entirely for a function,
+                because radon omits the key rather than setting it to None.
+
+        Returns:
+            A block dict.
+        """
+        block: dict[str, object] = {"type": "function", "complexity": score, "lineno": line, "name": name}
+        if classname is not None:
+            block["classname"] = classname
+        return block
+
+    def test_asks_radon_for_json_in_a_file(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The vector names ``--json`` and an ``--output-file``, so nothing needs a pipe.
+
+        This is the assertion that keeps the gate free of a capturing ``uvx``: a change that
+        reached for a pipe instead would have to change this vector.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        seen = self._radon(monkeypatch, {})
+        python.complexity(cfg)
+        assert seen[0][:5] == ("radon", "cc", "src", "--json", "--output-file")
+        assert Path(seen[0][5]) == cfg.root / "_tests" / "complexity.json"
+
+    def test_passes_when_every_block_is_at_or_below_the_ceiling(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The ceiling is inclusive: a block *at* the maximum is not a finding.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        self._radon(monkeypatch, {"src/a.py": [self._block("wide", 15), self._block("narrow", 1)]})
+        python.complexity(replace(cfg, complexity_max=15))
+        assert "no block above the complexity ceiling of 15" in capsys.readouterr().out
+
+    def test_fails_on_a_block_above_the_ceiling(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """One block over the line fails the gate and is named with its file and line.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        self._radon(monkeypatch, {"src/a.py": [self._block("sprawling", 16, line=42)]})
+        with pytest.raises(Failed, match=r"1 block\(s\) above the complexity ceiling of 15"):
+            python.complexity(replace(cfg, complexity_max=15))
+        assert "src/a.py:42 sprawling: 16" in capsys.readouterr().out
+
+    def test_honours_a_raised_ceiling(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The ceiling is a setting, so a consumer that wants 20 gets 20.
+
+        The gate would be unusable outside this repository otherwise: 15 is a ceiling for a
+        codebase that already argues its C blocks in comments.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        self._radon(monkeypatch, {"src/a.py": [self._block("sprawling", 18)]})
+        python.complexity(replace(cfg, complexity_max=20))
+
+    def test_reports_a_method_by_its_qualified_name(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A method reads as ``Class.method``, which is how radon's own text output reads.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        self._radon(monkeypatch, {"src/a.py": [self._block("check", 20, line=7, classname="Guard")]})
+        with pytest.raises(Failed):
+            python.complexity(cfg)
+        assert "src/a.py:7 Guard.check: 20" in capsys.readouterr().out
+
+    def test_orders_the_worst_block_first(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Findings are ordered by complexity, then by label, so the output is diffable.
+
+        The tie-break matters: dict order follows radon's file walk, so without it the same
+        two findings could swap places between runs and read as a change.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        self._radon(
+            monkeypatch,
+            {
+                "src/b.py": [self._block("tie", 17)],
+                "src/a.py": [self._block("worst", 30), self._block("tie", 17)],
+            },
+        )
+        with pytest.raises(Failed, match="3 block"):
+            python.complexity(cfg)
+        lines = [line for line in capsys.readouterr().out.splitlines() if line.startswith("src/")]
+        assert [line.rsplit(": ", 1)[1] for line in lines] == ["30", "17", "17"]
+        assert lines[1].startswith("src/a.py")
+
+    def test_skips_a_file_radon_could_not_parse(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unparseable file is an error dict, not a list, and is not this gate's finding.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        self._radon(monkeypatch, {"src/broken.py": {"error": "invalid syntax"}})
+        python.complexity(cfg)
+        assert "no block above the complexity ceiling" in capsys.readouterr().out
+
+    def test_skips_when_radon_wrote_no_report(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nothing measured is a skip, not a pass -- ``--strict`` is what promotes it.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        self._radon(monkeypatch, None)
+        with pytest.raises(Skip, match="radon wrote no report"):
+            python.complexity(cfg)
+
+    def test_discards_a_report_left_by_an_earlier_run(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stale report is removed before radon runs, so it cannot be read as this verdict.
+
+        Reaching Skip rather than Failed is the assertion: the pre-written report says a
+        block scores 99, and a gate that re-read it would fail instead.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        stale = cfg.root / "_tests" / "complexity.json"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text(json.dumps({"src/a.py": [self._block("sprawling", 99)]}))
+
+        self._radon(monkeypatch, None)
+        with pytest.raises(Skip):
+            python.complexity(cfg)


### PR DESCRIPTION
Closes #81, closes #82, closes #83, closes #84.

Four findings from a `/rhiza:quality` run. Each was a gate that existed on paper and was invoked by nothing.

## #81 — Rust and Go tasks run against a real toolchain

`tasks/rust.py` and `tasks/go.py` are 165 statements at 100% coverage, and every one of those statements was covered by an *argument-vector assertion*. That is the point of the package, not a shortcut — but it meant a vector that is well-formed and **wrong** (a flag `cargo` rejects, a subcommand renamed upstream) passed every gate here and broke in the first consumer with the toolchain installed. `grep -rniE "cargo|setup-go" .github/workflows/` returned nothing.

Two new jobs, `go-layer` and `rust-layer`, over a throwaway module and crate. Notes on the choices, all recorded in the workflow comments:

- **No toolchain action.** `ubuntu-latest` already ships rustup, cargo, clippy and go. What is under test is whether the vector is a command the real binary accepts, not whether it accepts it on one pinned version. A pin belongs there the day a vector turns out to be version-sensitive — adding one now is a third place to bump for no signal.
- **The fixture lives outside the repo.** A `go.mod` inside it would make `detect_layers` report this repository as a Go project and change what every other gate resolves.
- **Scope is the tasks whose prerequisites provision nothing.** `go:typecheck` wants five `go install`s and `rust:test` wants cargo-binstall plus four subcommands; each would add minutes to assert one more vector.

Running it for real caught what reading it would not: `cargo new` takes the package name from the directory and **rejects `crate`**, which is a Rust keyword.

`rust:typecheck` turned out to be the better-value target than it looks — it pulls in `rust:install`, and a fresh crate has no `Cargo.lock`, so `cargo fetch --locked` fails and the unlocked fallback runs. That fallback is rust.mk's `|| $(CARGO) fetch`, carried over rather than rediscovered, and this is the only place it executes for real.

## #82 — `mutation` runs weekly

`pyproject.toml` is careful to say the 100 floor does not claim what it looks like it claims: no statement is *unvisited*, and nothing asserts that any of them is meaningfully *asserted*. A floor the suite already reaches cannot ratchet further, so mutation score is the only signal left on assertion quality — and `mutation` was registered, guarded, fully implemented, and invoked by nothing.

`continue-on-error: true`, with the report uploaded on `always()`. A surviving mutant is a prompt to write an assertion, not a reason to hold a PR; the task already moves mutmut's HTML report and reports the run's remembered status, so the report exists precisely when it is worth reading. Remove that one line to make it blocking.

## #83 — `rhiza-task complexity` gates the stated ceiling

`config.py`'s `__post_init__` note commits to a number — **C (15)** — and nothing read it back. `uvx radon cc src -a -s` was a command a human had to remember to run, which is the same shape as a doctest no gate executes.

- radon writes JSON to `--output-file`, so the gate stays a fixed argument vector with no shell and **no capturing variant of `uvx`**. There is a test asserting that vector, so a change reaching for a pipe has to change it.
- The ceiling is `complexity_max` (default 15), resolved through the normal six layers. Without that the package would impose 15 on every consumer, which is what `[tool.rhiza-task]` exists to avoid.
- **Deliberately not a prerequisite of `all`.** `all` is the aggregate every consumer's CI invokes, so adding a gate to it would fail builds in repositories that changed nothing — a breaking change shipped as a feature. This repo opts in with a `ci.yml` step, which is the mechanism a consumer would use. Stated in `tasks/python.py` for the reason `ci.yml` states the same about `semgrep`: a reader has to be able to tell "outside `all` on purpose" from "forgotten".
- An unparseable file is radon's error dict rather than a list, and is skipped — that is ruff's finding to report, and failing here would put one syntax error behind two red gates.

**The new setting takes `__post_init__` from C (12) to C (13)** — one branch per validated setting, exactly as its own comment predicts. That is the point rather than an irony: the next setting to cross 15 now fails a build instead of going unnoticed. The comment is updated with the new figure and the revised headroom.

## #84 — the Windows/macOS smoke runs a task body

`list` walks the registry and `doctor` resolves binaries, but neither enters a `run` — so `cfg.root` path handling, `as_posix` and guard evaluation were still ubuntu-only, because `rhiza-task all` runs there and nowhere else. `todos` provisions nothing and reads the tree, which keeps this a smoke step rather than the gate suite.

## Gates

| gate | result |
|---|---|
| `rhiza-task all` | **green** (fmt, deps, test, docs-coverage, security, license, typecheck, rhiza-test) |
| `test` | **312 passed**, coverage **100% of 1118 statements** |
| `complexity` | clean at the 15 ceiling; worst block C (14) |
| doc examples | 39 executed, 0 failed; 6/9 README fences ok |
| test-layout parity | documented opt-out, exit 0 |

Also verified the Go and Rust vectors end-to-end **locally**, since this machine has both toolchains — `go:test` and `rust:typecheck` both pass, so the two new jobs are running commands already known to work rather than a guess.

## One thing found while building this, fixed separately

`rhiza-task <task> --root /does/not/exist` crashed with an unhandled `FileNotFoundError` traceback instead of a clean usage error — found while building the `--root` fixtures for #81, which is the first thing here to pass that flag in anger. Fixed in **#86**, stacked on this branch (it touches `config.py` and `tests/test_config.py`, which this PR also touches). Review order: this one, then #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
