### PR TITLE
fix: close the seven findings from the quality run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,43 @@ jobs:
         if: ${{ !cancelled() }}
         run: uvx ruff@0.16.3 format --check --diff .
 
+  # The gateable half of link checking. weekly.yml runs lychee over the network; this runs
+  # it with `--offline`, which resolves only *local* targets -- relative links between the
+  # eleven docs/ pages, and README's links into them.
+  #
+  # The split is about determinism, not thoroughness. An external 404 is somebody else's
+  # deploy, so gating a pull request on it fails builds the author cannot fix, and a gate
+  # that fails for unfixable reasons is one people learn to ignore. Offline checking cannot
+  # do that: a relative link either resolves in the tree or does not, and if it does not,
+  # the person who broke it is the person reading the failure.
+  #
+  # It is also the only thing checking docs/ cross-links at all. `rhiza-task docs-examples`
+  # asks whether the *fences* parse and markdownlint asks whether the markdown is
+  # well-formed; neither follows a link. Eleven files of prose linking to each other had
+  # nothing asking whether the targets exist.
+  links:
+    name: local links in README and docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check local links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --offline
+            --verbose
+            --no-progress
+            README.md
+            CONTRIBUTING.md
+            'docs/**/*.md'
+          fail: true
+
   gates:
     name: the gates this package applies to others
     runs-on: ubuntu-latest
@@ -227,6 +264,65 @@ jobs:
   # subcommands; each would add minutes per run to assert one more vector. The failure mode
   # being guarded against is "the vector is not the command the tool accepts", and one real
   # invocation per tool catches it.
+  # The Python counterpart of the two layer jobs below, and it exists for exactly the
+  # argument their comment makes: this layer's coverage is argument-vector assertions, so a
+  # vector that is well-formed and *wrong* passes every other gate here and breaks in the
+  # first consumer that runs it. That argument was never Go- or Rust-specific -- the Python
+  # layer simply had the *appearance* of coverage, because `gates` runs `rhiza-task all`
+  # against this repository, which is one very unusual project: it is the package's own
+  # source tree, with a manifest tuned to it.
+  #
+  # So: a throwaway project, the way go-layer and rust-layer use one, for the same reason
+  # theirs lives in $RUNNER_TEMP rather than being committed here -- a second pyproject.toml
+  # inside this repository would change what `detect_layers` and every path setting resolve.
+  #
+  # `test` is the task chosen because it is the one with the most vector to get wrong: it
+  # pulls in `install` (so `uv lock --check` and `uv sync` both run for real) and then
+  # invokes pytest with the coverage flags assembled from config. The scratch project sets no
+  # folder settings, so what runs here is the *shipped defaults* -- which is precisely what a
+  # consumer gets, and what this repository's own manifest overrides.
+  python-layer:
+    name: python tasks against a real toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # Deliberately minimal: a real manifest, one module, one passing test. Anything more
+      # would be testing the fixture. `coverage_fail_under = 0` because the subject is the
+      # vector, not the fixture's coverage -- leaving the shipped default would fail this job
+      # on a fixture detail and teach nothing about the vector.
+      - name: Build a throwaway Python project
+        run: |
+          mkdir -p "$RUNNER_TEMP/pyproj/src/demo" "$RUNNER_TEMP/pyproj/tests"
+          cd "$RUNNER_TEMP/pyproj"
+          cat > pyproject.toml <<'EOF'
+          [project]
+          name = "demo"
+          version = "0.1.0"
+          requires-python = ">=3.11"
+
+          [build-system]
+          requires = ["hatchling"]
+          build-backend = "hatchling.build"
+
+          [dependency-groups]
+          test = ["pytest", "pytest-cov"]
+
+          [tool.rhiza-task]
+          coverage_fail_under = 0
+          EOF
+          printf 'def add(a, b):\n    "Add two numbers."\n    return a + b\n' > src/demo/__init__.py
+          printf 'from demo import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n' > tests/test_demo.py
+
+      # `--root` addresses the scratch project, as the two layer jobs do. A vector that uv or
+      # pytest rejects fails here, which is the whole point: no stub can reject one.
+      - name: rhiza-task test
+        run: uv run rhiza-task test --root "$RUNNER_TEMP/pyproj"
+
   go-layer:
     name: go tasks against a real toolchain
     runs-on: ubuntu-latest

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -107,6 +107,21 @@ jobs:
           uv run rhiza-task book
           echo "Docs build: $(($(date +%s) - START))s" >> "$GITHUB_STEP_SUMMARY"
 
+      # The gate on what was *published* rather than on what was built. zensical reports
+      # `No issues found` for a nav entry whose page is missing and for one whose asset is
+      # missing, so the TeX install above fixes one instance of the 404 and this catches the
+      # class: any nav target that did not make it into `_book/`.
+      #
+      # Same condition as the install above and as `deploy`, for a reason that is the whole
+      # design of the gate: several nav entries here resolve only once the gates that produce
+      # them have run -- the two `reports/` pages need a `_tests/` tree, the paper needs
+      # latexmk -- so on a branch a dangling entry is the machine's shape, and on the ref
+      # that publishes it is a defect. `book-nav` is deliberately not a prerequisite of
+      # `book` for the same reason; a test in tests/test_tasks.py holds that.
+      - name: Check every nav entry resolves (publishing refs only)
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
+        run: uv run rhiza-task book-nav
+
       # Downloadable from the run page, so a reviewer can open the built book for a branch
       # that will never be published.
       - name: Upload the book as a workflow artifact

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -91,19 +91,34 @@ jobs:
           if-no-files-found: ignore
 
   # The README carries six badges and a dozen links -- to PyPI, to sibling repos, to the
