### PR TITLE
feat: gate the docs tree's fenced examples, and correct four drifted figures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,15 +169,40 @@ jobs:
       #
       # It is what turns the ceiling in config.py's `__post_init__` note from discipline into
       # a gate. That note commits to a number -- C (15) -- and until this step nothing read
-      # it back; `uvx radon cc src -a -s` was a command a human had to remember to run. The
-      # figure is currently 13, so there is real headroom, which is exactly when a gate is
-      # worth adding rather than after it has been crossed.
+      # it back; `uvx radon cc src -a -s` was a command a human had to remember to run.
+      #
+      # The figure the gate compares against that ceiling is the worst *block* radon reports,
+      # and radon's blocks include classes: the highest is currently the `Guard` class at
+      # C (14), one above `Guard.check` and `Config.__post_init__` at C (13). So the headroom
+      # is one, not the two settings' worth the `__post_init__` note's "roughly two more
+      # settings" might suggest -- that sentence is about how many *settings* fit before the
+      # flat form stops paying for itself, which is a different question from how much room
+      # the gate has left. Worth stating which number this tracks, because the class figure
+      # and the worst-function figure differ and only one of them fails the build.
       #
       # `!cancelled()` for the reason the ruff job's two halves have it: a complexity finding
       # and a gate failure are independent, and reporting one at a time costs a round trip.
       - name: rhiza-task complexity
         if: ${{ !cancelled() }}
         run: uv run rhiza-task complexity
+
+      # `docs-examples` is outside `all` for the same semver reason `complexity` is, and named
+      # here for the same reason: this is the mechanism a consumer would use to opt in.
+      #
+      # What it adds that no other gate here reaches: `docs-coverage` asks whether a docstring
+      # exists and markdownlint asks whether the markdown is well-formed, so the question
+      # "is what the documentation *claims* still true?" had one answer for `README.md` --
+      # pytest-rhiza's `test_readme_validation`, via `rhiza-test` -- and none at all for
+      # `docs/`, which holds the larger share of the fences and `getting_started.md` among
+      # them. That is the newcomer's first contact, and a stale command there renders
+      # perfectly right up to the moment it is run.
+      #
+      # `!cancelled()` for the reason the ruff job's two halves have it: a broken example and
+      # a failing gate are independent findings, and reporting one at a time costs a round
+      # trip per fix.
+      - name: rhiza-task docs-examples
+        if: ${{ !cancelled() }}
+        run: uv run rhiza-task docs-examples
 
   # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
   # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,9 @@ about working *on* it.
 
 ## This repository is not rhiza-managed
 
-There is no `.rhiza/` directory. Nothing here is synced from `jebel-quant/rhiza`, no file
-is template-owned, and **every file is locally owned and locally editable** — including
-`.github/workflows/`, `.pre-commit-config.yaml`, `ruff.toml` and `pytest.ini`, which in a
-managed repo would belong upstream.
+There is no `.rhiza/` directory, no file is template-owned, and **every file is locally
+owned and locally editable** — including `.github/workflows/`, `.pre-commit-config.yaml`,
+`ruff.toml` and `pytest.ini`, which in a managed repo would belong upstream.
 
 That is deliberate, and it is not an oversight to correct. This package is the thing that
 *replaces* the template's make layer: a repo that consumed the template would run its
@@ -27,6 +26,45 @@ is circular. Two visible consequences, both intended:
 
 `rhiza-test` and `test-pyproject` are *this repo's own* tasks running `pytest-rhiza`, and
 are unrelated to the absent template. Do not read them as evidence of a sync.
+
+### The two workflows that do reach upstream
+
+"Nothing is synced" is right; "nothing references `jebel-quant/rhiza`" would not be. Two
+workflow files are thin wrappers that `uses:` a reusable workflow from the template repo,
+and both still carry its `This file is part of the jebel-quant/rhiza repository` header:
+
+| file | delegates to | pin |
+|---|---|---|
+| `.github/workflows/rhiza_codeql.yml` | `rhiza/.github/workflows/rhiza_codeql.yml` | `31e1a11` (v1.4.2) |
+| `.github/workflows/rhiza_scorecard.yml` | `rhiza/.github/workflows/rhiza_scorecard.yml` | `31e1a11` (v1.4.2) |
+
+They are the odd ones out and it is worth knowing why they are tolerated. `rhiza_book.yml`,
+`rhiza_paper.yml` and `rhiza_release.yml` are *fully local* files with real jobs — the same
+name prefix, none of the delegation — so the pattern in this repo is to vendor, and these
+two have simply not been vendored.
+
+**This is not the circularity the section above forbids.** That one is specifically about
+*gates*: a repo whose gates run through a published copy of this package cannot test its
+own working tree. Neither delegated workflow invokes `rhiza-task`, `make` or `uv` at the
+pinned SHA — upstream's codeql is `codeql-action/init` plus `analyze` (its only `make`
+mention is inside a `build-mode == 'manual'` step that Python never takes, and which
+`exit 1`s if reached), and upstream's scorecard is `ossf/scorecard-action` plus
+`upload-sarif`. So no gate of this repository runs through a published `rhiza-task`.
+
+**What the SHA pin is holding back, though, is exactly that.** v1.4.2 is the template
+release that *retired the make layer*, which means upstream's gates now are `rhiza-task`.
+If a later release adds a `uvx rhiza-task` setup step to either workflow, a routine pin
+bump would make this repository gate itself with a published copy of itself, silently and
+for the first time. So the pin is load-bearing in a way a version pin usually is not:
+**before bumping either SHA, read the upstream workflow and check it still invokes no
+`rhiza-task`.** That is the review this table exists to prompt.
+
+Why not simply vendor them and be done: the delegation buys the *publish* half —
+`security-events: write`, `upload-sarif`, the Scorecard badge and API. Those are
+workflow-level `uses:` actions, so no task in this package can replace them, and a
+`rhiza-task codeql` or `rhiza-task scorecard` would complement these files rather than
+retire them. Vendoring remains the answer whenever the review above becomes tiresome; it
+is a copy of two short files, not a redesign.
 
 ## The layering invariant
 
@@ -95,6 +133,29 @@ where gating doctests is their call, and in `pytest.ini`'s `addopts` it would al
 `rhiza-test`'s `pytest --pyargs pytest_rhiza.checks.*` — gating a dependency's doctests in
 this repo's name.
 
