### PR TITLE
Stop publishing local build paths in the book's reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,19 @@ version = "{current_version}\""""
 replace = """name = "rhiza-task"
 version = "{new_version}\""""
 
+# `relative_files` makes coverage record paths relative to the project rather than absolute.
+# Without it every artefact carries the build machine's layout: `coverage.xml`'s Cobertura
+# `<source>` element held `/Users/<someone>/repos/.../src`, and `rhiza-task book` publishes
+# that file to GitHub Pages. It also matters off the book -- a Codecov upload and genbadge
+# both read this file, and an absolute source root is what makes a report from one machine
+# disagree with the same report from another.
+#
+# There is no CLI flag for it, deliberately on coverage's side: it changes how data is
+# *stored*, so it has to be set before measurement rather than at report time. That is why
+# this is repo config and not something `coverage_args` in tasks/python.py could pass.
+[tool.coverage.run]
+relative_files = true
+
 [tool.deptry.package_module_name_map]
 # python-dotenv installs a module called `dotenv`. deptry runs isolated via `uvx`, so the
 # package is not importable and it cannot discover the mapping itself -- it guesses

--- a/src/rhiza_task/tasks/book.py
+++ b/src/rhiza_task/tasks/book.py
@@ -226,6 +226,59 @@ def _copy_reports(cfg: Config) -> None:
     destination = cfg.root / "docs" / "reports"
     destination.mkdir(parents=True, exist_ok=True)
     shutil.copytree(reports, destination, dirs_exist_ok=True)
+    _scrub_local_paths(cfg.root, destination)
+
+
+SCRUBBED_SUFFIXES = (".html", ".htm", ".xml", ".json", ".js", ".css", ".txt", ".svg")
+"""Which report files are rewritten. Text formats only, so no binary is touched."""
+
+
+def _scrub_local_paths(root: Path, destination: Path) -> None:
+    """Mask absolute build paths in the *published* copy of the reports.
+
+    A report is written for the machine that produced it and then published to the web,
+    which is a change of audience nothing in the toolchain notices. Two paths leak:
+
+    * the repository root, which pytest records as its ``rootdir``;
+    * the home directory, because pytest-xdist stamps every test with the worker banner
+      ``[gw0] darwin -- Python 3.11.15 <interpreter>``, and under ``uv run --with`` that
+      interpreter lives in the user's uv cache. In this repository that was 300-odd
+      occurrences in one ``report.html``.
+
+    Neither is fixable upstream from here. coverage's own ``relative_files`` handles the
+    coverage artefacts and is set in ``pyproject.toml``; the xdist banner has no setting,
+    and dropping ``-n auto`` to avoid it would slow every consumer's suite to protect a
+    report. So the copy is rewritten and ``_tests/`` is left exactly as produced, which is
+    what a developer reads locally and where absolute paths are the useful form.
+
+    Ordering matters: the root is replaced before the home directory, because on CI the
+    root lives *inside* it and masking the shorter prefix first would leave a half-path.
+
+    Known limit: matching is textual, so a Windows path embedded in JSON arrives
+    backslash-escaped and is not recognised. The gate that publishes a book runs on Linux,
+    so this is a real gap rather than a closed one.
+
+    Args:
+        root: The repository root, as the reports spell it.
+        destination: The published copy, under ``docs/``.
+    """
+    # `Path.home()` rather than $HOME: on Windows the variable is often unset, and the
+    # masking has to be harmless there rather than crash.
+    masks = ((str(root), "."), (str(Path.home()), "~"))
+    for path in sorted(destination.rglob("*")):
+        if not path.is_file() or not path.name.endswith(SCRUBBED_SUFFIXES):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A report file that cannot be read as text is one this function has no opinion
+            # about; skipping it must not cost the book its build.
+            continue
+        scrubbed = text
+        for absolute, mask in masks:
+            scrubbed = scrubbed.replace(absolute, mask)
+        if scrubbed != text:
+            path.write_text(scrubbed, encoding="utf-8")
 
 
 def _export_notebooks(cfg: Config) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -632,6 +632,79 @@ class TestBook:
         book_tasks.book(cfg)
         assert not (cfg.path("book_output") / "paper").exists()
 
