### PR TITLE
docs: correct drifted figures and split the three example gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,14 @@ are unrelated to the absent template. Do not read them as evidence of a sync.
 ### The `rhiza_` filename prefix is residue, not a sync
 
 Three workflows still carry it — `rhiza_book.yml`, `rhiza_paper.yml` and
-`rhiza_release.yml` — and two of them still open with an upstream header. That is the
-history of how they arrived (a copy, once) rather than a claim about how they are
-maintained: each is a full local file with real jobs, nothing reconciles them against
-upstream, and editing them is the normal way to change them.
+`rhiza_release.yml` — and exactly one of them, `rhiza_release.yml`, still opens with
+upstream's *This file is part of the jebel-quant/rhiza repository* boilerplate;
+`grep -rn 'This file is part of the jebel-quant/rhiza' .github/` returns that one line. The
+other two open with a local *Adapted from* note naming what was changed and why, which is
+the honest header for what they now are. Either way the prefix is the history of how they
+arrived (a copy, once) rather than a claim about how they are maintained: each is a full
+local file with real jobs, nothing reconciles them against upstream, and editing them is
+the normal way to change them.
 
 `rhiza_release.yml` is the one not to rename, and the reason is in its own header:
 **PyPI Trusted Publishing validates the exact workflow file path.** The trusted publisher
@@ -139,12 +143,17 @@ this repo's name.
 
 ### The prose examples are gated too, and by a task rather than a test
 
-The same argument applied twice over to `docs/`. `README.md`'s fences were covered by
-pytest-rhiza's `test_readme_validation` under `rhiza-test`; the docs tree — 62 fences, 24 of
-them in `getting_started.md` — was covered by markdownlint asking whether the *markdown*
-parses, and by nothing asking whether the commands did. `rhiza-task docs-examples` is that
-gate, named by `ci.yml`'s `gates` job because, like `complexity`, it is deliberately not an
-`all` prerequisite.
+The same argument applied twice over to `docs/`. `README.md`'s fences are covered by
+pytest-rhiza's `test_readme_validation` under `rhiza-test`; the docs tree — 62 fences over 11
+files, 12 of them in `getting_started.md` — was covered by markdownlint asking whether the
+*markdown* parses, and by nothing asking whether the commands did. `rhiza-task docs-examples`
+is that gate, named by `ci.yml`'s `gates` job because, like `complexity`, it is deliberately
+not an `all` prerequisite.
+
+Its subject is `docs/` and **deliberately not `README.md`**, which stays pytest-rhiza's: two
+gates reporting one verdict would make a single fact read as two. So a broken fence in the
+README fails `rhiza-test`, and a broken fence under `docs/` fails `docs-examples` — which of
+the two went red tells you which file you edited.
 
 It is a **task and not a test**, and that placement is the rule in this repo rather than a
 preference: checking a shell fence means running `bash -n`, and no test here runs a tool. So