-  # uv and Ruff endpoints. Nothing else notices when one of them rots.
+  # uv and Ruff endpoints -- and docs/ adds eleven files of prose linking outward again.
+  # Nothing else notices when one of them rots.
+  #
+  # This is the *network* half, and it stays weekly on purpose: an external link that 404s
+  # is somebody else's deploy, and gating a pull request on it would fail builds for a
+  # reason the author cannot fix. ci.yml's `links` job is the half that can be gated --
+  # `--offline`, so it is deterministic -- and between them every link is covered by one or
+  # the other. See that job's comment for the division.
+  #
+  # Note what this job could *not* have caught pre-merge: the README's link to
+  # jebel-quant.github.io resolves against the *published* site, which lags a pull request
+  # by definition, so a page added in a PR is legitimately 404 until deploy. That class is
+  # `rhiza-task book-nav`'s, in rhiza_book.yml, not a link checker's.
   link-check:
-    name: README links
+    name: README and docs links
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check links in README.md
+      - name: Check links in README.md and docs/
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
             --verbose
             --no-progress
             --accept 200,206,429
+            --max-retries 3
             README.md
+            CONTRIBUTING.md
+            'docs/**/*.md'
           fail: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
 
 ## Where the gates run
 
-`ci.yml` has six jobs, and its comments explain each in detail. In short:
+`ci.yml` has eight jobs, and its comments explain each in detail. In short:
 
 - **`test`** — a 12-cell `pytest` matrix (3 OS × Python 3.11–3.14). **Windows is
   deliberate**, as the assertion that the shell dependency is gone, and the job carries a
@@ -198,10 +198,20 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
 - **`lint`** — `ruff check` and `ruff format --check`, both halves always running.
 - **`gates`** — the dogfood `uv run rhiza-task all`, plus the two gates deliberately outside
   `all`: `complexity` and `docs-examples`.
-- **`go-layer`** and **`rust-layer`** — the Rust and Go vectors against a *real* toolchain,
-  on a throwaway module built in `$RUNNER_TEMP`. These exist because those layers' coverage
-  is entirely argument-vector assertions, so a vector that is well-formed and *wrong* passes
-  every other gate here and breaks in the first consumer that has cargo or go installed.
+- **`links`** — lychee with `--offline` over `README.md` and `docs/`, so only *local*
+  targets are resolved. The network half stays in `weekly.yml`: an external 404 is somebody
+  else's deploy, and a gate that fails for reasons its author cannot fix is one people learn
+  to ignore. It is also the only thing checking docs cross-links at all — `docs-examples`
+  asks whether fences parse, markdownlint whether the markdown is well-formed, and neither
+  follows a link.
+- **`python-layer`**, **`go-layer`** and **`rust-layer`** — the three layers' vectors against
+  a *real* toolchain, on a throwaway project built in `$RUNNER_TEMP`. These exist because
+  those layers' coverage is entirely argument-vector assertions, so a vector that is
+  well-formed and *wrong* passes every other gate here and breaks in the first consumer that
+  runs it. The Python one was added last and is the least obvious: `gates` already runs
+  `rhiza-task all`, but against *this* repository — the package's own tree, with a manifest
+  tuned to it — so the shipped defaults a consumer actually gets were the part going
+  unexercised.
 - **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
   are real.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing
+
+Two facts first, because both contradict what a Python repository normally looks like and
+both cost time to rediscover.
+
+## There is no `Makefile`
+
+Run the gates through the CLI this package ships:
+
+```bash
+uv run rhiza-task list          # the whole registry, with prerequisites
+uv run rhiza-task all           # every gate, exactly as CI runs them
+uv run rhiza-task <task>        # one gate
+```
+
+`make test` will tell you there is no such file, and tools that probe for `make` will report
+every gate unavailable. That is this repository's shape, not a broken checkout: this package
+*is* the replacement for the template's make layer, so a repo consuming the template would
+run its gates through a published copy of this code rather than the working tree — which is
+circular. [`CLAUDE.md`](CLAUDE.md) has the full argument under *This repository is not
+rhiza-managed*.
+
+`uv run rhiza-task all` is the same entry point `ci.yml`'s `gates` job uses, so a green run
+locally means the same thing it means on CI.
+
+Two gates sit deliberately **outside** `all` and are named separately by CI —
+`rhiza-task complexity` and `rhiza-task docs-examples`. A third, `rhiza-task book-nav`, runs
+only on the branch that publishes the book. Running `all` alone will not exercise any of
+them.
+
+## Getting set up
+
+```bash
+uv sync --all-extras --all-groups     # or: uv run rhiza-task install
+uv run rhiza-task all
+```
+
+Nothing else is required. There is no `.rhiza/` directory to sync, no secrets, and no
+private index — `ci.yml` uses none either.
+
+## What the gates will hold you to
+
+Most of it is enforced, so this is a short list of what to expect rather than a set of rules
+to remember:
+
+| Expectation | Enforced by |
+|---|---|
+| 100% line coverage | `rhiza-task test`, `coverage_fail_under = 100` |
+| 100% docstring coverage over `src/` **and** `tests/`, with an `Args:` per parameter | `rhiza-task docs-coverage` |
+| No block above cyclomatic complexity 15 | `rhiza-task complexity` |
+| `ruff` clean, formatted; markdown, shell and workflows linted | `rhiza-task fmt` |
+| `ty` **and** `mypy --strict` clean | `rhiza-task typecheck` |
+| Every fenced example under `docs/` parses, and `result` blocks match | `rhiza-task docs-examples` |
+
+The coverage floor is load-bearing rather than decorative: it is what justifies the
+test-layout opt-out in `pyproject.toml`, so **lowering it invalidates that opt-out**. The
+two move together or neither moves.
+
+## Two invariants no gate checks
+
+These are the ones a newcomer breaks first, which is why they are here rather than left to
+the tooling.
+
+**The import graph is strictly layered**, and nothing enforces it:
+
+```text
+config, spec  →  uv  →  tasks/*  →  runner  →  cli
+```
+
+A lower layer never imports an upper one; there are no cycles; there are no function-local
+(deferred) imports; and no underscore-prefixed name crosses a module boundary. Check all
+four in two commands:
+
+```bash
+grep -rnE '^\s+(from|import) ' src/                          # deferred imports
+grep -rnE 'from \.{1,2}[a-z_.]* import .*\b_[a-z]' src/      # private cross-module imports
+```
+
+The first returns **two** lines, of which only one is an import — `spec.py`'s
+`TYPE_CHECKING` guard, which the rules permit. The other is prose in a `config.py` docstring
+that happens to begin with the word "from", so it is a false positive of matching text
+rather than syntax. The second should return nothing.
+
+**No test runs `uv`, or any other tool.** Every test patches `rhiza_task.uv`'s entry points
+through the `Recorder` fixture in `tests/conftest.py` and asserts on the argument vector that
+*would* have run. That is the point of the package rather than a shortcut: the make recipes
+expressed their contract as shell, and the vectors are that contract made assertable without
+provisioning a toolchain. So a new task's test asserts *what it would run*.
+
+If you find yourself wanting a real subprocess in a test, that is the signal that the logic
+belongs in a task body instead — which is why `docs-examples` is a task and not a test.
+
+## House style
+
+The comments in this repository are unusually dense, and that is the convention. The rule
+they follow: **say why, especially when the code looks wrong.** A flat `if ... raise`
+sequence that radon scores C, a `# nosec`, a version pinned one patch above upstream — each
+carries the bug it prevents or the decision it records. When you change such code, change the
+comment with it; a stale comment is worse than none.
+
+One placement rule that is easy to get wrong: a suppression comment's reason goes *above* the
+line, never after the marker, because bandit reads everything following `# nosec` as a list
+of test IDs.
+
+## Sending a change
+
+Branch, commit, open a PR against `main`. `ci.yml` runs on every pull request; `rhiza-task
+all` locally is the fastest way to know in advance what it will say.
+
+[`CLAUDE.md`](CLAUDE.md) is the deeper reference — it records the conventions held by
+discipline rather than by a gate, and the reasoning behind the decisions above. It is written
+for anyone changing this repository, human or agent.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,9 @@ No test in the suite runs uv. Every task test patches the four entry points in `
 executed, which is exactly what the make recipes expressed in `$$`-escaped shell and could
 not assert.
 
-`CLAUDE.md` carries the rest: the layering invariant the import graph holds by discipline,
-why the 100% coverage floor is load-bearing rather than decorative, and the house rule on
-comments. Read it before a first change.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the short version of all of this, and the place to
+start: how to run the gates without a `Makefile`, what the gates will hold you to, and the
+two invariants nothing checks. [`CLAUDE.md`](CLAUDE.md) carries the rest — the layering
+invariant the import graph holds by discipline, why the 100% coverage floor is load-bearing
+rather than decorative, and the house rule on comments. Read one of the two before a first
+change; read `CLAUDE.md` before a large one.

--- a/docs/adding_a_task.md
+++ b/docs/adding_a_task.md
@@ -91,7 +91,7 @@ A guard is the first of the three parts every recipe has. Two forms:
 
 When a guard fails the task reports:
 
-```
+```text
  skipped  audit  source_folder 'src' not found
 ```
 
@@ -156,7 +156,7 @@ consumer's CI reads.
 
 `load_tasks()` reports an import failure and moves on:
 
-```
+```text
 could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,7 +160,7 @@ exports one for every caller and deliberately leaves it empty for consumers, who
     unconditionally, and every consumer inherits it via `INHERIT`. With this empty, `book`
     invoked `uvx zensical build` with no `--with`, and zensical refused:
 