+    def test_masks_build_paths_in_the_published_reports(self, cfg: Config, recorder: Recorder) -> None:
+        """The published copy carries no absolute paths; ``_tests/`` keeps them.
+
+        A report is written for the machine that produced it and then published to the web.
+        pytest records the repository root as its ``rootdir``, and pytest-xdist stamps every
+        test with a worker banner naming the interpreter -- which under ``uv run --with``
+        sits in the user's home. Both are masked in the copy, and deliberately left alone in
+        ``_tests/``, which is what a developer reads locally.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        reports = cfg.root / "_tests"
+        reports.mkdir()
+        banner = f"[gw0] linux -- Python 3.11.15 {Path.home()}/.cache/uv/bin/python"
+        original = f"rootdir: {cfg.root}\n{banner}\n"
+        (reports / "report.html").write_text(original)
+        (reports / "coverage.xml").write_text(f"<source>{cfg.root}/src</source>")
+
+        book_tasks.book(cfg)
+
+        published = cfg.root / "docs" / "reports"
+        scrubbed = (published / "report.html").read_text()
+        assert str(cfg.root) not in scrubbed
+        assert str(Path.home()) not in scrubbed
+        assert "rootdir: ." in scrubbed
+        assert "~/.cache/uv/bin/python" in scrubbed
+        assert (published / "coverage.xml").read_text() == "<source>./src</source>"
+
+        # The source of truth for a local reader is untouched.
+        assert (reports / "report.html").read_text() == original
+
+    def test_leaves_binary_and_unreadable_report_files_alone(self, cfg: Config, recorder: Recorder) -> None:
+        """A report file that is not decodable UTF-8 is skipped, not fatal.
+
+        The report tree carries PNGs and icons beside its HTML. Those are excluded by suffix
+        already, but a ``.json`` or ``.html`` that turns out to be undecodable must not cost
+        the book its build -- publishing is not the place to fail on somebody else's artefact.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        reports = cfg.root / "_tests"
+        reports.mkdir()
+        (reports / "broken.json").write_bytes(b"\xff\xfe not utf-8 \x00")
+        (reports / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        book_tasks.book(cfg)
+
+        published = cfg.root / "docs" / "reports"
+        assert (published / "broken.json").read_bytes() == b"\xff\xfe not utf-8 \x00"
+        assert (published / "logo.png").is_file()
+
+    def test_rewrites_only_the_files_that_carry_a_path(self, cfg: Config, recorder: Recorder) -> None:
+        """A report with nothing to mask is left byte-identical rather than rewritten.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        reports = cfg.root / "_tests"
+        reports.mkdir()
+        (reports / "clean.html").write_text("<p>nothing absolute here</p>")
+
+        book_tasks.book(cfg)
+
+        assert (cfg.root / "docs" / "reports" / "clean.html").read_text() == "<p>nothing absolute here</p>"
+
     def test_skips_without_a_mkdocs_config(self, cfg: Config, recorder: Recorder) -> None:
         """No ``mkdocs.yml``, nothing to build.
 


### PR DESCRIPTION
Stacked on #87 — based on `docs/paper` rather than `main`, because both branches touch `src/rhiza_task/tasks/book.py`. GitHub retargets this to `main` when #87 merges.

Follow-up to the note at the end of #87: the published reports still carried absolute paths from the build machine.

## Two leaks, two different fixes

The reports are written *for the machine that produced them* and then published to the web. That change of audience is invisible to the toolchain. Only one of the two leaks has an upstream setting, which is why this isn't one change.

### `coverage.xml` — fixed at the source

It carried `<source>/Users/<someone>/repos/.../src</source>`. coverage.py's own answer is **`relative_files`**, now set in `pyproject.toml`; it emits `<source>src</source>`.

There is deliberately no CLI flag for it — it changes how data is *stored*, so it must be set before measurement, which is why this is repo config and not something `coverage_args` in `tasks/python.py` could pass. It also matters away from the book: `genbadge` and any Codecov upload read the same file, and an absolute source root is what makes one machine's report disagree with another's.

### `report.html` — masked at publish time

It carried the home directory **~300 times, once per test**.

I first assumed metadata, and that was wrong — worth recording because it changed the fix. It is pytest-**xdist**'s per-test worker banner:

```
[gw0] darwin -- Python 3.11.15 /Users/<someone>/.cache/uv/builds-v0/.tmpXXXX/bin/python
```

Under `uv run --with`, that interpreter lives in the user's uv cache. A `pytest_metadata` hook — my first instinct — would not have touched it. I found it by grepping the surrounding characters instead of guessing.

That leak has no setting, and dropping `-n auto` to avoid it would slow every consumer's suite to protect a report. So `book` masks paths as it copies the tree into `docs/`: root → `.`, home → `~`. **Root first**, because on CI the root lives *inside* home, and masking the shorter prefix first would leave a half-path.

## `_tests/` is deliberately untouched

Only the published copy has the wrong audience. `_tests/` is what a developer reads locally, and there the absolute paths are the *useful* form — they are clickable. Asserted in a test, so a future change cannot quietly scrub both.

## Honest about its edges

Documented in the docstring rather than implied away:

- **Text suffixes only**, so no binary is touched.
- **An undecodable file is skipped, not fatal** — publishing is not the place to fail on somebody else's artefact.
- **Matching is textual**, so a Windows path embedded in JSON arrives backslash-escaped and is missed. The gate that publishes a book runs on Linux, so this is a real gap rather than a closed one.

## The floor did its job

The 100% coverage floor caught the three uncovered branches in the new helper before I did — which is the argument for the floor in one line.

## Verified end-to-end

Built the book and grepped the entire site for `$HOME`: **nothing**. The banner now reads `~/.cache/uv/...`, `coverage.xml` reads `<source>src</source>`, the paper is still published, and `_tests/` still has its absolute paths.

| gate | result |
|---|---|
| `rhiza-task all` | **green** |
| `test` | **309 passed**, coverage **100% of 1119 statements** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)