@@ -155,10 +164,11 @@ every other task's.
 Two things a change to `docs/` should know. A ```` ```result ```` block is **executed and
 diffed** against the `python` fences above it, so an example that goes stale fails a build
 rather than quietly outdating — and the prelude is every earlier `python` fence in that
-file, because `README.md`'s pair needs the first fence's `@task` before the second's
-`lookup`. And fences in a language it cannot check (`toml`, `mermaid`, `makefile`, `yaml`,
-and those carrying no language) are **reported with a count** rather than passed over in
-silence, because a green line with no numbers reads as full coverage.
+file, because `adding_a_task.md`'s pair needs the first fence's `@task` before the second's
+`lookup` — that page holds the one `result` block in the tree, which is why the gate's
+summary line reads `1 diffed`. And fences in a language it cannot check (`toml`, `mermaid`,
+`makefile`, `yaml`, and those carrying no language) are **reported with a count** rather
+than passed over in silence, because a green line with no numbers reads as full coverage.
 
 ## The coverage floor is 100, and it is load-bearing
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ race, never on 1/2/4), `mutation` (run/html/move/results, reporting the *first* 
 |---|---|
 | `spec.py` | `Task`, `Guard`, `Skip`/`Failed`, the `@task` registry, layer resolution |
 | `config.py` | six-layer resolution, replacing `?=` and `+=` |
-| `uv.py` | the three ways rhiza reaches a tool |
+| `uv.py` | the four ways rhiza reaches a tool: `uv`, `uvx`, `uv run --with`, and `tool` for a cargo/go binary already on PATH |
 | `runner.py` | prerequisite dedup, guards, outcome bookkeeping |
 | `cli.py` | Typer app, generated from the registry |
 | `tasks/*.py` | the gates themselves, loaded by entry point |
@@ -197,10 +197,12 @@ audit - run the in-house audit
 ('install',) source_folder Quality
 ```
 
-That last pair of blocks is executed and diffed, not just rendered: the `result` block is
-compared against the fences' real output by the same convention `rhiza-task rhiza-test`
-applies to every docstring's `>>>` examples. A change to `lookup`, to `Task`, or to the
-decorator above breaks the README rather than quietly outdating it.
+That last pair of blocks is executed and diffed, not just rendered: `rhiza-task rhiza-test`
+runs the `python` fences and compares their real output against the `result` block. The copy
+of the same pair in the book's [Adding a Task](https://jebel-quant.github.io/rhiza-task/adding_a_task/)
+page is diffed by `rhiza-task docs-examples`, which owns the docs tree for the same reason.
+A change to `lookup`, to `Task`, or to the decorator above breaks a build rather than quietly
+outdating a page.
 
 A one-off that is only ever a make target goes in `local.mk` — but that file is in core's
 `.gitignore`, so it holds developer-local targets only. A repo-owned target CI invokes
@@ -253,7 +255,9 @@ repeating it:
 | [Adding a Task](https://jebel-quant.github.io/rhiza-task/adding_a_task/) | guards, outcomes, and which of the four provisioning forms to reach for |
 | [Migrating from make](https://jebel-quant.github.io/rhiza-task/migration/) | the three steps, and the fragment-relocation trap that silently drops targets |
 | [FAQ](https://jebel-quant.github.io/rhiza-task/faq/) | the failure modes, and what each one actually means |
+| [Design](https://jebel-quant.github.io/rhiza-task/design/) | where the evidence came from — jointview, the repo the comments cite by name — and why exactly four recipes resisted the declarative form |
 | [API Reference](https://jebel-quant.github.io/rhiza-task/api/) | the modules, generated from the docstrings that carry the reasoning |
+| [Paper](https://jebel-quant.github.io/rhiza-task/paper/paper.pdf) | the argument written up long-form, compiled by `rhiza-task paper` into the book |
 
 It is built by the `book` task itself — `mkdocs.yml` at the root is what turns that task
 from a skip into a build — and published by `.github/workflows/rhiza_book.yml` on every
@@ -269,23 +273,45 @@ uv run rhiza-task serve    # build, then serve on http://localhost:8000
 ```bash
 uv sync --all-groups
 uv run pytest              # the fast inner loop
-uv run rhiza-task all      # run before pushing: every gate, as CI runs them
+uv run rhiza-task all      # every gate `all` names, as CI runs them
 ```
 
 `uv run rhiza-task all` is the pre-push check, and it is what `ci.yml`'s `gates` job runs
-— deptry, the 100% coverage floor, interrogate, bandit, the copyleft scan, `ty` and
-`rhiza-test` on top of the suite. `uv run pytest` alone is strictly weaker than the check
-that will fail a pull request, so a green pytest is not yet a green PR. This repo exists to
-provide that aggregate, so it gates itself with it.
+— the pre-commit hooks, deptry, the 100% coverage floor, interrogate, bandit, the copyleft
+scan, `ty` and `rhiza-test` on top of the suite. That job then names the two gates that sit
+outside `all` on purpose, `complexity` and `docs-examples`, because adding either as an
+`all` prerequisite would fail builds in consumer repositories that changed nothing. So the
+full pre-push sequence is three commands:
 
-The examples above are checked, not decorative — `rhiza-task rhiza-test` runs the `>>>`
-examples in `config.py`, `runner.py` and `spec.py` and diffs this README's `python` fences
-against its `result` block. Both need the project environment, since the fences import the
-package: `uv run` rather than a bare interpreter.
+```bash
+uv run rhiza-task all
+uv run rhiza-task complexity
+uv run rhiza-task docs-examples
+```
 
-No test in the suite runs uv. Every task test patches the three entry points in `uv.py`
-and asserts on the argument vector that would have been executed — which is exactly what
-the make recipes expressed in `$$`-escaped shell, and could not assert.
+`uv run pytest` alone is strictly weaker than the check that will fail a pull request, so a
+green pytest is not yet a green PR. This repo exists to provide that aggregate, so it gates
+itself with it.
+
+The examples in this file are checked, not decorative, and three different gates own three
+different sets of them:
+
+| examples | gate |
+|---|---|
+| this README's `python` fences, diffed against its `result` block | `rhiza-task rhiza-test`, via pytest-rhiza's `test_readme_validation` |
+| every fence under `docs/` — `python` compiled, `bash` parsed, `result` diffed | `rhiza-task docs-examples` |
+| the 39 `>>>` examples in `config.py`, `runner.py` and `spec.py` | `tests/test_doctests.py`, under plain `pytest` |
+
+`rhiza-test` is not what runs the docstring examples, which is worth knowing because it
+reads as though it should: pytest-rhiza's `test_docstrings` asks whether a docstring exists
+and is well-formed, and `interrogate` asks the same presence question at 100%. Neither
+evaluates a `>>>`. All three gates need the project environment, since the examples import
+the package: `uv run` rather than a bare interpreter.
+
+No test in the suite runs uv. Every task test patches the four entry points in `uv.py` —
+`uv`, `uvx`, `uv_run` and `tool` — and asserts on the argument vector that would have been
+executed, which is exactly what the make recipes expressed in `$$`-escaped shell and could
+not assert.
 
 `CLAUDE.md` carries the rest: the layering invariant the import graph holds by discipline,
 why the 100% coverage floor is load-bearing rather than decorative, and the house rule on


### PR DESCRIPTION
`CLAUDE.md` and `README.md` had drifted from the code in four places, and one section credited the wrong gate.

## Corrected figures

- **One workflow, not two,** still opens with upstream's *This file is part of the jebel-quant/rhiza repository* boilerplate — `rhiza_release.yml`. The other two carry a local *Adapted from* note. The grep that confirms it is in the text.
- **The docs tree is 62 fences over 11 files, 12 of them in `getting_started.md`** — the old figure said 24. And the `result` pair the prelude rule exists for lives in `adding_a_task.md`, not the README, which is why the gate's summary reads `1 diffed`.
- **`uv.py` reaches a tool four ways,** not three: `uv`, `uvx`, `uv run --with`, and `tool` for a cargo/go binary already on PATH. The tests patch four entry points to match.
- **`rhiza-task all` is not the whole pre-push check.** `complexity` and `docs-examples` sit outside `all` on purpose — adding either as a prerequisite would fail builds in consumer repos that changed nothing — so the honest pre-push sequence is three commands, and the README now prints all three.

## Which gate owns which examples

The README said `rhiza-test` runs the `>>>` examples. It does not: pytest-rhiza's `test_docstrings` asks whether a docstring exists and is well-formed, and `interrogate` asks the same presence question at 100%; neither evaluates a `>>>`. A table now splits the three sets — README fences to pytest-rhiza's `test_readme_validation`, the `docs/` tree to `docs-examples`, the 39 `>>>` examples to `tests/test_doctests.py` under plain pytest. `CLAUDE.md` gains the matching note on why `docs-examples`' subject is `docs/` and deliberately not `README.md`: two gates reporting one verdict would make a single fact read as two.

## Verification

- `uv run rhiza-task docs-examples` → `11 file(s), 62 fence(s): 31 checked` / `8 python, 22 shell, 1 diffed`
- `uv run rhiza-task rhiza-test` → 34 passed

Prose only; no source or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)