### PR TITLE
fix: decompose Guard to A (5), and retire the orphaned Scorecard comments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,13 @@
 #
 # Pull requests that modify matching paths require an approving review from a listed
 # owner. That requirement is enforced by `require_code_owner_review` in
-# .github/rulesets/main-branch-protection.json, and it feeds the OpenSSF Scorecard
-# Code-Review and Branch-Protection checks that .github/workflows/rhiza_scorecard.yml
-# publishes.
+# .github/rulesets/main-branch-protection.json.
 #
 # Repository admins can still bypass, per that ruleset's `bypass_actors` entry, so a
 # maintainer can self-merge without waiting for a second reviewer. Note what that costs:
-# Scorecard's Code-Review check counts *approved* changesets, so a bypassed merge leaves
-# it at 0 even with this file in place. Branch-Protection is the check this moves.
+# this file constrains who *can* approve, and the ruleset constrains what may reach main,
+# but neither records that a human actually reviewed a bypassed merge. So the protection
+# it buys is real for anyone without admin and advisory for anyone with it.
 #
 # One owner, not the `@Jebel-Quant/rhiza` team the upstream copy names: that team has no
 # access to this repository, and GitHub treats an owner without write access as unknown --

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -89,7 +89,8 @@ concurrency:
   cancel-in-progress: false
 
 # Least-privilege default: every job below re-declares exactly the write
-# scopes it needs (Scorecard Token-Permissions). Top-level stays read-only.
+# scopes it needs, so a compromised action in one job holds no token that
+# would let it write what a different job writes. Top-level stays read-only.
 permissions:
   contents: read
 
@@ -326,8 +327,9 @@ jobs:
         # Attach the SBOM's Sigstore attestation bundle to the release as a
         # recognised signature asset (*.sigstore.json). Non-buildable repos
         # (no [build-system], so no dist/*.intoto.jsonl provenance) would
-        # otherwise ship releases without any signature asset, which fails
-        # OpenSSF Scorecard's Signed-Releases check.
+        # otherwise ship a release whose SBOM nothing can authenticate --
+        # leaving a consumer unable to tell the published inventory from one
+        # edited after the fact.
         if: hashFiles('pyproject.toml') != '' && github.event.repository.private == false
         run: cp "${{ steps.attest-sbom.outputs.bundle-path }}" sbom.cdx.json.sigstore.json
 
@@ -350,8 +352,8 @@ jobs:
 
       - name: Stage provenance bundle for the GitHub release
         # Attach the SLSA provenance bundle to the release as a recognised
-        # signature asset (*.intoto.jsonl) so consumers — and OpenSSF
-        # Scorecard's Signed-Releases check — can verify the artifacts.
+        # signature asset (*.intoto.jsonl) so a consumer can verify which
+        # workflow run, on which commit, produced these artifacts.
         if: steps.buildable.outputs.buildable == 'true' && github.event.repository.private == false
         run: cp "${{ steps.provenance.outputs.bundle-path }}" dist/provenance.intoto.jsonl
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,15 +53,23 @@ actually runs. Renaming it means editing PyPI's publisher entry in the same chan
 now removed, which is what makes the paragraph above unqualified. Two consequences worth
 knowing:
 
-- **CodeQL security analysis is not running from a workflow any more.** GitHub's dynamic
-  *code-quality* scan still reports on pull requests, but that is a different product from
-  the security analysis, and default security setup reads `not-configured`. Enabling default
-  setup in repository settings restores the coverage with no workflow file and no upstream
-  dependency, which is strictly better than either delegating or vendoring; until it is
-  enabled, this repo has no CodeQL security scanning.
-- **The OSSF Scorecard badge and SARIF upload are gone with the scorecard workflow.** Note
-  that `rhiza_release.yml` still generates SBOMs and build attestations for Scorecard's
-  Signed-Releases check, so those comments describe a check nothing is currently scoring.
+- **CodeQL security analysis runs from GitHub's default setup, not from a workflow.**
+  GitHub's dynamic *code-quality* scan also reports on pull requests, but that is a
+  different product from the security analysis. Default setup was enabled in repository
+  settings on 2026-08-21 and covers `actions` and `python`, which restores the coverage
+  with no workflow file and no upstream dependency — strictly better than either
+  delegating to a stub or vendoring the workflow. So there is deliberately no `codeql.yml`
+  to find, and its absence is not a gap to fill:
+  `gh api repos/Jebel-Quant/rhiza-task/code-scanning/default-setup` reporting
+  `"state":"configured"` is how you confirm the coverage exists. That endpoint may report
+  `"languages":[]` straight after a settings change even while both analyses run; the
+  run's own jobs are the authority.
+- **The OSSF Scorecard badge and SARIF upload are gone with the scorecard workflow.**
+  `rhiza_release.yml` still generates SBOMs and build attestations, and `CODEOWNERS` still
+  gates review — but those are kept for consumers rather than for a scorer, and their
+  comments now say so on their own terms. Nothing here is scored by Scorecard; a comment
+  that implies otherwise is stale and should be rewritten, not left as a hint that a run
+  exists somewhere.
 
 A local `rhiza-task scorecard` task was considered as a replacement and rejected: Scorecard's
 checks are forge-API queries about the *remote* repository, so a local task could not give a