+### The prose examples are gated too, and by a task rather than a test
+
+The same argument applied twice over to `docs/`. `README.md`'s fences were covered by
+pytest-rhiza's `test_readme_validation` under `rhiza-test`; the docs tree — 62 fences, 24 of
+them in `getting_started.md` — was covered by markdownlint asking whether the *markdown*
+parses, and by nothing asking whether the commands did. `rhiza-task docs-examples` is that
+gate, named by `ci.yml`'s `gates` job because, like `complexity`, it is deliberately not an
+`all` prerequisite.
+
+It is a **task and not a test**, and that placement is the rule in this repo rather than a
+preference: checking a shell fence means running `bash -n`, and no test here runs a tool. So
+the logic belongs in a task body, exactly as the note above about wanting a real subprocess
+in a test says. Its own tests then patch `bash` and `uv_run` and assert the vectors, like
+every other task's.
+
+Two things a change to `docs/` should know. A ```` ```result ```` block is **executed and
+diffed** against the `python` fences above it, so an example that goes stale fails a build
+rather than quietly outdating — and the prelude is every earlier `python` fence in that
+file, because `README.md`'s pair needs the first fence's `@task` before the second's
+`lookup`. And fences in a language it cannot check (`toml`, `mermaid`, `makefile`, `yaml`,
+and those carrying no language) are **reported with a count** rather than passed over in
+silence, because a green line with no numbers reads as full coverage.
+
 ## The coverage floor is 100, and it is load-bearing
 
 `[tool.rhiza-task] coverage_fail_under = 100` in `pyproject.toml`. `rhiza-task test` and
@@ -115,11 +176,20 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
 
 ## Where the gates run
 
-`ci.yml` has four jobs, and its comments explain each in detail. In short: a 12-cell
-`pytest` matrix (3 OS × Python 3.11–3.14 — **Windows is deliberate**, as the assertion that
-the shell dependency is gone), a `ruff` job, a `gates` job running the dogfood `uv run
-rhiza-task all`, and a `lowest-deps` job that resolves `--resolution lowest-direct` to prove
-the manifest's floors are real.
+`ci.yml` has six jobs, and its comments explain each in detail. In short:
+
+- **`test`** — a 12-cell `pytest` matrix (3 OS × Python 3.11–3.14). **Windows is
+  deliberate**, as the assertion that the shell dependency is gone, and the job carries a
+  CLI smoke step because the suite stubs every subprocess and so never starts the CLI.
+- **`lint`** — `ruff check` and `ruff format --check`, both halves always running.
+- **`gates`** — the dogfood `uv run rhiza-task all`, plus the two gates deliberately outside
+  `all`: `complexity` and `docs-examples`.
+- **`go-layer`** and **`rust-layer`** — the Rust and Go vectors against a *real* toolchain,
+  on a throwaway module built in `$RUNNER_TEMP`. These exist because those layers' coverage
+  is entirely argument-vector assertions, so a vector that is well-formed and *wrong* passes
+  every other gate here and breaks in the first consumer that has cargo or go installed.
+- **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
+  are real.
 
 Two things follow for a change to `pyproject.toml`:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ keep working owns that `Makefile` itself and forwards each target to `uvx rhiza-
 | Python | `install` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Rust | `install` `cargo-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Go | `install` `go-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
-| Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` `complexity` |
+| Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` `complexity` `docs-examples` |
 | Testing extras | `benchmark` `hypothesis-test` `stress` `mutation` |
 | Book | `book` `serve` `marimo` `marimo-validate` |
 | Dev | `doctor` `clean` |