-    ```
+    ```text
     Error: mkdocstrings plugin is enabled, but mkdocstrings is not installed.
     ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -130,7 +130,7 @@ actually wants.
 `load_tasks()` imports every module in the `rhiza_task.tasks` entry-point group, and a
 failure is **reported and skipped** rather than fatal:
 
-```
+```text
 could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,7 +61,7 @@ Two likely causes:
 2. **Its module failed to import.** A plugin import error is reported and skipped rather
    than fatal, so look for this line earlier in the output:
 
-   ```
+   ```text
    could not load task module acme: ModuleNotFoundError: No module named 'acme_internal'
    ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,7 +33,7 @@ Start by asking what this repository has:
 uvx rhiza-task@1.0.0 list
 ```
 
-```
+```text
  task                section         needs                 does
  all                 Python          fmt deps test         run every gate, as
                                      docs-coverage         CI does
@@ -89,7 +89,7 @@ A task whose subject is absent **skips** rather than fails. `fmt` with no
 `.pre-commit-config.yaml`, `marimo-validate` with no notebooks, `paper` with no LaTeX
 folder — each reports `skipped` and a reason:
 
-```
+```text
  skipped  fmt  no .pre-commit-config.yaml
 ```
 
@@ -174,7 +174,7 @@ same configuration the tasks read:
 uvx rhiza-task@1.0.0 ci-os-matrix
 ```
 
-```
+```text
 ["ubuntu-latest"]
 ```
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -137,6 +137,7 @@ the output and reports the **first** status rather than the last.
 | task | needs | does |
 |---|---|---|
 | `book` | `test benchmark stress hypothesis-test paper` | build the companion book |
+| `book-nav` | — | check that every mkdocs nav entry resolves in the built book |
 | `serve` | `book` | build the book and serve it on port 8000 |
 | `marimo` | `install` | start the Marimo editor |
 | `marimo-validate` | `install` | check that every Marimo notebook runs |
@@ -153,6 +154,20 @@ repository with no paper — or no latexmk — still builds its book, because a 
 prerequisite does not block a dependent; only a failed one does. Under `--strict` that skip
 becomes a failure and would block `book`, which is worth knowing but is not specific to
 `paper`: `benchmark` and `stress` guard on folders most repositories do not have.
+
+`book-nav` is the other side of that permissiveness, and deliberately **not** a prerequisite
+of `book`. Skipping a producer is what lets a repository without latexmk still build its
+book — and the cost is that `mkdocs.yml` can name a target the build never wrote. zensical
+does not catch it: it reports `No issues found` for a nav entry whose page is missing *and*
+for one whose asset is missing, so such a site builds green and publishes a 404 in its own
+navigation. That is not hypothetical — it is what
+`https://jebel-quant.github.io/rhiza-task/paper/paper.pdf` did.
+
+So the check is a separate gate, for the ref that publishes rather than for every build.
+Markdown targets are matched against both forms mkdocs may write (`faq.html` and
+`faq/index.html`, per `use_directory_urls`); assets are matched verbatim; external targets
+are left to a link checker. It skips before the book is built and when the config declares
+no nav, because both are questions that are not askable rather than answers that are wrong.
 
 Its prerequisite list is also where make's no-op stubs came from: `book.mk` had to declare
 `test:: ; @:`, `benchmark:: ; @:`, `stress:: ; @:` and `hypothesis-test:: ; @:` so that
@@ -238,7 +253,7 @@ in the module docstring.
 `skipped` is not a soft failure and not a pass. It is the third status, and it is what
 makes one aggregate work across repositories with different bundles installed:
 
-```
+```text
       ok  install
       ok  typecheck
  skipped  fmt  no .pre-commit-config.yaml

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -67,6 +67,15 @@ class Failed(Exception):  # noqa: N818 - ditto
 # the order they fire. A dispatch table of five predicates would move that count rather
 # than reduce it, and would cost the reader the ordering -- tool before file before folder
 # before glob, cheapest and most likely first. The shape is deliberate.