@@ -232,15 +240,26 @@ The comments here are unusually dense, and that is the convention rather than an
 The rule they follow: **say why, especially when the code looks wrong.** A flat
 `if ... raise` sequence that radon scores C, a `--partial-match` flag, a `# nosec`, a
 version pinned one patch above upstream — each carries the bug it prevents or the decision
-it records. Four blocks rank C on cyclomatic complexity and each states why the flat form
+it records. Two blocks rank C on cyclomatic complexity and each states why the flat form
 is preferred over a decomposition that would satisfy the metric.
 
-One rule those four are held to: **if the branch count grows, the comment states a
-ceiling.** Three of them are bounded by closed sets — `_run_one` by the size of `Status`,
-`Guard` and `Guard.check` by the number of guard kinds — so their figures cannot drift far
-and "deliberate" is a complete answer. `Config.__post_init__` is one branch per validated
-setting, which is open-ended, so it names C (15) as the point where per-group helpers win.
-A growth rule without a limit is an open licence rather than a decision.
+One rule those two are held to: **if the branch count grows, the comment states a
+ceiling.** `_run_one` is bounded by a closed set — the size of `Status` — so its figure
+cannot drift far and "deliberate" is a complete answer. `Config.__post_init__` is one
+branch per validated setting, which is open-ended, so it names C (15) as the point where
+per-group helpers win. A growth rule without a limit is an open licence rather than a
+decision.
+
+`Guard` and `Guard.check` used to be the other two, at C (14) and C (13). They are the
+worked example of a ceiling being *honoured* rather than restated: at one branch of
+headroom the comment stopped claiming "deliberate", named a tuple of
+`(predicate, message)` as the decomposition to reach for, and that decomposition is now
+`_clauses` — with the class at A (5). Two lessons kept from doing it. The helper is a
+module-level function because **radon scores a class as the sum of its methods**, so a
+second method would have relocated the 14 and reduced nothing. And it is a *generator*,
+because the property the flat form was really protecting was evaluation order — tool
+before file before folder before glob, each only reached if the last was satisfied — which
+a lazily-consumed `yield` keeps and an eagerly-built tuple of pairs would have lost.
 
 Unlike the layering invariant above, this one **is** gated: `rhiza-task complexity` fails on
 any block above `complexity_max`, which `pyproject.toml` leaves at the shipped 15, and
@@ -248,7 +267,8 @@ any block above `complexity_max`, which `pyproject.toml` leaves at the shipped 1
 read back by a build rather than by a reader who remembers to — which is the whole reason
 that note can say "roughly two more settings" and be held to it. `uvx radon cc src -a -s`
 remains how you read the figure by hand, and the gate reports the worst *block*, classes
-included, so the number to watch is currently `Guard`'s 14 rather than any method's 13.
+included — so the number to watch is currently `Config.__post_init__`'s 13, with
+`_run_one`'s 12 behind it and no class above either.
 
 When changing such code, update the comment with it. A stale comment is worse than none:
 `ci.yml` once asserted that `rhiza-task fmt` skipped for want of a pre-commit config, for

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -28,7 +28,7 @@ language-neutral and answers to its bare name, which is what ``core`` was.
 from __future__ import annotations
 
 import shutil
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -61,21 +61,30 @@ class Failed(Exception):  # noqa: N818 - ditto
         self.code = code
 
 
-# radon scores this class C (14) and :meth:`Guard.check` C (13) -- the class figure *is*
-# check's, since everything else here is five fields and a docstring. Both count the same
-# five ``if ... raise Skip`` clauses: one per kind of precondition, flat, no nesting, in
-# the order they fire. A dispatch table of five predicates would move that count rather
-# than reduce it, and would cost the reader the ordering -- tool before file before folder
-# before glob, cheapest and most likely first. The shape is deliberate.
+# This class used to hold five flat ``if ... raise Skip`` clauses, which scored C (14)
+# against `complexity_max = 15` -- one branch of headroom, so the sixth guard kind would
+# have tripped `rhiza-task complexity` rather than merely approached it. It is now the
+# decomposition that comment named: :func:`_clauses` yields one ``(unmet, message)`` pair
+# per precondition and :meth:`Guard.check` raises on the first unmet one.
 #