--- a/docs/adding_a_task.md
+++ b/docs/adding_a_task.md
@@ -47,11 +47,16 @@ audit - run the in-house audit
 ('install',) source_folder Quality
 ```
 
-!!! tip "That example is executed, in the README"
-    The same pair of blocks lives in the repository's `README.md`, where `rhiza-task
-    rhiza-test` **runs the fence and diffs it against the `result` block**. A change to
-    `lookup`, to `Task`, or to the decorator breaks the README rather than quietly
-    outdating it. This page is a copy for reading; the README is the copy that is checked.
+!!! tip "That example is executed — here as well as in the README"
+    The pair above is **run and diffed against its `result` block**, by `rhiza-task
+    docs-examples` for this page and by `rhiza-task rhiza-test` for the copy in the
+    repository's `README.md`. A change to `lookup`, to `Task`, or to the decorator breaks
+    both rather than quietly outdating either.
+
+    It used to be only the README: this page said so, and said it was "a copy for reading".
+    That is what `docs-examples` was added to fix — every `python` and `bash` fence under
+    `docs/` is now checked too, so a stale command here fails a build instead of waiting
+    for a newcomer to run it.
 
 ## `@task` parameters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,7 @@ exports one for every caller and deliberately leaves it empty for consumers, who
 |---|---|---|
 | `source_folder` | `src` | the package tree the gates measure |
 | `tests_folder` | `tests` | the test tree |
+| `docs_folder` | `docs` | the prose docs tree, whose examples `docs-examples` checks |
 | `marimo_folder` | `docs/notebooks` | Marimo notebooks, exported into the book |
 | `book_output` | `_book` | where `book` writes the built site |
 | `python_version` | `3.13` | the interpreter tasks provision |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -90,9 +90,18 @@ and checks the floor itself.
 | `test-pyproject` | `install` | run the `pyproject.toml` structure checks, verbosely |
 | `todos` | — | list every TODO, FIXME and HACK comment |
 | `complexity` | — | fail on a block above the cyclomatic-complexity ceiling |
+| `docs-examples` | `install` | check the fenced examples in the docs tree |
 
-`fmt` skips without a `.pre-commit-config.yaml`, and `semgrep` without a
-`.rhiza/semgrep.yml`. Neither is a defect — see [Skip is an outcome](#skip-is-an-outcome).
+`fmt` skips without a `.pre-commit-config.yaml`, `semgrep` without a
+`.rhiza/semgrep.yml`, and `docs-examples` without a docs folder — or with one holding no
+fence it can check. None is a defect — see [Skip is an outcome](#skip-is-an-outcome).
+
+`docs-examples` parses every `python` fence with `compile`, every `bash` fence with
+`bash -n` — parsed, never executed — and runs the `python` fences that a ```result```
+block follows, diffing what they print against that block. Fences in any other language
+are reported as unchecked with a count, because silence there would read as full
+coverage. It answers the question no other gate does: not "is there a docstring?" but
+"is what the documentation claims still true?"
 
 `complexity` is the one task in this section that is Python-only: it runs `radon`, so it is
 registered in the `python` layer even though it reads like a neutral gate. It measures every
@@ -238,6 +247,9 @@ reader can tell "skipped deliberately" from "forgotten":
 
 - **`semgrep`** — no `all` names it. Upstream rhiza runs it on a weekly cadence, not per
   pull request.
+- **`complexity`** and **`docs-examples`** — adding either to `all` would fail builds in
+  repositories that changed nothing, so a repo opts in by naming it in its own CI, which
+  is what this one does.
 - **the bundle-owned sections** — none is a gate, as above.
 
 Anything else registered *is* in `all` for its layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,11 @@ python-dotenv = "dotenv"
 # order -- the package configuring itself with the mechanism it sells.
 #
 # The floor is 100, not the shipped default of 90 and no longer the 95 it passed through:
-# the suite now covers all 1080 statements in `src/`, and a floor below what the suite
-# already achieves is a ratchet that never catches anything. At 100 a new branch arrives
+# the suite covers every statement in `src/` -- 1234 of them at the time of writing -- and a
+# floor below what the suite already achieves is a ratchet that never catches anything.
+# The figure is incidental to the argument and moves with every commit, which is why it is
+# written as "at the time of writing" rather than as a claim the next branch invalidates;
+# `rhiza-task test` prints the current total. At 100 a new branch arrives
 # with the test that exercises it or the gate goes red. It is enforced wherever `test`
 # runs -- the `gates` job's `rhiza-task all` in CI, and every local invocation -- which is
 # what makes it a gate rather than a note.

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -148,6 +148,12 @@ class Config:
 
     source_folder: str = "src"
     tests_folder: str = "tests"
+    # The prose documentation tree, which ``docs-examples`` checks the fenced examples in.
+    # A setting rather than a literal ``docs`` for the reason every other folder here is
+    # one: ``marimo_folder`` and ``paper_folder`` already default to paths *inside* it, so a
+    # repo that keeps its documentation somewhere else would otherwise have to move two
+    # settings and hardcode the third.
+    docs_folder: str = "docs"
     marimo_folder: str = "docs/notebooks"
     book_output: str = "_book"
     python_version: str = "3.13"

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -21,10 +21,13 @@ import shutil
 # reads everything after that marker as a comma-separated list of test IDs, so a trailing
 # explanation becomes one `Test in comment:` warning per word.
 import subprocess  # nosec B404
+import textwrap
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..config import Config
-from ..spec import Guard, Skip, task
+from ..spec import Failed, Guard, Skip, task
 from ..uv import uv_run, uvx
 
 TODO_PATTERN = re.compile(r"\b(TODO|FIXME|HACK):")
@@ -47,6 +50,43 @@ TODO_SKIP_DIRS = frozenset(
 )
 
 CLEAN_ARTIFACTS = ("dist", "build", ".coverage", ".pytest_cache", ".benchmarks", "_tests", "_book")
+
+# Deliberately permissive about what follows the language: mkdocs-material accepts
+# ```python title="x", and an opening fence this pattern failed to match would have its
+# *closing* fence read as the next opening one, cascading the misparse through the rest of
+# the file. Matching any fence line and keeping only the first word cannot do that.
+DOC_FENCE_OPEN = re.compile(r"^(?P<indent>[ \t]*)```(?P<language>[^`\s]*)")
+# A closing fence carries nothing but backticks. A bare ``` therefore matches both patterns,
+# which is why :func:`_fences` tracks state instead of classifying lines independently.
+DOC_FENCE_CLOSE = re.compile(r"^[ \t]*```[ \t]*$")
+# `bash` and `sh` only. `console` and `shell-session` are excluded on purpose: their content
+# is a transcript -- prompts, output and all -- so `bash -n` would reject the very thing that
+# makes them correct. A language this set does not name is counted as unchecked and reported
+# rather than guessed at.
+SHELL_FENCE_LANGUAGES = frozenset({"bash", "sh"})
+PYTHON_FENCE_LANGUAGE = "python"
+# The convention README.md already uses and pytest-rhiza's `test_readme_validation` already
+# checks *there*: a ```result``` block holds the expected stdout of the python fence above it.
+RESULT_FENCE_LANGUAGE = "result"
+CHECKED_FENCE_LANGUAGES = SHELL_FENCE_LANGUAGES | {PYTHON_FENCE_LANGUAGE, RESULT_FENCE_LANGUAGE}
+
+
+@dataclass(frozen=True)
+class Fence:
+    """One fenced code block, located and dedented.
+
+    Attributes:
+        path: Repository-relative path, posix-separated, because this reaches report output
+            a reader pastes into an editor.
+        line: 1-based line number of the opening fence.
+        language: The info string's first word, lowercased; empty when the fence carries none.
+        code: The block's content, dedented.
+    """
+
+    path: str
+    line: int
+    language: str
+    code: str
 
 
 @task("fmt", "run the pre-commit hooks over all files", section="Quality")
@@ -191,6 +231,78 @@ def todos(cfg: Config) -> None:
     print(f"\n[INFO] {hits} item(s) found.")
 
 
