### PR TITLE
Reject a --root that is not an existing directory

### DIFF
--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -278,8 +278,8 @@ class Config:
         Raises:
             ValueError: When ``typechecker`` is not one of ty, mypy, both,
                 ``coverage_fail_under`` is outside 0-100, ``complexity_max`` is below 1,
-                ``layers`` names a layer that does not exist, or a ``*_folder`` escapes
-                :attr:`root`.
+                ``layers`` names a layer that does not exist, :attr:`root` is not an
+                existing directory, or a ``*_folder`` escapes it.
         """
         for f in fields(self):
             if str(f.type).replace(" ", "") != "tuple[str,...]":
@@ -309,7 +309,37 @@ class Config:
             msg = f"complexity_max must be at least 1 (got {self.complexity_max!r})"
             raise ValueError(msg)
 
+        # Two calls rather than two more `if`s, and not only for tidiness: this method is
+        # the one whose branch count has a stated ceiling, so validation that needs its own
+        # branches goes in a helper where it costs nothing here. A call is not a decision
+        # point, so `__post_init__` stays at C (13) with both of these in front of it.
+        self._validate_root()
         self._validate_folders()
+
+    def _validate_root(self) -> None:
+        """Reject a :attr:`root` that is not an existing directory.
+
+        Every other setting is validated here and this one was not, so a mistyped ``--root``
+        travelled all the way into a task body and surfaced as whatever the first tool did
+        with a working directory that is not there: ``FileNotFoundError`` from
+        ``subprocess._execute_child`` for a gate that shells out, ``NotADirectoryError`` from
+        ``Path._scandir`` for one that walks the tree. Both are tracebacks through a private
+        stdlib frame, and neither names the flag the user got wrong.
+
+        The two cases are separated because they are different mistakes: a path that is not
+        there is usually a typo, and a path that is a file is usually a missing ``dirname``.
+
+        Deliberately not folded into :meth:`_validate_folders`. That method asks whether a
+        *setting* escapes the root, which presupposes there is a root to escape -- so this
+        has to run first, and merging them would make one message answer two questions.
+
+        Raises:
+            ValueError: When ``root`` does not exist, or exists and is not a directory.
+        """
+        if not self.root.is_dir():
+            reason = "is not a directory" if self.root.exists() else "does not exist"
+            msg = f"root {str(self.root)!r} {reason}"
+            raise ValueError(msg)
 
     def _validate_folders(self) -> None:
         """Reject a ``*_folder`` setting that resolves outside :attr:`root`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,6 +284,36 @@ def test_invalid_complexity_ceiling_fails_at_load(tmp_path: Path, value: int) ->
         Config.load(root=tmp_path, complexity_max=value)
 
 
+def test_a_root_that_does_not_exist_fails_at_load(tmp_path: Path) -> None:
+    """A mistyped ``--root`` is a usage error, not a traceback from inside a task.
+
+    Without this the path reached a task body and surfaced as whatever the first tool did
+    with a missing working directory -- ``FileNotFoundError`` from ``subprocess`` for a gate
+    that shells out, ``NotADirectoryError`` from ``Path._scandir`` for one that walks.
+
+    Args:
+        tmp_path: A directory to hang a non-existent child off, so the path is absolute and
+            the test cannot collide with anything real.
+    """
+    with pytest.raises(ValueError, match="does not exist"):
+        Config.load(root=tmp_path / "nope")
+
+
+def test_a_root_that_is_a_file_fails_at_load(tmp_path: Path) -> None:
+    """A root that exists but is a file is a different mistake, and says so.
+
+    Usually a missing ``dirname``, where "does not exist" would be actively misleading --
+    the path is right there.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text('[project]\nname = "d"\nversion = "0"\n')
+    with pytest.raises(ValueError, match="is not a directory"):
+        Config.load(root=manifest)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
Stacked on #85 — based on `fix/quality-findings-81-84` rather than `main`, because both branches touch `config.py` and `tests/test_config.py`. GitHub retargets this to `main` automatically when #85 merges.

## The bug

`rhiza-task <task> --root /does/not/exist` exited with a traceback through a private stdlib frame instead of a usage error. Found while building the `--root` fixtures for the Rust and Go end-to-end jobs in #85, which is the first thing in this repository to pass the flag in anger.

Every other setting is validated in `__post_init__` and this one was not, so the path travelled all the way into a task body and surfaced as whatever the first tool did with a working directory that is not there:

```
$ rhiza-task todos --root /does/not/exist
FileNotFoundError: [Errno 2] No such file or directory: '/does/not/exist'
  ...  Path._scandir                     # a gate that walks the tree

$ rhiza-task rust:typecheck --root /nope
FileNotFoundError: [Errno 2] ...
  ...  subprocess._execute_child         # a gate that shells out
```

Neither names the flag the user got wrong.

## After

```
$ rhiza-task todos --root /does/not/exist
root '/does/not/exist' does not exist

$ rhiza-task todos --root README.md
root '/.../README.md' is not a directory
```

Exit code **2**, confirmed — the usage-error status `run_tasks`' docstring already documents.

## Three choices worth reviewing

- **`ValueError`, not a new exception type.** It reaches the `except ValueError -> Exit(2)` handler `cli.py` already has, which `test_invalid_config_exits_two` already covers. The new error rides a tested path rather than adding a second one.
- **A helper called from `__post_init__`, not two more `if`s in it.** That method is the one with a stated complexity ceiling (C 15, currently at 13). A call is not a decision point, so it stays at **C (13)** with this in front of it — confirmed by `rhiza-task complexity`, the gate #85 adds. This is that gate earning its keep on the first change after it landed.
- **Not folded into `_validate_folders`.** That method asks whether a *setting* escapes the root, which presupposes there is a root to escape — so this has to run first, and merging them would make one message answer two questions.

The two failure cases are reported separately because they are different mistakes: a path that is not there is usually a typo, and a path that is a file is usually a missing `dirname`, where "does not exist" would be actively misleading — the path is right there.

## Scope

`--root` is the only way in. `RHIZA_ROOT` is not a config layer for this field (verified: it is ignored), and the default is `Path.cwd()`, which exists by construction.

## Gates

| gate | result |
|---|---|
| `rhiza-task all` | **green** |
| `test` | **314 passed**, coverage **100%** |
| `complexity` | clean; `__post_init__` unchanged at C (13) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)