+#
+# The ceiling, because 14 against `complexity_max = 15` leaves one branch of headroom and
+# "bounded by a closed set" stops being a complete answer that close to the gate: **a sixth
+# guard kind is the point where this must be decomposed.** Adding one costs two branches
+# here -- the clause itself, and the field's interaction with the existing ones -- so it
+# trips `rhiza-task complexity` rather than merely approaching it. The decomposition to
+# reach for then is a tuple of (predicate, message) checked in order, which keeps the
+# ordering the flat form is protecting; what not to reach for is raising the ceiling, since
+# that retires the only gate reading this comment back.
 @dataclass(frozen=True)
 class Guard:
     """A precondition on the repository layout.

--- a/src/rhiza_task/tasks/book.py
+++ b/src/rhiza_task/tasks/book.py
@@ -16,6 +16,7 @@ runner skips unregistered prerequisites, so all four stubs are gone.
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 
@@ -307,3 +308,157 @@ def _export_notebooks(cfg: Config) -> None:
             cwd=folder,
             withs=("marimo",),
         )
+
+
+_NAV_KEY = re.compile(r"^nav:\s*(?:#.*)?$")
+"""The ``nav:`` mapping's own line: top-level, so no leading whitespace."""
+
+
+def _nav_targets(text: str) -> list[str]:
+    """Extract the file targets from a mkdocs ``nav:`` block.
+
+    Hand-parsed rather than loaded with a YAML library, for the reason
+    :func:`~rhiza_task.tasks.quality.docs_examples` hand-parses fences instead of pulling a
+    markdown parser: this package declares three runtime dependencies and adding a fourth to
+    read eleven lines of one file is the wrong trade. The subset relied on is the one mkdocs
+    documents -- ``- Title: path`` and ``- path``, nested under section keys -- and the
+    parser is deliberately shallow: it collects targets and does not reconstruct the tree,
+    because the tree is not what a missing file is about.
+
+    Two things are skipped rather than reported. A section header (``- Guides:``, no value)
+    names no file. An external target (anything carrying ``://``) is not this gate's to
+    check -- reaching the network would make a docs build fail on someone else's outage,
+    which is what ``weekly.yml``'s link checker is for.
+
+    Args:
+        text: The contents of ``mkdocs.yml``.
+
+    Returns:
+        Every in-repository nav target, in document order, with duplicates kept.
+    """
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if _NAV_KEY.match(line)), None)
+    if start is None:
+        return []
+
+    targets: list[str] = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # A non-indented line is the next top-level key, which ends the nav block.
+        if not line[:1].isspace():
+            break
+        target = _nav_target(stripped)
+        if target:
+            targets.append(target)
+    return targets
+
+
+# Split out from the loop above rather than inlined, which is the opposite of the choice the
+# four C-ranked blocks elsewhere in this package defend -- and for the opposite reason. Those
+# keep a flat shape because decomposing them would cost the reader something real: the order
+# the guards fire in, or the one-branch-per-setting correspondence. Here there is no ordering
+# to protect. One line's grammar and the block's extent are genuinely separate questions, and
+# inlining both put the function at C (12) for no gain.
+def _nav_target(item: str) -> str | None:
+    """Return the file target a single nav list item names, if it names one.
+
+    Args:
+        item: One stripped line from inside the ``nav:`` block.
+
+    Returns:
+        The target, or None for a line that names no file -- a nested key with no ``- ``, a
+        section header carrying no value, or an external URL.
+    """
+    if not item.startswith("- "):
+        return None
+    value = item[2:].strip()
+    if "://" in value:
+        return None
+    target = value.rsplit(":", 1)[-1].strip() if ":" in value else value
+    return target or None
+
+
+def _built_candidates(target: str) -> tuple[str, ...]:
+    """Return the paths a nav target may legitimately have become in the built site.
+
+    A markdown page is not published under its own name: with mkdocs's default
+    ``use_directory_urls``, ``faq.md`` is written as ``faq/index.html``, and with it off as
+    ``faq.html``. Both are correct, and which one applies is a theme-and-config question this
+    function deliberately does not try to resolve -- accepting either is enough to answer
+    "was this page built at all?", which is the question. Anything that is not markdown is an
+    asset and is copied verbatim, so it has exactly one candidate.
+
+    Args:
+        target: A nav target as spelled in ``mkdocs.yml``.
+
+    Returns:
+        The candidate paths, relative to the built site, any one of which satisfies the nav
+        entry.
+    """
+    if not target.endswith(".md"):
+        return (target,)
+    stem = target[: -len(".md")]
+    return (f"{stem}.html", f"{stem}/index.html")
+
+
+@task(
+    "book-nav",
+    "check that every mkdocs nav entry resolves in the built book",
+    section="Book",
+    guards=(Guard(file="mkdocs.yml"),),
+)
+def book_nav(cfg: Config) -> None:
+    """Fail when ``mkdocs.yml`` names a nav target the built site does not contain.
+
+    The gap this closes, and it is a published one rather than a hypothetical: zensical
+    reports ``No issues found`` for a nav entry whose page does not exist *and* for one whose
+    asset does not exist. So `- Paper: paper/paper.pdf` survived a build in which
+    ``rhiza-task paper`` had skipped for want of latexmk, and the site deployed with a 404 in
+    its own navigation, green the whole way. Every other gate here asks about the source; this
+    is the only one that asks whether what was *published* holds together.
+
+    **Not a prerequisite of** :func:`book`, deliberately. Half the nav entries in a repository
+    like this one resolve only after the gates that produce them have run -- the two
+    ``reports/`` pages need a ``_tests/`` tree, the paper needs a LaTeX distribution -- and a
+    repository with no latexmk must keep building its book, which is exactly what a *skipped*
+    prerequisite buys. Making that a failure would break every consumer that documents a
+    paper it cannot compile locally. So this is a separate gate, named by ``rhiza_book.yml``
+    on the ref it deploys, where the entries are supposed to be complete and a dangling one is
+    a defect rather than a machine's shape.
+
+    Markdown targets are resolved through :func:`_built_candidates`; assets are matched
+    verbatim.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Skip: When the book has not been built, or ``mkdocs.yml`` declares no nav targets.
+            Both are "the question is not askable", not "the answer is wrong".
+        Failed: When at least one nav target is missing from the built site.
+    """
+    output = cfg.path("book_output")
+    if not output.is_dir():
+        raise Skip(f"no built book at '{cfg.book_output}'; run `rhiza-task book` first")
+
+    targets = _nav_targets((cfg.root / "mkdocs.yml").read_text(errors="replace"))
+    if not targets:
+        raise Skip("mkdocs.yml declares no nav targets")
+
+    missing = [
+        target
+        for target in targets
+        if not any((output / candidate).exists() for candidate in _built_candidates(target))
+    ]
+    for target in missing:
+        print(f"[ERROR] nav target not in the built book: {target}")
+
+    if missing:
+        raise Failed(
+            1,
+            f"{len(missing)} of {len(targets)} nav target(s) missing from '{cfg.book_output}' -- "
+            f"the site would publish a 404 in its own navigation",
+        )
+    print(f"[SUCCESS] all {len(targets)} nav target(s) resolve in {cfg.book_output}/")