+@task(
+    "docs-examples",
+    "check the fenced examples in the docs tree",
+    section="Quality",
+    needs=("install",),
+    guards=(Guard("docs_folder"),),
+)
+def docs_examples(cfg: Config) -> None:
+    """Parse every checkable fence under the docs folder, and diff the executed ones.
+
+    The gap this closes: ``docs-coverage`` asks whether a docstring *exists* and
+    markdownlint asks whether the markdown is *well-formed*. Neither asks whether what the
+    documentation **claims** is still true, and a stale command keeps rendering perfectly --
+    so the reader who finds out is a newcomer, at the worst moment. ``README.md`` was already
+    covered, by pytest-rhiza's ``test_readme_validation`` under :func:`rhiza_test`; the docs
+    tree had nothing, and it is the larger half.
+
+    Not a second check of ``README.md``, deliberately: that file is pytest-rhiza's subject,
+    and counting one verdict twice would make two gates report one fact.
+
+    Three kinds of fence are checked and the rest are counted:
+
+    * ``python`` -- :func:`compile`, so a fence that is a *fragment* still passes. Names need
+      not resolve; only the syntax is asserted.
+    * ``bash``/``sh`` -- ``bash -n``, which parses without executing. Never executed, because
+      a README's shell is routinely ``rm -rf`` and ``git push``, and an unparseable fence is a
+      documentation bug without running it.
+    * ``result`` -- executed and diffed against the python fences above it.
+
+    Anything else -- ``toml``, ``mermaid``, ``makefile``, ``yaml``, and fences carrying no
+    language at all -- is reported as unchecked. Naming the count is the point: silence there
+    would read as "everything was checked".
+
+    ``install`` is a prerequisite because the executed half imports the project's own
+    packages, exactly as :func:`rhiza_test`'s docstring check does.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When the tree holds no checkable fence, so nothing was measured. A docs tree
+            documenting nothing runnable would otherwise score a silent pass, which is the
+            failure this gate exists to make visible.
+        Failed: When at least one example is broken or stale.
+    """
+    scratch = cfg.root / "_tests" / "docs-examples"
+    scratch.mkdir(parents=True, exist_ok=True)
+    # Resolved once: `bash` is absent on a stock Windows runner, and its absence must leave
+    # the shell fences *unchecked and counted* rather than failing the gate for a fact about
+    # the machine. Same reasoning as `Guard(tool=...)` raising Skip rather than Failed.
+    bash = shutil.which("bash")
+
+    per_file = [
+        _fences(md.relative_to(cfg.root).as_posix(), md.read_text(errors="replace"))
+        for md in sorted(cfg.path("docs_folder").rglob("*.md"))
+    ]
+    fences = [fence for one_file in per_file for fence in one_file]
+
+    broken = [
+        *_syntax_violations(fences),
+        *(_shell_violations(fences, bash, scratch) if bash else []),
+        *_result_violations(per_file, cfg, scratch),
+    ]
+    for violation in broken:
+        print(violation)
+
+    if not _report(fences, bash, len(per_file)):
+        raise Skip(f"no checkable fence under {cfg.docs_folder}")
+    if broken:
+        raise Failed(1, f"{len(broken)} broken example(s) under {cfg.docs_folder}")
+
+
 @task("clean", "remove build artifacts and stale local branches", section="Dev")
 def clean(cfg: Config) -> None:
     """Remove ignored files, build artifacts, and local branches whose remote is gone.
@@ -244,6 +356,260 @@ def _walk(root: Path) -> list[Path]:
             elif entry.suffix in TODO_SUFFIXES:
                 found.append(entry)
     return found
+
+
+def _fences(path: str, text: str) -> list[Fence]:
+    """Return every fenced code block in one markdown file, in document order.
+
+    Indentation is why this is a state machine rather than a regex over the whole file:
+    mkdocs admonitions and content tabs indent their fences by four spaces, and ``faq.md``
+    indents one by three inside a numbered list. ``textwrap.dedent`` on the collected body is
+    what makes those compile -- without it every fence inside an admonition is an
+    ``IndentationError``, which would be a finding against this checker rather than the docs.
+
+    Nested fences are not handled, and cannot be: distinguishing them needs the four-backtick
+    form, which no file in this repository uses. If one appears, its inner fence closes the
+    outer block early and the languages reported go wrong -- visible in the inventory line
+    rather than silent, which is the reason that line prints a per-language count.
+
+    Args:
+        path: Repository-relative path, stored on each returned fence.
+        text: The file's content.
+
+    Returns:
+        The fences found, dedented.
+    """
+    fences: list[Fence] = []
+    language: str | None = None
+    start = 0
+    body: list[str] = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        if language is None:
+            opening = DOC_FENCE_OPEN.match(line)
+            if opening:
+                language, start, body = opening.group("language").lower(), number, []
+            continue
+        if DOC_FENCE_CLOSE.match(line):
+            fences.append(Fence(path, start, language, textwrap.dedent("\n".join(body))))
+            language = None
+            continue
+        body.append(line)
+    return fences
+
+
+def _syntax_violations(fences: list[Fence]) -> list[str]:
+    """Return one message per python fence that does not parse.
+
+    :func:`compile` rather than execution, so a fence holding a *fragment* -- ``guards =
+    (Guard("source_folder"),)`` in ``adding_a_task.md``, with ``Guard`` never imported --
+    passes. Undefined names are not the question; syntax is.
+
+    Args:
+        fences: Every fence in the tree.
+
+    Returns:
+        Violation messages, one per broken fence.
+    """
+    broken: list[str] = []
+    for fence in fences:
+        if fence.language != PYTHON_FENCE_LANGUAGE:
+            continue
+        try:
+            compile(fence.code, f"{fence.path}:{fence.line}", "exec")
+        except SyntaxError as exc:
+            # The *offending* line, not the fence's: `getting_started.md` holds 24 fences, and
+            # "somewhere in this file" is the part of a report a reader has to redo by hand.
+            # `fence.line` is the opening backticks, so body line 1 sits one below it, which is
+            # what makes this sum the absolute line rather than one short of it.
+            broken.append(f"{fence.path}:{fence.line + (exc.lineno or 0)}: python fence does not parse: {exc.msg}")
+    return broken
+
+
+def _shell_violations(fences: list[Fence], bash: str, scratch: Path) -> list[str]:
+    """Return one message per shell fence that does not parse.
+
+    ``-n`` is the whole point: bash reads and parses the script and exits without running a
+    command of it. So this validates ``rm -rf`` and ``git push`` fences without their
+    consequences.
+
+    Captured rather than streamed through :func:`~rhiza_task.uv.tool`, which every other
+    binary in this package goes through, for two reasons that both come from this being a
+    checker rather than a gate over one command: the message is wanted *per fence* and lives
+    on stderr, and echoing ``$ bash -n ...`` once per fence would bury the report it exists to
+    produce under twenty invocation lines. ``_git`` above captures for the same reason.
+
+    Args:
+        fences: Every fence in the tree.
+        bash: Absolute path to bash, already resolved by the caller.
+        scratch: Directory for the throwaway script.
+
+    Returns:
+        Violation messages, one per broken fence.
+    """
+    broken: list[str] = []
+    script = scratch / "fence.sh"
+    for fence in fences:
+        if fence.language not in SHELL_FENCE_LANGUAGES:
+            continue
+        script.write_text(fence.code)
+        checked = subprocess.run(  # noqa: S603  # nosec B603
+            [bash, "-n", str(script)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if checked.returncode:
+            # bash reports against the throwaway path and its own line numbers, neither of
+            # which the reader can act on. The fence's own location is already the prefix, so
+            # the script path is stripped to leave the diagnosis.
+            detail = checked.stderr.strip().splitlines()
+            message = detail[-1].replace(str(script), "fence") if detail else f"exit {checked.returncode}"
+            broken.append(f"{fence.path}:{fence.line}: shell fence does not parse: {message}")
+    return broken
+
+
+def _result_violations(per_file: list[list[Fence]], cfg: Config, scratch: Path) -> list[str]:
+    """Return one message per ``result`` block that no longer matches what its python prints.
+
+    This is the half that catches an example gone *stale* rather than malformed, which is the
+    failure with the longest half-life: the fence still parses, still renders, and is wrong.
+
+    The prelude is every python fence earlier in the same file, concatenated, because that is
+    what ``README.md``'s pair needs -- the first fence defines the ``audit`` task with
+    ``@task`` and the second calls ``lookup("audit")``, so running the second alone raises.
+    The whole captured stdout is then compared against the block.
+
+    That comparison is exact but for surrounding whitespace, and it carries one assumption
+    worth stating: a prelude fence that *prints* would have its output counted as part of the
+    result. No file here has one. If that changes, the fix is to fence off the prelude's
+    output rather than to loosen the diff, because a loosened diff is how a stale example
+    starts passing again.
+
+    Args:
+        per_file: Fences grouped by file, so a prelude cannot reach across files.
+        cfg: The resolved config.
+        scratch: Directory for the throwaway script and its captured stdout.
+
+    Returns:
+        Violation messages, one per stale or unrunnable block.
+    """
+    broken: list[str] = []
+    for one_file in per_file:
+        for index, fence in enumerate(one_file):
+            if fence.language != RESULT_FENCE_LANGUAGE:
+                continue
+            prelude = [f.code for f in one_file[:index] if f.language == PYTHON_FENCE_LANGUAGE]
+            if not prelude:
+                broken.append(f"{fence.path}:{fence.line}: result block with no python fence above it")
+                continue
+            printed = _run_fences(cfg, scratch, prelude)
+            if printed is None:
+                broken.append(f"{fence.path}:{fence.line}: the python above this block exited non-zero")
+            elif printed.strip() != fence.code.strip():
+                broken.append(
+                    f"{fence.path}:{fence.line}: result block is stale\n"
+                    f"           expected: {fence.code.strip()!r}\n"
+                    f"           actual:   {printed.strip()!r}"
+                )
+    return broken
+
+
+def _run_fences(cfg: Config, scratch: Path, codes: list[str]) -> str | None:
+    """Run python fences in the project environment and return their stdout.
+
+    A subprocess, and not :func:`exec` in this process, which would be shorter: the fences in
+    ``adding_a_task.md`` call ``@task``, and ``@task`` registers into the live
+    :data:`~rhiza_task.spec.REGISTRY`. Running them here would add an ``audit`` task to the
+    process running the gate, so a later ``list`` in the same ``rhiza-task all`` would print a
+    task that does not exist. Isolation is a requirement here, not caution.
+
+    stdout arrives through a file rather than a pipe for the reason ``complexity`` reads
+    radon's ``--output-file``: :func:`~rhiza_task.uv.uv_run` streams rather than captures, and
+    adding a capturing variant to ``uv.py`` for one caller would widen that module's surface
+    for it. The script redirects its own stdout, so the invocation stays a fixed argument
+    vector with no shell -- and the fences' tracebacks still reach the terminal on stderr,
+    which is where a reader wants them.
+
+    Args:
+        cfg: The resolved config.
+        scratch: Directory for the script and its captured stdout.
+        codes: The python fences to run, in document order.
+
+    Returns:
+        The captured stdout, or None when the script exited non-zero or wrote nothing.
+    """
+    printed = scratch / "stdout.txt"
+    # Stale output first, for the reason `complexity` unlinks its report: output left by an
+    # earlier run would be read as this run's, and a diff that passes against last run's
+    # stdout is worse than no diff.
+    printed.unlink(missing_ok=True)
+    script = scratch / "fences.py"
+    script.write_text(
+        f"import sys\nsys.stdout = open({str(printed)!r}, 'w', encoding='utf-8')\n"
+        + "\n".join(codes)
+        + "\nsys.stdout.flush()\n"
+    )
+    code = uv_run("python", script.relative_to(cfg.root).as_posix(), cwd=cfg.root, check=False)
+    if code or not printed.is_file():
+        return None
+    return printed.read_text(errors="replace")
+
+
+def _tally(fences: list[Fence]) -> tuple[int, int, int, list[tuple[str, int]]]:
+    """Count the fences by what can be done with them.
+
+    Split out of :func:`_report` rather than inlined there, which read more directly: the two
+    together score C on cyclomatic complexity, and a fifth C block in this package is a
+    fifth thing a reader has to accept an argument for. Counting and printing are genuinely
+    separate jobs, so this is the decomposition the metric asks for rather than a contortion
+    to satisfy it.
+
+    Args:
+        fences: Every fence in the tree.
+
+    Returns:
+        ``(python, shell, diffed, unchecked)``, where ``unchecked`` pairs each remaining
+        language with its count, commonest first and then alphabetically so the line is
+        diffable between runs. A fence with no language is counted under ``(none)``.
+    """
+    tally = Counter(fence.language or "(none)" for fence in fences)
+    unchecked = sorted(
+        ((language, count) for language, count in tally.items() if language not in CHECKED_FENCE_LANGUAGES),
+        key=lambda item: (-item[1], item[0]),
+    )
+    return (
+        tally[PYTHON_FENCE_LANGUAGE],
+        sum(tally[language] for language in SHELL_FENCE_LANGUAGES),
+        tally[RESULT_FENCE_LANGUAGE],
+        unchecked,
+    )
+
+
+def _report(fences: list[Fence], bash: str | None, files: int) -> bool:
+    """Print the inventory and report whether anything was checkable.
+
+    The unchecked count is printed rather than dropped because "0 examples" and "43 fences
+    nothing looks at" both pass every other gate in this repository while documenting nothing
+    verifiable. A reader seeing only a green line would take it for full coverage.
+
+    Args:
+        fences: Every fence in the tree.
+        bash: Path to bash, or None when it is absent.
+        files: How many markdown files were read.
+
+    Returns:
+        True when at least one fence was checked, so the caller can skip rather than pass.
+    """
+    python, shell, diffed, unchecked = _tally(fences)
+    checked = python + diffed + (shell if bash else 0)
+    print(f"\n[INFO] {files} file(s), {len(fences)} fence(s): {checked} checked")
+    print(f"[INFO] {python} python, {shell} shell, {diffed} diffed")
+    if bash is None and shell:
+        print(f"[INFO] bash not found: {shell} shell fence(s) went unchecked")
+    if unchecked:
+        listing = ", ".join(f"{count} {language}" for language, count in unchecked)
+        print(f"[INFO] {sum(count for _, count in unchecked)} fence(s) not checkable: {listing}")
+    return checked > 0
 
 
 def _git(git: str, args: list[str], cwd: Path, capture: bool = False) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,15 @@
 
 No test in this suite runs uv. The point of extracting the make layer into a package is
 that its logic becomes testable *without* provisioning a toolchain, so every test patches
-:mod:`rhiza_task.uv`'s three entry points and asserts on the argument vectors that would
-have been executed. Those vectors are the contract the make recipes expressed in shell.
+:mod:`rhiza_task.uv`'s four entry points -- ``uv``, ``uvx``, ``uv_run`` and ``tool`` -- and
+asserts on the argument vectors that would have been executed. Those vectors are the
+contract the make recipes expressed in shell.
+
+Four, not three: ``tool`` is the form rust.mk and go.mk added for a toolchain binary
+already on PATH, which uv neither provisions nor knows about. :mod:`rhiza_task.uv` explains
+why that is a fourth form rather than a variant of the other three, and the fixture below
+patches it alongside them -- so a count of three here would understate what this file
+stands in for by exactly the language layers it was extended to cover.
 """
 
 from __future__ import annotations

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -357,6 +357,7 @@ def test_folders_and_path_resolve(tmp_path: Path) -> None:
     assert set(cfg.folders) == {
         "source_folder",
         "tests_folder",
+        "docs_folder",
         "marimo_folder",
         "docker_folder",
         "paper_folder",

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from rhiza_task.config import Config
-from rhiza_task.spec import Failed, Skip
+from rhiza_task.spec import Failed, Skip, lookup
 from rhiza_task.tasks import book as book_tasks
 from rhiza_task.tasks import extras, python, quality
 from rhiza_task.tasks.doctor import at_least, parse_version
@@ -947,3 +948,342 @@ class TestComplexity:
         self._radon(monkeypatch, None)
         with pytest.raises(Skip):
             python.complexity(cfg)
+
+
+class TestDocsExamples:
+    """``docs-examples``: the fence parser, the three checks, and the inventory.
+
+    Hermetic like the rest of the suite. ``bash`` and ``uv_run`` are both patched, so the
+    tests assert the argument vector each check *would* run -- ``bash -n`` over a throwaway
+    script, ``uv run python`` over a generated one -- rather than provisioning either. That
+    matters more here than elsewhere: this gate's whole job is to run other people's code,
+    and a test that really ran it would execute the repository's own documentation.
+    """
+
+    @staticmethod
+    def _docs(cfg: Config, name: str, text: str) -> None:
+        """Write one markdown file into the docs folder.
+
+        Args:
+            cfg: The resolved config.
+            name: File name, e.g. ``guide.md``.
+            text: The file's content.
+        """
+        folder = cfg.path("docs_folder")
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / name).write_text(text)
+
+    @staticmethod
+    def _bash(monkeypatch: pytest.MonkeyPatch, code: int, stderr: str = "") -> list[list[str]]:
+        """Patch out the ``bash -n`` probe and collect the vectors it would have run.
+
+        Args:
+            monkeypatch: pytest's patcher.
+            code: The exit status every probe reports.
+            stderr: The stderr every probe reports.
+
+        Returns:
+            The recorded argument vectors, appended to as the gate runs.
+        """
+        seen: list[list[str]] = []
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: "/bin/bash")
+
+        def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            """Record the vector and report the canned outcome.
+
+            Args:
+                argv: The argument vector.
+                **_kwargs: Ignored.
+
+            Returns:
+                A completed process carrying the canned status and stderr.
+            """
+            seen.append(argv)
+            return subprocess.CompletedProcess(argv, code, "", stderr)
+
+        monkeypatch.setattr(quality.subprocess, "run", fake_run)
+        return seen
+
+    def test_dedents_a_fence_indented_inside_an_admonition(self) -> None:
+        """A fence indented by an admonition compiles, because the body is dedented.
+
+        Without the dedent every fence inside an mkdocs admonition or content tab is an
+        ``IndentationError``, which would be a finding against this checker rather than the
+        documentation -- and this repository's docs indent eight of them.
+        """
+        fences = quality._fences("docs/x.md", '!!! tip "t"\n\n    ```python\n    x = 1\n    ```\n')
+        assert [(f.line, f.language, f.code) for f in fences] == [(3, "python", "x = 1")]
+        assert quality._syntax_violations(fences) == []
+
+    def test_keeps_only_the_language_from_an_attributed_fence(self) -> None:
+        """``python title="x"`` is a python fence, and an unlabelled one carries no language.
+
+        The opening pattern is permissive for a reason worth pinning: were it to miss an
+        attributed fence, that fence's *closing* backticks would be read as the next opening
+        one and every language after it would be wrong.
+        """
+        fences = quality._fences("d.md", '```python title="a.py"\nx = 1\n```\n\n```\nplain\n```\n')
+        assert [f.language for f in fences] == ["python", ""]
+
+    def test_reports_a_python_fence_that_does_not_parse(self) -> None:
+        """A malformed python fence is a violation, and a mere fragment is not.
+
+        ``guards = (Guard("source_folder"),)`` in ``adding_a_task.md`` never imports
+        ``Guard``, so resolving names would report the documentation as broken when it is
+        only partial.
+        """
+        fences = quality._fences("d.md", "```python\nx = (1,\n```\n\n```python\ny = Undefined(1)\n```\n")
+        violations = quality._syntax_violations(fences)
+        assert len(violations) == 1
+        # Line 2, the offending code, not line 1 where the fence opens.
+        assert violations[0].startswith("d.md:2: python fence does not parse:")
+
+    def test_reports_a_shell_fence_that_does_not_parse(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A non-zero ``bash -n`` is a violation, and the throwaway path is not in the message.
+
+        bash reports against the scratch file and its own line numbers, neither of which the
+        reader can act on; the fence's real location is the prefix instead.
+
+        Args:
+            monkeypatch: pytest's patcher.
+            tmp_path: Scratch directory for the throwaway script.
+        """
+        seen = self._bash(monkeypatch, 2, f"{tmp_path / 'fence.sh'}: line 2: syntax error\n")
+        fences = quality._fences("d.md", "```bash\nif true\n```\n")
+        violations = quality._shell_violations(fences, "/bin/bash", tmp_path)
+        assert seen[0][:2] == ["/bin/bash", "-n"]
+        assert violations == ["d.md:1: shell fence does not parse: fence: line 2: syntax error"]
+
+    def test_falls_back_to_the_exit_status_when_bash_says_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A failure with empty stderr still reports, rather than producing an empty message.
+
+        Args:
+            monkeypatch: pytest's patcher.
+            tmp_path: Scratch directory for the throwaway script.
+        """
+        self._bash(monkeypatch, 2, "")
+        fences = quality._fences("d.md", "```sh\nif true\n```\n")
+        violations = quality._shell_violations(fences, "/bin/bash", tmp_path)
+        assert violations == ["d.md:1: shell fence does not parse: exit 2"]
+
+    def test_runs_the_generated_script_through_the_project_environment(self, cfg: Config, recorder: Recorder) -> None:
+        """The fences run as ``uv run python <script>``, so imports see the project's deps.
+
+        A file rather than ``-c``: the echoed invocation stays one readable line, and the
+        script is what redirects its own stdout, keeping the vector shell-free.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+        quality._run_fences(cfg, scratch, ["print('hi')"])
+        call = recorder.find("python")
+        assert call.kind == "uv_run"
+        assert call.flags == ["_tests/docs-examples/fences.py"]
+        assert "sys.stdout = open(" in (scratch / "fences.py").read_text()
+
+    def test_treats_a_script_that_wrote_nothing_as_unrunnable(self, cfg: Config, recorder: Recorder) -> None:
+        """No captured stdout means the fences did not run, which is not a passing diff.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder, which records rather than runs the script.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+        assert quality._run_fences(cfg, scratch, ["print('hi')"]) is None
+        assert recorder.tools() == ["python"]
+
+    def test_discards_stdout_left_by_an_earlier_run(self, cfg: Config, recorder: Recorder) -> None:
+        """Stale stdout is removed first, so a diff cannot pass against the previous run.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+        (scratch / "stdout.txt").write_text("last time's answer")
+        assert quality._run_fences(cfg, scratch, ["print('hi')"]) is None
+        assert recorder.tools() == ["python"]
+
+    @pytest.mark.parametrize(
+        ("printed", "expected"),
+        [
+            ("one", []),
+            ("two", ["stale"]),
+            (None, ["exited non-zero"]),
+        ],
+    )
+    def test_diffs_a_result_block_against_what_the_python_prints(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, printed: str | None, expected: list[str]
+    ) -> None:
+        """A ``result`` block matching its fence passes; a stale or unrunnable one does not.
+
+        ``_run_fences`` is patched rather than run, so this asserts the diff and not the
+        subprocess -- which the two tests above already pin as a vector.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            printed: What the python fences are made to print, or None for a failed run.
+            expected: Substrings the violations must contain.
+        """
+        monkeypatch.setattr(quality, "_run_fences", lambda *_args: printed)
+        fences = quality._fences("d.md", "```python\nprint('one')\n```\n\n```result\none\n```\n")
+        violations = quality._result_violations([fences], cfg, cfg.root)
+        assert len(violations) == len(expected)
+        for violation, fragment in zip(violations, expected, strict=True):
+            assert fragment in violation
+
+    def test_reports_a_result_block_with_no_python_above_it(self, cfg: Config) -> None:
+        """A ``result`` block that documents nothing runnable is a violation, not a pass.
+
+        Args:
+            cfg: The resolved config.
+        """
+        fences = quality._fences("d.md", "```result\nnothing produces this\n```\n")
+        assert quality._result_violations([fences], cfg, cfg.root) == [
+            "d.md:1: result block with no python fence above it"
+        ]
+
+    def test_a_prelude_fence_defines_names_the_later_one_uses(self, cfg: Config, recorder: Recorder) -> None:
+        """Every python fence above the block is concatenated, because the pair needs it.
+
+        ``README.md``'s first fence registers ``audit`` with ``@task`` and its second calls
+        ``lookup("audit")``; running the second alone raises. Asserted on the generated
+        script rather than on its output, which keeps the test hermetic.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+        quality._run_fences(cfg, scratch, ["V = 7", "print(V)"])
+        script = (scratch / "fences.py").read_text()
+        assert "V = 7" in script
+        assert script.index("V = 7") < script.index("print(V)")
+        assert recorder.tools() == ["python"]
+
+    def test_skips_when_the_docs_folder_holds_no_checkable_fence(
+        self, cfg: Config, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A tree of ``toml`` and unlabelled fences measured nothing, so it skips.
+
+        Passing would be the failure this gate exists to prevent: 100 percent docstring
+        coverage over documentation carrying nothing runnable already reads as green.
+
+        Args:
+            cfg: The resolved config.
+            capsys: pytest's output capture.
+        """
+        self._docs(cfg, "conf.md", "```toml\nx = 1\n```\n\n```\nplain\n```\n")
+        with pytest.raises(Skip, match="no checkable fence"):
+            quality.docs_examples(cfg)
+        assert "2 fence(s) not checkable: 1 (none), 1 toml" in capsys.readouterr().out
+
+    def test_counts_shell_fences_as_unchecked_when_bash_is_absent(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No bash means the shell fences go uncounted as checked, and the gate says so.
+
+        A stock Windows runner has no bash, and Windows is in the matrix deliberately. That
+        is a fact about the machine, so it must not fail the gate -- the same reasoning as a
+        tool guard raising Skip.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: None)
+        self._docs(cfg, "g.md", "```bash\nls\n```\n\n```python\nx = 1\n```\n")
+        quality.docs_examples(cfg)
+        out = capsys.readouterr().out
+        assert "bash not found: 1 shell fence(s) went unchecked" in out
+        assert "1 file(s), 2 fence(s): 1 checked" in out
+
+    def test_fails_on_a_broken_fence_and_names_it(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """One unparseable fence fails the gate, with its file and line in the output.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: None)
+        self._docs(cfg, "g.md", "```python\nx = (1,\n```\n")
+        with pytest.raises(Failed, match="1 broken example"):
+            quality.docs_examples(cfg)
+        assert "docs/g.md:2: python fence does not parse" in capsys.readouterr().out
+
+    def test_passes_a_clean_tree_and_checks_the_shell_fences(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With bash present every shell fence is probed, and a clean tree passes.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        seen = self._bash(monkeypatch, 0)
+        self._docs(cfg, "a.md", "```bash\nls\n```\n")
+        self._docs(cfg, "b.md", "```python\nx = 1\n```\n")
+        quality.docs_examples(cfg)
+        assert len(seen) == 1
+        assert "2 file(s), 2 fence(s): 2 checked" in capsys.readouterr().out
+
+    def test_is_guarded_on_the_docs_folder(self, cfg: Config) -> None:
+        """A repository with no docs tree skips through the guard, rather than failing.
+
+        Args:
+            cfg: The resolved config.
+        """
+        spec = lookup("docs-examples")
+        assert [guard.folder for guard in spec.guards] == ["docs_folder"]
+        with pytest.raises(Skip, match="docs_folder"):
+            spec.guards[0].check(cfg.root, cfg.folders)
+
+    def test_needs_install_because_the_examples_import_the_project(self) -> None:
+        """The executed half imports the project's own packages, as ``rhiza-test`` does."""
+        assert lookup("docs-examples").needs == ("install",)
+
+    def test_returns_the_captured_stdout_when_the_script_ran(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A script that wrote its stdout file has that text returned for diffing.
+
+        ``uv_run`` is patched with a stand-in that produces the *effect* the real script has
+        -- the redirected stdout file -- rather than running python, which keeps the test
+        hermetic while still covering the path the diff depends on.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+
+        def fake_uv_run(*_args: object, **_kwargs: object) -> int:
+            """Write the stdout the redirected script would have written.
+
+            Args:
+                *_args: Ignored.
+                **_kwargs: Ignored.
+
+            Returns:
+                Zero, as a successful run does.
+            """
+            (scratch / "stdout.txt").write_text("captured\n")
+            return 0
+
+        monkeypatch.setattr(quality, "uv_run", fake_uv_run)
+        assert quality._run_fences(cfg, scratch, ["print('captured')"]) == "captured\n"


### PR DESCRIPTION
Closes #89. Closes #90.

## #89 — the docs tree's fences are now gated

`docs-coverage` asks whether a docstring exists; markdownlint asks whether the markdown is
well-formed. Neither asks whether what the documentation **claims** is still true.
`README.md` had an answer — pytest-rhiza's `test_readme_validation`, via `rhiza-test` — and
`docs/` had none. That is the larger half: **62 fences over 11 files**, 24 of them in
`getting_started.md`, which is a newcomer's first contact.

New task **`rhiza-task docs-examples`**, plus a `docs_folder` setting:

| fence | what happens |
|---|---|
| `python` | `compile()`, so a *fragment* still passes — `guards = (Guard("source_folder"),)` never imports `Guard` |
| `bash` / `sh` | `bash -n` — parsed, **never executed**; a README's shell is routinely `rm -rf` |
| ` ```result ` | the `python` fences above it are **executed and diffed** against it |
| anything else | reported with a per-language count |

It reports `31 checked` of 62 — where a `grep` for `^```bash` sees 43 fences total. The
difference is fences indented inside admonitions and list items, which the parser dedents.

Two design points:

- **A task, not a test.** Checking a shell fence runs a tool, and no test in this suite
  does — which is what `CLAUDE.md` says to do when you want a subprocess in a test. Its own
  tests patch `bash` and `uv_run` and assert the vectors, like every other task's.
- **A subprocess, not `exec()`.** `adding_a_task.md` calls `@task`, which would otherwise
  register an `audit` task into the live `REGISTRY` of the process running the gate, so a
  later `list` in the same `all` would print a task that does not exist.

Named by `ci.yml`'s `gates` job rather than added to `all`, for the reason `complexity` is:
an `all` prerequisite fails builds in consumer repos that changed nothing.

## #90 — four drifted figures

The house style holds that *a stale comment is worse than none*. Four had drifted:

- `tests/conftest.py` — "three entry points"; there are **four**, and the fixture patches
  all four. `ci.yml` already said four, so the two contradicted each other.
- `pyproject.toml` — "1080 statements"; **1234**. Now written as "at the time of writing",
  since the figure moves every commit and the argument does not rest on it.
- `ci.yml` — "the figure is currently 13"; the worst block is the `Guard` **class at 14**,
  so headroom is one, not two settings' worth. Now says it tracks the worst *block*,
  classes included, because that and the worst function differ and only one fails a build.
- `CLAUDE.md` — "`ci.yml` has four jobs"; it has **six**, with `go-layer` and `rust-layer`
  unmentioned. Found while working, same defect class, so fixed here.

## Also: the two workflows that do reach upstream

`CLAUDE.md` claimed nothing here is synced from `jebel-quant/rhiza`. `rhiza_codeql.yml` and
`rhiza_scorecard.yml` both `uses:` a reusable workflow there, and carry its header. That is
now documented rather than denied.

Neither invokes `rhiza-task`, `make` or `uv` at the pinned SHA — upstream's codeql is
`codeql-action/init` + `analyze`, its scorecard is `ossf/scorecard-action` +
`upload-sarif` — **so this is not the circularity the layering argument forbids.** But
v1.4.2 is the release that retired the make layer, so a later pin bump could make it so
silently. Hence the recorded instruction: read the upstream workflow before moving either
SHA.

## Verification

`rhiza-task all` green (fmt, deps, test, docs-coverage, security, license, typecheck,
rhiza-test), plus `complexity`, `docs-examples`, the 39 doctests executing clean, and
test-layout OK. **334 tests, coverage back at 100%** on 1234 statements.

`_report` initially ranked **C (12)** — a fifth C block in a repo documenting exactly four.
`_tally` was extracted rather than a justification written: reducing the count beats arguing
for it. Back to four, average A (3.25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
