### PR TITLE
ci: install TeX Live on the ref the book deploys, fixing the paper 404

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -71,6 +71,32 @@ jobs:
           restore-keys: |
             mkdocs-plugin-${{ runner.os }}-
 
+      # TeX Live, and only on the ref `deploy` will publish. `book` names `paper` as a
+      # prerequisite and a *skipped* prerequisite does not block a dependent, so without
+      # latexmk this job built a site whose `Paper: paper/paper.pdf` nav entry pointed at a
+      # file nothing had written -- and published it. That is what 404ed:
+      # https://jebel-quant.github.io/rhiza-task/paper/paper.pdf, on a run that was green,
+      # because every gate here passes when the paper is absent.
+      #
+      # Scoped to the default branch rather than run everywhere because the apt-get is the
+      # expensive half and a branch book is downloaded from the run page, not visited. A
+      # branch build therefore still carries the dangling entry; the condition mirrors
+      # `deploy`'s exactly, so the ref that publishes is the ref that has latexmk. (The
+      # fork exclusion is the job's own `if`, so it is not repeated here.)
+      #
+      # The same four packages as rhiza_paper.yml, deliberately: two workflows compiling one
+      # document against different TeX package sets is a divergence neither would catch --
+      # that one produces the PDF on the `paper` branch, this one the copy inside the book.
+      - name: Install TeX Live (publishing refs only)
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-bibtex-extra \
+            latexmk
+
       # `book` depends on `test`, so this step also produces the `_tests/` tree it folds in
       # as docs/reports -- the coverage XML the badge step reads, and the HTML report and
       # coverage pages mkdocs.yml lists under Reports.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,11 +33,18 @@ nav:
   - Reports:
       - Test Report: reports/html-report/report.html
       - Coverage Report: reports/html-coverage/index.html
-  # Same trade, one directory over: `rhiza-task paper` compiles docs/paper/paper.tex in
-  # place, and docs/paper is inside docs_dir, so the built site carries the PDF without
-  # anything copying it. `book` names `paper` as a prerequisite, so the normal path produces
-  # both together; the entry dangles in a checkout where latexmk is absent, exactly as the
-  # two above dangle before the gates have run.
+  # One directory over, and *not* the same trade: `rhiza-task paper` compiles
+  # docs/paper/paper.tex in place, and docs/paper is inside docs_dir, so the built site
+  # carries the PDF without anything copying it. `book` names `paper` as a prerequisite, so
+  # the normal path produces both together.
+  #
+  # What differs from the two above is a toolchain rather than a build order. The reports
+  # need only the gates, which any runner can run; this needs latexmk, and a *skipped*
+  # prerequisite does not block `book` -- so a runner with no LaTeX distribution published
+  # this entry pointing at a file nothing had written, on a green run. It did, and 404ed,
+  # until rhiza_book.yml installed TeX Live on the ref it deploys. So the entry resolves in
+  # the published book and on a machine with latexmk, and dangles anywhere else -- a branch
+  # book, or a bare checkout.
   - Paper: paper/paper.pdf
 
 extra:


### PR DESCRIPTION
## The bug

<https://jebel-quant.github.io/rhiza-task/paper/paper.pdf> returns **404**, on builds that
were green.

Three facts that only break in combination:

1. `docs/paper/paper.pdf` is gitignored (`.gitignore:33`), so it exists only when something
   compiles it.
2. `mkdocs.yml`'s nav names `paper/paper.pdf`, relying on `book`'s `paper` prerequisite to
   have written it in place — `docs/paper` is inside `docs_dir`, so no copy step.
3. **`rhiza_book.yml` — the only workflow that publishes to Pages — never installed TeX
   Live.** So `HAVE_LATEXMK` skipped `paper`, and a *skipped* prerequisite deliberately does
   not block `book` (`book.py`), so the site built and deployed with a nav entry pointing at
   a file nothing had written.

Evidence, from the last deploying run (32450715768):

```
skipped  paper  latexmk not found; install a LaTeX distribution (MacTeX, TeX ...
```

and its Pages artifact listing ends at `./paper/paper.tex` — no `paper.pdf`.

`rhiza_paper.yml` compiles this same document fine: the orphan `paper` branch holds a
349,277-byte `paper.pdf`. It just never reached Pages.

## The change

**`.github/workflows/rhiza_book.yml`** — a TeX Live step before `Build the book`, gated on
`github.ref_name == github.event.repository.default_branch`.

- The condition mirrors `deploy`'s **exactly**, so the ref that publishes is the ref that has
  `latexmk`. The apt-get is the expensive half, and a branch book is downloaded from a run
  page rather than visited, so paying it on every push to every branch buys nothing.
- The **same four packages as `rhiza_paper.yml`**, deliberately: two workflows compiling one
  document against different TeX package sets is a divergence neither would catch — that one
  produces the PDF on the `paper` branch, this one the copy inside the book.

**`mkdocs.yml`** — the nav comment claimed the Paper entry "dangles in a checkout where
latexmk is absent, exactly as the two above dangle before the gates have run." That parity
was false: the Reports entries *do* resolve in the published book, because the gates run
there. Rewritten to say the difference is a toolchain rather than a build order, and to
record the 404 — so the next reader doesn't restore the old claim.

`README.md:260`'s "compiled by `rhiza-task paper` into the book" needed no change; it becomes
true rather than being wrong.

## Verification, and its one limit

Verified locally that the last link in the chain holds: with a probe PDF at
`docs/paper/paper.pdf` and a cleaned `_book`, zensical copies it to exactly
`_book/paper/paper.pdf`. Probe removed afterwards.

**This PR's own book build will not exercise the fix.** Because the install is gated on the
default branch, `latexmk` is still absent here and `paper` still skips — the fix is first
observable on the push to `main` after merge, which compiles the paper and deploys. That is
inherent in scoping the apt-get to the publishing ref, not something a gate can cover.

Files changed are `.github/workflows/rhiza_book.yml` and `mkdocs.yml` only. No gates were run
locally — `/rhiza:quality` is the scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