--- a/tests/test_rhiza_packaging.py
+++ b/tests/test_rhiza_packaging.py
@@ -18,7 +18,11 @@ the one being tested, and every gate still passes.
 The rationale that does **not** carry over is upstream's second one -- that this is the only
 test a freshly synced project has, standing in for an empty suite that would let ``test``
 pass while measuring nothing. That vacuum cannot exist here: the suite is 300 tests behind a
-100% coverage floor. This file is one narrow invariant, not a floor.
+100% coverage floor. This file is narrow release-plumbing invariants, not a floor.
+
+The second such invariant is the release workflow's *filename*, which is load-bearing for
+publishing in a way no other file here is -- see
+:func:`test_the_trusted_publishing_workflow_keeps_its_filename`.
 
 Deliberately self-contained, as upstream is: no fixtures, so it cannot depend on what
 pytest-rhiza contributes to ``rhiza-task rhiza-test``.
@@ -89,4 +93,38 @@ def test_the_installed_version_matches_pyproject() -> None:
         f"The environment is stale, or the build backend is picking up a different tree -- re-run "
         f"`uv run rhiza-task install`, and check [build-system] and the packages it is told to "
         f"include if that does not fix it."
+    )
+
+
+# The one path in this repository that cannot be renamed by editing this repository alone.
+TRUSTED_PUBLISHING_WORKFLOW = ".github/workflows/rhiza_release.yml"
+"""The workflow filename PyPI's trusted publisher for this project is registered against."""
+
+
+def test_the_trusted_publishing_workflow_keeps_its_filename() -> None:
+    """The release workflow must keep the exact path PyPI's trusted publisher names.
+
+    PyPI Trusted Publishing validates the *workflow file path*, not the repository or the
+    job, so renaming this file silently revokes this project's ability to publish. The
+    failure is maximally delayed: every job stays green, `rhiza-task all` passes, the PR
+    merges, and the break surfaces only when a tag runs the release for real -- by which
+    point the release is the thing that is broken.
+
+    That is why the invariant is asserted here rather than left to the note in the
+    workflow's own header. A comment is read by whoever opens that file; a rename is done by
+    whoever *doesn't*. Renaming it legitimately means editing PyPI's publisher entry in the
+    same change, and then this test's constant -- which is the reminder, in the one place
+    that cannot be skipped.
+
+    Deliberately only existence, not content: what PyPI pins is the path. Asserting anything
+    about the jobs inside would couple this test to release-workflow edits it has no opinion
+    about, and every such coupling is a future red build that teaches nothing.
+    """
+    workflow = _ROOT / TRUSTED_PUBLISHING_WORKFLOW
+    assert workflow.is_file(), (
+        f"{TRUSTED_PUBLISHING_WORKFLOW} is missing. PyPI Trusted Publishing validates the exact "
+        f"workflow file path, so this project cannot publish until the file is restored at that "
+        f"path -- or, if the rename was deliberate, until PyPI's trusted publisher entry for this "
+        f"project is updated to the new filename and this test's TRUSTED_PUBLISHING_WORKFLOW "
+        f"follows it."
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -783,6 +783,142 @@ class TestBook:
         assert "genbadge[coverage]" in recorder.tools()
 
 
+class TestBookNav:
+    """``book-nav``: the gate on what the built site actually contains."""
+
+    NAV = """\
+site_name: demo
+nav:
+  - Home: index.md
+  # a comment inside the block
+  - Guides:
+      - Deep: guides/deep.md
+  - Paper: paper/paper.pdf
+  - bare.md
+  - Upstream: https://example.com/x.pdf
+
+extra:
+  social: []
+"""
+
+    def test_parses_titles_sections_bare_paths_and_skips_urls(self) -> None:
+        """The parser collects file targets and ignores what names no file.
+
+        Four shapes in one fixture, because they are the whole grammar mkdocs documents and
+        the parser is hand-written: a titled page, a section header with no value, an asset,
+        a bare path, and an external URL. The URL is the one that must *not* appear -- a
+        docs gate that reaches the network fails on somebody else's outage.
+        """
+        assert book_tasks._nav_targets(self.NAV) == [
+            "index.md",
+            "guides/deep.md",
+            "paper/paper.pdf",
+            "bare.md",
+        ]
+
+    def test_returns_nothing_without_a_nav_block(self) -> None:
+        """A config with no ``nav:`` declares no targets, which is not an error."""
+        assert book_tasks._nav_targets("site_name: demo\nextra: {}\n") == []
+
+    def test_ignores_a_nav_written_as_a_mapping(self) -> None:
+        """An entry with no ``- `` yields no target, rather than a mis-sliced one.
+
+        Writing ``nav:`` as a mapping instead of a list is a real mkdocs mistake, and the
+        branch that skips it is load-bearing rather than defensive: without it the line falls
+        through to ``stripped[2:]``, which would strip two characters off the *title* and
+        report ``index.md`` as a target it never actually found. Failing to parse is fine
+        here; inventing a target is not, because this gate's whole output is a list of names.
+        """
+        assert book_tasks._nav_targets("nav:\n  Home: index.md\n") == []
+
+    def test_markdown_resolves_to_either_built_form(self) -> None:
+        """A page may be published as ``x.html`` or ``x/index.html``; an asset only as itself.
+
+        Which of the two applies is mkdocs's ``use_directory_urls``, and this gate has no
+        opinion on it -- accepting either answers "was the page built", which is the question.
+        """
+        assert book_tasks._built_candidates("faq.md") == ("faq.html", "faq/index.html")
+        assert book_tasks._built_candidates("paper/paper.pdf") == ("paper/paper.pdf",)
+
+    def test_passes_when_every_target_was_built(self, cfg: Config) -> None:
+        """All four targets present, in both markdown forms, so the gate is silent.
+
+        Args:
+            cfg: The resolved config.
+        """
+        (cfg.root / "mkdocs.yml").write_text(self.NAV)
+        output = cfg.path("book_output")
+        for built in ("index.html", "guides/deep/index.html", "paper/paper.pdf", "bare.html"):
+            target = output / built
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("x")
+
+        book_tasks.book_nav(cfg)
+
+    def test_fails_naming_the_missing_asset(self, cfg: Config, capsys: pytest.CaptureFixture[str]) -> None:
+        """The published 404 this gate exists for: a nav entry whose asset was never written.
+
+        This is the paper's case exactly. ``rhiza-task paper`` skips without latexmk, the
+        build succeeds, zensical reports ``No issues found``, and the site deploys with a
+        dead entry in its own navigation -- so the assertion is that the *name* reaches the
+        operator, not merely that the count is wrong.
+
+        Args:
+            cfg: The resolved config.
+            capsys: pytest's output capture.
+        """
+        (cfg.root / "mkdocs.yml").write_text(self.NAV)
+        output = cfg.path("book_output")
+        for built in ("index.html", "guides/deep/index.html", "bare.html"):
+            target = output / built
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("x")
+
+        with pytest.raises(Failed, match="1 of 4"):
+            book_tasks.book_nav(cfg)
+        assert "paper/paper.pdf" in capsys.readouterr().out
+
+    def test_skips_before_the_book_is_built(self, cfg: Config) -> None:
+        """Nothing to inspect yet, which is not askable rather than wrong.
+
+        Args:
+            cfg: The resolved config.
+        """
+        (cfg.root / "mkdocs.yml").write_text(self.NAV)
+        with pytest.raises(Skip, match="no built book"):
+            book_tasks.book_nav(cfg)
+
+    def test_skips_when_the_config_declares_no_nav(self, cfg: Config) -> None:
+        """A built book and a config with no ``nav:`` measures nothing.
+
+        Args:
+            cfg: The resolved config.
+        """
+        (cfg.root / "mkdocs.yml").write_text("site_name: demo\n")
+        cfg.path("book_output").mkdir(parents=True, exist_ok=True)
+        with pytest.raises(Skip, match="no nav targets"):
+            book_tasks.book_nav(cfg)
+
+    def test_is_not_a_prerequisite_of_book(self) -> None:
+        """``book`` must not need this gate.
+
+        Half the nav entries here resolve only after the gates that produce them have run,
+        and a repository with no latexmk must still build its book -- which is what a skipped
+        prerequisite buys. Wiring this into ``book`` would turn that into a failure for every
+        consumer documenting a paper it cannot compile, so the omission is the design and a
+        test holds it.
+        """
+        spec = lookup("book")
+        assert spec is not None
+        assert "book-nav" not in spec.needs
+
+    def test_guards_on_the_mkdocs_config(self) -> None:
+        """No ``mkdocs.yml``, no nav to check -- declared as a guard, not re-checked in the body."""
+        spec = lookup("book-nav")
+        assert spec is not None
+        assert any(guard.file == "mkdocs.yml" for guard in spec.guards)
+
+
 class TestDoctorVersions:
     """doctor.mk's awk version comparison, as two functions."""
 


### PR DESCRIPTION
Closes #96, #97, #98, #99, #100, #101, #102 — the seven findings from the `/rhiza:quality`
run.

> **#95 is merged and the 404 is gone** — <https://jebel-quant.github.io/rhiza-task/paper/paper.pdf>
> now returns `200`, `application/pdf`, 349,277 bytes. This PR is one commit on top of that,
> based on `main`.

## #96 — `book-nav`, a new gate

I probed zensical with a bogus **page** *and* a bogus **asset** in `nav:`. It reported
`No issues found` for both. So nothing was checking that the published site contains what
`mkdocs.yml` names — which is why the paper's 404 deployed green.

The gate is **deliberately not a prerequisite of `book`**. Several nav entries here resolve
only after the gates that produce them have run — the two `reports/` pages need a `_tests/`
tree, the paper needs latexmk — and a repository without latexmk must keep building its book,
which is exactly what a *skipped* prerequisite buys. Making it a failure would break every
consumer documenting a paper it cannot compile locally. So it runs in `rhiza_book.yml` on the
ref that deploys, where a dangling entry is a defect rather than a fact about the machine. A
test holds the non-prerequisite so it cannot be "helpfully" wired in later.

Markdown targets match either form mkdocs may write (`faq.html` / `faq/index.html`); assets
match verbatim; external targets are left to the link checker. Skips before the book is built
and when the config declares no nav.

It currently **fails on this branch locally**, correctly — there is no latexmk on my machine,
which is precisely the case it is scoped away from.

## #97 — link checking split by determinism, not moved

- **`ci.yml` gains a `links` job**: lychee `--offline`, so only local targets resolve.
- **`weekly.yml` keeps the network sweep**, now widened to `docs/` and `CONTRIBUTING.md`.

The split is the point. An external 404 is somebody else's deploy, and a gate that fails for
reasons its author cannot fix is one people learn to ignore. Offline checking cannot do that.

**What a PR-time network check could not have caught anyway:** README's links into
`jebel-quant.github.io` resolve against the *published* site, which lags a PR by definition —
so a page added in a PR is legitimately 404 until deploy. That class is #96's job, not a link
checker's. Flagging the interpretation in case you read #97's "done when" more literally.

The `links` job is also the only thing checking docs **cross-links** at all: `docs-examples`
asks whether fences parse, markdownlint whether the markdown is well-formed, and neither
follows a link. Verified all 13 files' local links resolve, so it lands green.

## #98 — `python-layer`, the third real-toolchain job

`go-layer`'s own comment makes the argument, and it was never language-specific. The Python
layer only *looked* covered: `gates` runs `rhiza-task all`, but against this repository — the
package's own tree, with a manifest tuned to it. The scratch project sets no folder settings,
so what runs is the **shipped defaults a consumer actually gets**.

Verified by extracting the step's script, running it, and running
`rhiza-task test --root` against the result: `install` and `test` both green on a real
toolchain.

## #99 — the release filename, asserted

PyPI Trusted Publishing validates the exact workflow path, so renaming `rhiza_release.yml`
revokes publishing with every job still green until a tag runs for real. Now a test in
`tests/test_rhiza_packaging.py`. A comment is read by whoever opens that file; a rename is
done by whoever doesn't.

Existence only, deliberately — what PyPI pins is the path, and asserting anything about the
jobs inside would couple the test to edits it has no opinion about.

## #100 — the nine bare fences

All nine are **program output**, so `text` is the honest label rather than a workaround.
`docs-examples` now reports `9 text` instead of `9 (none)`, and the uncheckable count is
structural only:

```text
[INFO] 31 fence(s) not checkable: 11 toml, 9 text, 5 mermaid, 4 makefile, 2 yaml
```

## #101 — `CONTRIBUTING.md`

Leads with the two facts that contradict what a Python repo normally looks like: there is no
`Makefile`, and no test runs a tool. Carries the layering invariant's two grep commands
including which output is an expected false positive. Links to `CLAUDE.md` rather than
restating it; README now points at both.

## #102 — Guard's ceiling

At C (14) against `complexity_max = 15`, "bounded by a closed set" stops being a complete
answer. The comment now says a sixth guard kind is the decomposition point, which
decomposition to reach for, and why raising the ceiling is the wrong move — it would retire
the only gate reading the comment back.

## One incidental find

The new `_nav_targets` came in at **C (12)** — a fifth C block. Split rather than defended:
the four existing ones keep a flat shape because decomposing would cost the reader an ordering
or a one-branch-per-setting correspondence, and here there was none to protect. Back to four C
blocks, so `CLAUDE.md`'s count stays true.

## Gates

All 9 in `all` green, plus `complexity`, `docs-examples`, `fmt`, `typecheck`. **355 tests**,
coverage back at the **100** floor. Docs updated for the new task and jobs: `docs/tasks.md`,
and `CLAUDE.md`'s job count (six → eight) with the `links` and `python-layer` rationales.

**Not done, and not filed:** enabling GitHub's default CodeQL setup. It is a repository
settings toggle rather than a code change, and it remains the single highest-leverage
improvement — `code-scanning/default-setup` reads `not-configured`, and the green "CodeQL"
runs in Actions are the `dynamic` Code Quality product, not the security analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