-# The ceiling, because 14 against `complexity_max = 15` leaves one branch of headroom and
-# "bounded by a closed set" stops being a complete answer that close to the gate: **a sixth
-# guard kind is the point where this must be decomposed.** Adding one costs two branches
-# here -- the clause itself, and the field's interaction with the existing ones -- so it
-# trips `rhiza-task complexity` rather than merely approaching it. The decomposition to
-# reach for then is a tuple of (predicate, message) checked in order, which keeps the
-# ordering the flat form is protecting; what not to reach for is raising the ceiling, since
-# that retires the only gate reading this comment back.
+# Three properties the flat form had, kept deliberately:
+#
+# * **The order still reads off the source** -- tool before file before folder before glob,
+#   cheapest and most likely first. That ordering was the whole reason the flat form was
+#   defended, and a generator preserves it where a dict of predicates would not.
+# * **Evaluation is still lazy.** Because :func:`_clauses` is a generator consumed one pair
+#   at a time, a guard whose tool is absent never stats the filesystem -- the same work the
+#   flat form did, in the same order. A tuple of eagerly-built pairs would have run every
+#   predicate before testing the first.
+# * **A sixth guard kind now costs one ``yield``**, not two branches in an already-full
+#   block. That is the point of having done this: the next kind is an edit, not a
+#   decomposition.
+#
+# `_clauses` is a module-level function rather than a second method, and that is load-bearing
+# rather than stylistic: radon scores a *class* as the sum of its methods, so moving these
+# branches to `Guard._clauses` would have relocated the 14 and reduced nothing. As written
+# the class scores A. Being module-private it also stays inside this module, which rule 4 of
+# CLAUDE.md's layering invariant requires of any underscore-prefixed name.
 @dataclass(frozen=True)
 class Guard:
     """A precondition on the repository layout.
@@ -162,20 +171,46 @@ class Guard:
             no test files found
             >>> tmp.cleanup()
         """
-        # Five guard clauses, each one precondition and each raising the line the runner
-        # prints -- see the note above the class for why they are not factored apart.
-        if self.tool and not have(self.tool):
-            raise Skip(self.reason or f"{self.tool} not found")
-        if self.file and not (root / self.file).is_file():
-            raise Skip(self.reason or f"no {self.file}")
-        if self.folder is None:
-            return
-        name = folders.get(self.folder, self.folder)
+        # The first unmet precondition wins, so `reason` overrides whichever message that
+        # clause generated -- see the note above the class for why the clauses live in a
+        # module-level generator rather than in this body or in a second method.
+        for unmet, message in _clauses(self, root, folders):
+            if unmet:
+                raise Skip(self.reason or message)
+
+
+def _clauses(guard: Guard, root: Path, folders: dict[str, str]) -> Iterator[tuple[bool, str]]:
+    """Yield each of *guard*'s preconditions as ``(unmet, message)``, in firing order.
+
+    The order is the contract: tool before file before folder before glob, cheapest and
+    most likely first. Being a generator, a pair is only produced -- and its predicate only
+    evaluated -- once the caller has consumed every earlier one, so the filesystem is left
+    alone when an earlier clause has already decided the outcome.
+
+    ``folder`` is tested with ``is not None`` rather than for truthiness, unlike the other
+    three: ``Guard(folder="")`` means the repository root, which is a satisfiable guard,
+    where an empty ``tool`` or ``file`` names nothing at all.
+
+    Args:
+        guard: The guard whose fields describe the preconditions.
+        root: Repository root.
+        folders: Resolved folder settings, e.g. ``{"source_folder": "src"}``.
+
+    Yields:
+        One ``(unmet, message)`` pair per precondition the guard declares. ``unmet`` is
+        True when the precondition fails; ``message`` is the line the runner prints unless
+        the guard carries its own ``reason``.
+    """
+    if guard.tool:
+        yield not have(guard.tool), f"{guard.tool} not found"
+    if guard.file:
+        yield not (root / guard.file).is_file(), f"no {guard.file}"
+    if guard.folder is not None:
+        name = folders.get(guard.folder, guard.folder)
         target = root / name
-        if not target.is_dir():
-            raise Skip(self.reason or f"{self.folder} '{name}' not found")
-        if self.glob and not any(target.rglob(self.glob)):
-            raise Skip(self.reason or f"no {self.glob} below '{name}'")
+        yield not target.is_dir(), f"{guard.folder} '{name}' not found"
+        if guard.glob:
+            yield not any(target.rglob(guard.glob)), f"no {guard.glob} below '{name}'"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes #104. Closes #105.

Two `Closes` keywords, one per issue, deliberately — see the note at the foot.

## #104 — `Guard` decomposed to A (5)

`Guard` was **C (14)** against `complexity_max = 15`. One branch of headroom means the
*sixth* guard kind would have tripped `rhiza-task complexity` rather than approached it,
turning a design change into an unplanned CI failure for whoever added the field. Its own
comment had already named the decomposition to reach for, so this applies it: `_clauses`
yields one `(unmet, message)` pair per precondition and `check` raises on the first unmet
one.

| Block | Before | After |
| --- | --- | --- |
| `Guard` (class) | C (14) | **A (5)** |
| `Guard.check` | C (13) | off the C-list |
| `_clauses` | — | A (5) |
| Average over `src/` | A (3.37) | A (3.26) |

Two C blocks remain — `_run_one` (12) and `Config.__post_init__` (13) — each with its
documented justification untouched.

### Two things the doing of it taught

Both are now in `CLAUDE.md`, because neither is recoverable from reading the result.

**`_clauses` is a module-level function, not a second method, and that is load-bearing.**
radon scores a class as the **sum** of its methods, so a `Guard._clauses` would have
relocated the 14 and reduced the class figure by nothing. #104's acceptance criterion was
the class, so the method version would have failed it while looking exactly like the
prescribed fix.

**It is a generator, not the tuple of pairs the old comment literally specified.** The
property that comment was protecting was evaluation *order* — tool before file before
folder before glob, each reached only if the last was satisfied. An eagerly-built tuple
runs every predicate before testing the first, so a guard whose tool is absent would stat
the filesystem anyway. A lazily-consumed `yield` keeps the order *and* the work.

### Behaviour is identical

Including one asymmetry preserved on purpose: `folder` keeps its `is not None` test, since
`Guard(folder="")` means the repository root and is satisfiable, where an empty `tool` or
`file` names nothing at all.

**No new tests.** The existing suite plus `Guard.check`'s ten doctests already covered
every branch, and coverage held at the 100 floor unmoved. That is the coverage floor doing
the job `[tool.check_test_layout] enforce = false` credits it with.

## #105 — the orphaned Scorecard comments

Five comments described OpenSSF Scorecard as scoring this repository. Nothing does; the
workflow is gone. Each now explains its practice on its own terms:

- **least-privilege permissions** — because a compromised action in one job should hold no
  token that writes what another job writes;
- **SBOM attestation** — so a release's inventory can be told from one edited after the
  fact;
- **SLSA provenance** — so a consumer can verify which workflow run, on which commit,
  produced the artifacts;
- **CODEOWNERS** — as a constraint on who *can* approve, honestly qualified by the fact
  that an admin bypass records no review at all.

**No behaviour changed.** The SBOMs, attestations and review gating are all worth keeping
on their own merits — only the justification had gone stale, and the house rule is that a
stale comment is worse than none. `dependabot.yml`'s mention is deliberately left alone:
it says both workflows *"have since been removed"*, which is accurate history.

## Folded in: this session's `CLAUDE.md` drift

CodeQL default setup was enabled for `actions` and `python` during the same session, which
made the paragraph promising that enabling it "restores the coverage" false the moment it
was true. Two further drifts this PR's own change created are corrected with it: *"Four
blocks rank C"* → two, and *"the number to watch is currently `Guard`'s 14"* →
`Config.__post_init__`'s 13.

## Gates

`rhiza-task all` green (9 gates), plus `complexity` and `docs-examples`. 353 tests,
coverage **100.00%**, `ty` and `mypy --strict` clean, pre-commit hooks green.

Layering invariant re-verified by hand: rule 3's grep still returns its two lines (the
`TYPE_CHECKING` guard plus the `config.py` prose false positive), rule 4's returns none,
and all 39 doctest examples are intact.

## Why two `Closes` keywords

`f3c3b1b` wrote `Closes #96, #97, #98, #99, #100, #101, #102` and only **#96** closed:
GitHub's closing keyword binds to the first reference in a list. Six already-fixed issues
sat open because of it, and were closed by hand earlier today. Repeating the keyword is
the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
