### PR TITLE
fix: close the three findings from the quality run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,166 @@ jobs:
       - name: rhiza-task rust:typecheck
         run: uv run rhiza-task rust:typecheck --root "$RUNNER_TEMP/demo-crate"
 
+  # The three jobs above exist because a vector that is well-formed and *wrong* passes every
+  # other gate here and breaks in the first consumer that runs it. That argument was never
+  # specific to the language layers, and cross-referencing every `rhiza-task <task>` in
+  # .github/ against the registry showed where else it applied: docker, presentation, marimo,
+  # lfs and the GitHub helpers -- around eighteen shipped vectors -- had no real execution
+  # anywhere, in the families a consumer reaches for after the core gates. This job is that
+  # gap closed. `bundle` is the suite's own word for them, from tests/test_bundle_tasks.py.
+  #
+  # One job rather than five, unlike the language layers: those are separate because each
+  # needs a different toolchain installed, whereas docker, node, git-lfs and gh are all
+  # preinstalled on ubuntu-latest, so five jobs would be five checkouts to say the same thing.
+  #
+  # Four vectors are deliberately *not* here, and the reason is structural rather than
+  # effort -- each one blocks forever by design, so a job running it would hang until the
+  # timeout rather than report anything:
+  #
+  #   docker-run           `docker run --rm -it`, an interactive terminal
+  #   presentation-serve   Marp's watching preview server
+  #   marimo               the Marimo editor, a headless server with no exit
+  #   book/serve           `python -m http.server`, already covered by rhiza_book.yml
+  #
+  # `presentation-pdf` is left out for a different and weaker reason: Marp renders PDF
+  # through headless Chrome, so the step would download a browser on every run. Its vector
+  # differs from `presentation`'s only by `--allow-local-files`, which is asserted in the
+  # suite. If it ever earns a real run, that is the trade to revisit.
+  #
+  # `lfs-pull` is left out because it needs a remote holding LFS objects; the fixture has no
+  # remote at all, and inventing one would test the fixture.
+  bundle-layer:
+    name: bundle tasks against a real toolchain
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The GitHub helpers are read-only queries, and each needs the scope for what it reads:
+      # `view-prs` pull-requests, `view-issues` issues, and `failed-workflows` and
+      # `workflow-status` the Actions API. GITHUB_TOKEN grants none of these from the
+      # workflow-level `contents: read`, so a missing line here is a 403 rather than a skip.
+      pull-requests: read
+      issues: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # One fixture for the four families that need a project, built to the shapes the tasks'
+      # guards actually look for: docker/Dockerfile, PRESENTATION.md, docs/notebooks/*.py, and
+      # a git repository for git-lfs to configure. `coverage_fail_under = 0` for the reason
+      # python-layer gives -- the subject is the vector, not the fixture's coverage.
+      - name: Build a throwaway project
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bundle/docker" "$RUNNER_TEMP/bundle/docs/notebooks" \
+                   "$RUNNER_TEMP/bundle/src/demo"
+          cd "$RUNNER_TEMP/bundle"
+          # src/demo exists because `marimo-validate` names `install` as a prerequisite, and
+          # `uv sync` builds the project: a manifest declaring hatchling with nothing for it to
+          # package fails the build, which blocks the task before its vector is ever reached.
+          # The other four families have no prerequisite and would not have noticed. Found by
+          # running this job's steps for real, which is the same way rust-layer learned that
+          # `cargo new crate` is rejected.
+          printf '"""A package for hatchling to build."""\n' > src/demo/__init__.py
+          cat > pyproject.toml <<'EOF'
+          [project]
+          name = "demo"
+          version = "0.1.0"
+          requires-python = ">=3.11"
+
+          [build-system]
+          requires = ["hatchling"]
+          build-backend = "hatchling.build"
+
+          [tool.rhiza-task]
+          coverage_fail_under = 0
+          EOF
+          # `ARG PYTHON_VERSION` on purpose: docker-build passes --build-arg whatever the
+          # layer, and a Dockerfile declaring no such ARG gets a warning. Declaring it is what
+          # asserts the flag is actually consumed rather than merely tolerated.
+          cat > docker/Dockerfile <<'EOF'
+          ARG PYTHON_VERSION=3.11
+          FROM alpine:3.22
+          RUN echo "built for python ${PYTHON_VERSION}"
+          EOF
+          # Marp needs front matter to treat the file as a deck rather than plain markdown.
+          cat > PRESENTATION.md <<'EOF'
+          ---
+          marp: true
+          ---
+
+          # Slide one
+
+          ---
+
+          # Slide two
+          EOF
+          # marimo-validate runs each notebook as a plain script and reads
+          # NOTEBOOK_OUTPUT_FOLDER, so a script that writes there is the smallest fixture that
+          # exercises the env-var half of the vector rather than just the exit status.
+          cat > docs/notebooks/demo.py <<'EOF'
+          import os
+          import pathlib
+
+          out = pathlib.Path(os.environ["NOTEBOOK_OUTPUT_FOLDER"])
+          out.mkdir(parents=True, exist_ok=True)
+          (out / "ran.txt").write_text("ok\n")
+          print("notebook ran")
+          EOF
+          git init --quiet .
+          git config user.email ci@example.com
+          git config user.name CI
+
+      # buildx with --load, against a real daemon. The vector's failure mode is a flag docker
+      # stopped accepting, which no stub can reject.
+      - name: rhiza-task docker-build
+        run: uv run rhiza-task docker-build --root "$RUNNER_TEMP/bundle"
+
+      # Immediately after, so the image it removes is one this run built. `docker rmi` is
+      # `check=False` in the task -- removing an image that was never built is the expected
+      # state of a clean target -- so this asserts the vector parses, not that it found work.
+      - name: rhiza-task docker-clean
+        run: uv run rhiza-task docker-clean --root "$RUNNER_TEMP/bundle"
+
+      # Resolves through the npx branch of marp_argv, which is the one a consumer without a
+      # global marp hits. The first real exercise of cfg.marp_package.
+      - name: rhiza-task presentation
+        run: uv run rhiza-task presentation --root "$RUNNER_TEMP/bundle"
+
+      - name: rhiza-task marimo-validate
+        run: uv run rhiza-task marimo-validate --root "$RUNNER_TEMP/bundle"
+
+      # git-lfs is preinstalled on ubuntu-latest. `lfs-install` is the one task in that module
+      # that raises Failed rather than Skip on a missing binary, so an image that dropped
+      # git-lfs would fail here loudly instead of skipping quietly -- which is the correct
+      # outcome and worth having somewhere.
+      - name: rhiza-task lfs-install, lfs-track, lfs-status
+        run: |
+          uv run rhiza-task lfs-install --root "$RUNNER_TEMP/bundle"
+          uv run rhiza-task lfs-track --root "$RUNNER_TEMP/bundle"
+          uv run rhiza-task lfs-status --root "$RUNNER_TEMP/bundle"
+
+      # Against the checkout, not the fixture: every one of these resolves the repository from
+      # the git remote, so a throwaway directory with no remote would test nothing. All are
+      # read-only queries.
+      #
+      # `whoami` runs `gh auth status --json hosts --template ...`, and `--json` on that
+      # subcommand is recent enough that this job is the only thing asserting the installed gh
+      # still has it.
+      - name: rhiza-task github helpers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uv run rhiza-task whoami
+          uv run rhiza-task view-prs
+          uv run rhiza-task view-issues
+          uv run rhiza-task failed-workflows
+          uv run rhiza-task workflow-status
+          uv run rhiza-task latest-release
+
   # The floors in pyproject.toml -- typer>=0.15, rich>=13.0, python-dotenv>=1.0 -- are a
   # claim, and `--frozen` everywhere else means nothing tests it: the lockfile resolves
   # typer 0.27.1 and rich 15.0.0, nine and two minor versions above what the manifest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,6 +6,10 @@
 #
 # Its third job, semgrep, is not lifted: `rhiza-task semgrep` skips without
 # .rhiza/semgrep.yml and this repository ships none, exactly as pytest-rhiza does not.
+#
+# Two more jobs here are local rather than lifted, so the count does not reconcile with
+# upstream's: `advisories` and `link-check`. Both exist because nothing else asks their
+# question -- see each one's own comment.
 
 name: Weekly
 
@@ -49,6 +53,50 @@ jobs:
       # dependencies, so the CLI under test has to be the one in the tree.
       - name: Run the gates
         run: uv run rhiza-task test
+
+  # `rhiza-task security` is bandit, which is SAST: it lints the source this repository owns
+  # and never looks at what is installed. So nothing asked the *dependency* question, and
+  # tasks/python.py's `security` docstring explains at length why the answer is not to add
+  # pip-audit to that task -- doing so would put a gate in consumers' CI that the template
+  # they also follow says is not there. That argument is about the *shipped task*. It says
+  # nothing about this repository scanning its own lockfile in its own workflow, which is
+  # what this job does: no consumer inherits it, and no published gate changes.
+  #
+  # Weekly, and for the reason link-check below is weekly rather than the reason mutation is:
+  # an advisory published on Tuesday is not the Tuesday author's fault, so gating a pull
+  # request on it would fail builds for something the author cannot fix. A scheduled run is a
+  # notification instead.
+  #
+  # Deliberately *not* continue-on-error, unlike mutation. A surviving mutant is a prompt to
+  # write an assertion; a published advisory against a pinned dependency is a fact that wants
+  # someone to look. Red is the whole signal, and it blocks nothing. If an advisory ever lands
+  # with no fixed version available, the escape hatch is `--ignore-vuln <ID>` carrying its
+  # reason on the line above -- not continue-on-error, which would silence every future one
+  # too.
+  advisories:
+    name: dependency advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # The committed lockfile is the subject, so `--frozen`: resolving afresh would scan
+      # versions this repository has not pinned and miss the ones it has. `--all-extras
+      # --all-groups` because a vulnerable test-only dependency still executes in CI, and
+      # `--no-emit-project` drops rhiza-task itself, which is the thing being audited rather
+      # than an input to the audit.
+      - name: Export the locked dependency set
+        run: >
+          uv export --frozen --all-extras --all-groups --no-emit-project
+          --format requirements-txt -o requirements.txt
+
+      # `uvx`, not a dependency: this is the only place pip-audit is used, and provisioning it
+      # per run keeps it out of the manifest that `lowest-deps` has to resolve.
+      - name: Audit them against the advisory database
+        run: uvx pip-audit -r requirements.txt
 
   # The complement of the 100 coverage floor, which pyproject.toml is careful to say does
   # not claim what it looks like it claims: at 100 no statement is *unvisited*, and nothing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,24 @@ diffed** against the `python` fences above it, so an example that goes stale fai
 rather than quietly outdating — and the prelude is every earlier `python` fence in that
 file, because `adding_a_task.md`'s pair needs the first fence's `@task` before the second's
 `lookup` — that page holds the one `result` block in the tree, which is why the gate's
-summary line reads `1 diffed`. And fences in a language it cannot check (`toml`, `mermaid`,
-`makefile`, `yaml`, and those carrying no language) are **reported with a count** rather
+summary line reads `1 diffed`. And fences in a language it cannot check (`mermaid`,
+`makefile`, and those carrying no language) are **reported with a count** rather
 than passed over in silence, because a green line with no numbers reads as full coverage.
+
+`toml` and `yaml` used to be in that uncheckable list and are now parsed, which is worth
+knowing for two reasons beyond the count moving from 31 to 18. The `toml` half is
+in-process `tomllib` — stdlib at this package's `>=3.11` floor, so it is checked on every
+machine that can run the gate — and it covers the eleven fences quoting this repo's *own*
+`[tool.rhiza-task]` and `[tool.bumpversion]` settings, which is the class that goes stale
+when a setting is renamed. The `yaml` half is a **provisioned subprocess**
+(`uv run --no-project --with pyyaml`), deliberately not a dependency: `rhiza-task` is a
+published CLI, so a runtime dependency is an install cost every consumer pays on every
+`uvx` invocation, and two fences do not justify one. That makes yaml the second check
+after `bash -n` that can go *unavailable* on a working machine, and both follow the same
+rule — the fences are counted out of `checked` and named on their own `[INFO]` line, never
+assumed sound. Parsing is not validation: a fence that parses may still name a setting
+this package does not have, and for the workflow snippets actionlint already owns that
+question over the real files.
 
 ## The coverage floor is 100, and it is load-bearing
 
@@ -198,7 +213,7 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
 
 ## Where the gates run
 
-`ci.yml` has eight jobs, and its comments explain each in detail. In short:
+`ci.yml` has nine jobs, and its comments explain each in detail. In short:
 
 - **`test`** — a 12-cell `pytest` matrix (3 OS × Python 3.11–3.14). **Windows is
   deliberate**, as the assertion that the shell dependency is gone, and the job carries a
@@ -220,6 +235,18 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
   `rhiza-task all`, but against *this* repository — the package's own tree, with a manifest
   tuned to it — so the shipped defaults a consumer actually gets were the part going
   unexercised.
+- **`bundle-layer`** — the same argument carried past the language layers, which is where it
+  always led: `docker`, `presentation`, `marimo`, `lfs` and the GitHub helpers had no real
+  execution anywhere, so around eighteen shipped vectors rested on unit assertions alone.
+  One job rather than five, because docker, node, git-lfs and `gh` are all preinstalled on
+  `ubuntu-latest` and the language layers are separate only because each needs its own
+  toolchain. **Four vectors are deliberately absent and cannot be added**: `docker-run`
+  (`-it`), `presentation-serve`, `marimo` and `serve` each block forever by design, so a
+  step running one would hang to the timeout rather than report. `presentation-pdf` is
+  absent for a weaker reason — Marp renders PDF through headless Chrome, so it would
+  download a browser per run, and its vector differs from `presentation`'s by one flag the
+  suite already asserts. `lfs-pull` needs a remote holding LFS objects, and the fixture has
+  no remote.
 - **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
   are real.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -97,11 +97,25 @@ and checks the floor itself.
 fence it can check. None is a defect — see [Skip is an outcome](#skip-is-an-outcome).
 
 `docs-examples` parses every `python` fence with `compile`, every `bash` fence with
-`bash -n` — parsed, never executed — and runs the `python` fences that a ```result```
-block follows, diffing what they print against that block. Fences in any other language
-are reported as unchecked with a count, because silence there would read as full
-coverage. It answers the question no other gate does: not "is there a docstring?" but
-"is what the documentation claims still true?"
+`bash -n` — parsed, never executed — every `toml` fence with `tomllib`, every `yaml` fence
+with a real parser, and runs the `python` fences that a ```result``` block follows,
+diffing what they print against that block. Fences in any other language are reported as
+unchecked with a count, because silence there would read as full coverage. It answers the
+question no other gate does: not "is there a docstring?" but "is what the documentation
+claims still true?"
+
+Two of those five can go unavailable on a machine that runs the gate fine otherwise, and
+both say so on their own line rather than passing quietly: `bash` may be absent (a stock
+Windows runner), and the yaml parser is *provisioned* rather than depended on — `rhiza-task`
+is a published CLI, so a runtime dependency is an install cost every consumer pays on every
+invocation, which two fences do not justify. In either case those fences are counted out of
+the checked total, never assumed sound. `toml` has no such caveat: `tomllib` is stdlib at
+this package's `>=3.11` floor.
+
+Parsing is not validation. A `toml` fence that parses may still name a setting that does not
+exist, and a `yaml` fence that parses may still be an invalid workflow; checking either would
+need the schema. What this closes is the narrower gap where a fence stopped being the language
+it claims.
 
 `complexity` is the one task in this section that is Python-only: it runs `radon`, so it is
 registered in the `python` layer even though it reads like a neutral gate. It measures every

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -266,6 +266,18 @@ def security(cfg: Config) -> None:
     Closing the gap belongs upstream, where both halves move together. Recorded here so
     the next reader does not have to rediscover which of the two it is.
 
+    What that argument covers is the *shipped task*, and it is worth being precise about the
+    limit, because the paragraph above used to be the only note on the subject and so read as
+    "nothing anywhere audits dependencies". This repository does audit its own: ``weekly.yml``
+    exports the committed lockfile and runs ``pip-audit`` over it on a schedule. Nothing about
+    that reaches a consumer -- no task name, no prerequisite of ``all``, nothing a
+    ``uvx rhiza-task`` invocation can find -- which is exactly why it is a workflow job and not
+    the two lines it would take to add here.
+
+    So the honest summary is that the gap is closed for this repository and open for consumers,
+    deliberately and in that order. If it is ever closed for consumers too, this is the place
+    that changes, and the note above is the argument that has to be answered first.
+
     Args:
         cfg: The resolved config.
     """

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -22,6 +22,7 @@ import shutil
 # explanation becomes one `Test in comment:` warning per word.
 import subprocess  # nosec B404
 import textwrap
+import tomllib
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,7 +69,19 @@ PYTHON_FENCE_LANGUAGE = "python"
 # The convention README.md already uses and pytest-rhiza's `test_readme_validation` already
 # checks *there*: a ```result``` block holds the expected stdout of the python fence above it.
 RESULT_FENCE_LANGUAGE = "result"
-CHECKED_FENCE_LANGUAGES = SHELL_FENCE_LANGUAGES | {PYTHON_FENCE_LANGUAGE, RESULT_FENCE_LANGUAGE}
+# `tomllib` is stdlib at the floor this package declares (`requires-python = ">=3.11"`), so
+# the toml half costs nothing to provision -- and it is the half that matters most here: the
+# toml fences under `docs/` are this package's own `[tool.rhiza-task]` and `[tool.bumpversion]`
+# examples, which is precisely the class that goes stale when a setting is renamed or a
+# default moves. Eleven of them at the time of writing, against two yaml.
+TOML_FENCE_LANGUAGE = "toml"
+# `yml` as well as `yaml`: mkdocs-material's own docs spell it both ways, and a fence this set
+# failed to name would be silently counted as unchecked rather than parsed -- the exact
+# silence this gate exists to break.
+YAML_FENCE_LANGUAGES = frozenset({"yaml", "yml"})
+CHECKED_FENCE_LANGUAGES = (
+    SHELL_FENCE_LANGUAGES | YAML_FENCE_LANGUAGES | {PYTHON_FENCE_LANGUAGE, RESULT_FENCE_LANGUAGE, TOML_FENCE_LANGUAGE}
+)
 
 
 @dataclass(frozen=True)
@@ -87,6 +100,35 @@ class Fence:
     line: int
     language: str
     code: str
+
+
+@dataclass(frozen=True)
+class Tally:
+    """How many fences of each kind the tree holds.
+
+    A record rather than the tuple this used to be. Four counts unpacked positionally were
+    already at the edge of readable; toml and yaml take it to six, where
+    ``python, shell, toml, yaml, diffed, unchecked = _tally(fences)`` stops being checkable by
+    eye and a transposed pair would report shell fences as toml with nothing failing. The
+    fields carry the meaning instead.
+
+    Attributes:
+        python: ``python`` fences, checked by :func:`compile`.
+        shell: ``bash``/``sh`` fences, checked by ``bash -n`` when bash is present.
+        toml: ``toml`` fences, checked in-process by :mod:`tomllib`.
+        yaml: ``yaml``/``yml`` fences, checked by a provisioned parser in a subprocess.
+        diffed: ``result`` fences, executed and compared against the python fences above them.
+        unchecked: Each remaining language paired with its count, commonest first and then
+            alphabetically so the report line is diffable between runs. A fence with no
+            language at all is counted under ``(none)``.
+    """
+
+    python: int
+    shell: int
+    toml: int
+    yaml: int
+    diffed: int
+    unchecked: list[tuple[str, int]]
 
 
 @task("fmt", "run the pre-commit hooks over all files", section="Quality")
@@ -251,18 +293,29 @@ def docs_examples(cfg: Config) -> None:
     Not a second check of ``README.md``, deliberately: that file is pytest-rhiza's subject,
     and counting one verdict twice would make two gates report one fact.
 
-    Three kinds of fence are checked and the rest are counted:
+    Five kinds of fence are checked and the rest are counted:
 
     * ``python`` -- :func:`compile`, so a fence that is a *fragment* still passes. Names need
       not resolve; only the syntax is asserted.
     * ``bash``/``sh`` -- ``bash -n``, which parses without executing. Never executed, because
       a README's shell is routinely ``rm -rf`` and ``git push``, and an unparseable fence is a
       documentation bug without running it.
+    * ``toml`` -- :func:`tomllib.loads`, in this process. Stdlib at this package's Python
+      floor, so it needs nothing provisioned.
+    * ``yaml``/``yml`` -- a real parser, provisioned into a subprocess because adding one to
+      this package's runtime dependencies to serve two fences would be the wrong trade: it is
+      a published CLI whose install cost every consumer pays.
     * ``result`` -- executed and diffed against the python fences above it.
 
-    Anything else -- ``toml``, ``mermaid``, ``makefile``, ``yaml``, and fences carrying no
-    language at all -- is reported as unchecked. Naming the count is the point: silence there
-    would read as "everything was checked".
+    Anything else -- ``mermaid``, ``makefile``, and fences carrying no language at all -- is
+    reported as unchecked. Naming the count is the point: silence there would read as
+    "everything was checked".
+
+    Parsing is *not* validation, and the distinction is worth keeping: a ``toml`` fence that
+    parses may still name a setting this package does not have, and a ``yaml`` fence that
+    parses may still be an invalid workflow. Schema-checking either would need the schema, and
+    for the workflow snippets actionlint already owns that question over the real files. What
+    this closes is the narrower gap where a fence stopped being the language it claims.
 
     ``install`` is a prerequisite because the executed half imports the project's own
     packages, exactly as :func:`rhiza_test`'s docstring check does.
@@ -289,15 +342,23 @@ def docs_examples(cfg: Config) -> None:
     ]
     fences = [fence for one_file in per_file for fence in one_file]
 
+    # None, not [], when the parser could not be provisioned: an empty list is
+    # "checked, all sound", and reporting a machine's missing network as a clean bill of
+    # health is the one thing this gate must never do. `bash` is handled the same way one
+    # line above, by the same argument.
+    yaml_broken = _yaml_violations(fences, cfg, scratch)
+
     broken = [
         *_syntax_violations(fences),
         *(_shell_violations(fences, bash, scratch) if bash else []),
+        *_toml_violations(fences),
+        *(yaml_broken or []),
         *_result_violations(per_file, cfg, scratch),
     ]
     for violation in broken:
         print(violation)
 
-    if not _report(fences, bash, len(per_file)):
+    if not _report(fences, bash, yaml_broken is not None, len(per_file)):
         raise Skip(f"no checkable fence under {cfg.docs_folder}")
     if broken:
         raise Failed(1, f"{len(broken)} broken example(s) under {cfg.docs_folder}")
@@ -468,6 +529,118 @@ def _shell_violations(fences: list[Fence], bash: str, scratch: Path) -> list[str
     return broken
 
 
+def _toml_violations(fences: list[Fence]) -> list[str]:
+    """Return one message per toml fence that does not parse.
+
+    In this process and with no subprocess, unlike every other checker here, because
+    :mod:`tomllib` is stdlib from 3.11 and this package declares ``requires-python = ">=3.11"``.
+    So there is nothing to provision and nothing to skip for: a toml fence is checked on every
+    machine that can run the gate at all, which is not true of the shell or yaml halves.
+
+    A *fragment* is accepted the way :func:`_syntax_violations` accepts one -- ``tomllib``
+    parses a bare ``key = value`` with no table header perfectly well, which is what most
+    configuration examples in ``docs/`` are. Only genuine syntax errors are reported.
+
+    Args:
+        fences: Every fence in the tree.
+
+    Returns:
+        Violation messages, one per broken fence.
+    """
+    broken: list[str] = []
+    for fence in fences:
+        if fence.language != TOML_FENCE_LANGUAGE:
+            continue
+        try:
+            tomllib.loads(fence.code)
+        except tomllib.TOMLDecodeError as exc:
+            # `exc` already carries "(at line N, column M)", and that N is relative to the
+            # fence body. Prefixing the fence's own line would produce two numbers meaning
+            # different things on one line, so the message is taken whole and the fence is
+            # located by its opening line alone -- the same choice `_shell_violations` makes.
+            broken.append(f"{fence.path}:{fence.line}: toml fence does not parse: {exc}")
+    return broken
+
+
+def _yaml_violations(fences: list[Fence], cfg: Config, scratch: Path) -> list[str] | None:
+    """Return one message per yaml fence that does not parse, or None when unmeasured.
+
+    The one checker here that needs a package this project does not depend on. That is the
+    whole reason it is a subprocess: ``rhiza-task`` is a published CLI, so every runtime
+    dependency is an install cost paid by every consumer on every ``uvx`` invocation, and
+    taking one on to parse two fences in this repository's own docs would be a poor trade.
+    ``uv_run(..., withs=("pyyaml",), no_project=True)`` provisions it for the length of one
+    call instead -- the same move :func:`~rhiza_task.tasks.book.marimo` makes for marimo, and
+    the reason :mod:`rhiza_task.uv` grew ``withs`` at all.
+
+    The fences are written to files rather than embedded in the generated script. Embedding
+    would need them escaped into a literal, and a yaml fence is exactly the kind of text --
+    quotes, backslashes, indentation that carries meaning -- where an escaping bug would look
+    like a parse failure in the document. Files move the bytes without reinterpreting them.
+
+    Args:
+        fences: Every fence in the tree.
+        cfg: The resolved config.
+        scratch: Directory for the throwaway files.
+
+    Returns:
+        Violation messages, one per broken fence; an empty list when the tree holds no yaml
+        fence or every one of them parsed; or None when the parser could not be provisioned,
+        so the caller can report them as unchecked rather than sound.
+    """
+    targets = [fence for fence in fences if fence.language in YAML_FENCE_LANGUAGES]
+    if not targets:
+        return []
+
+    folder = scratch / "yaml"
+    folder.mkdir(parents=True, exist_ok=True)
+    for number, fence in enumerate(targets):
+        (folder / f"{number:04d}.yaml").write_text(fence.code)
+    (folder / "index.txt").write_text("\n".join(f"{fence.path}:{fence.line}" for fence in targets))
+
+    report = folder / "report.txt"
+    # Unlinked first: the file's *existence* is how a run that happened is told from one that
+    # never started, so a stale copy from a previous invocation would report last run's
+    # verdict as this one's.
+    report.unlink(missing_ok=True)
+    script = scratch / "fence_yaml.py"
+    script.write_text(
+        textwrap.dedent(
+            """\
+            import pathlib
+
+            import yaml
+
+            here = pathlib.Path(__file__).parent / "yaml"
+            broken = []
+            for number, where in enumerate((here / "index.txt").read_text().splitlines()):
+                try:
+                    yaml.safe_load((here / f"{number:04d}.yaml").read_text())
+                except yaml.YAMLError as exc:
+                    # Flattened: a YAMLError's str spans four lines with a caret diagram, and
+                    # the report this joins is one line per violation.
+                    detail = " ".join(str(exc).split())
+                    broken.append(f"{where}: yaml fence does not parse: {detail}")
+            (here / "report.txt").write_text("\\n".join(broken))
+            """
+        )
+    )
+
+    uv_run(
+        "python",
+        script.relative_to(cfg.root).as_posix(),
+        cwd=cfg.root,
+        withs=("pyyaml",),
+        no_project=True,
+        check=False,
+    )
+    if not report.is_file():
+        return None
+    # An empty report file is "ran, found nothing", which splitlines turns into [] -- distinct
+    # from the None above, and the distinction is the point of writing the file at all.
+    return report.read_text(errors="replace").splitlines()
+
+
 def _result_violations(per_file: list[list[Fence]], cfg: Config, scratch: Path) -> list[str]:
     """Return one message per ``result`` block that no longer matches what its python prints.
 
@@ -555,7 +728,7 @@ def _run_fences(cfg: Config, scratch: Path, codes: list[str]) -> str | None:
     return printed.read_text(errors="replace")
 
 
-def _tally(fences: list[Fence]) -> tuple[int, int, int, list[tuple[str, int]]]:
+def _tally(fences: list[Fence]) -> Tally:
     """Count the fences by what can be done with them.
 
     Split out of :func:`_report` rather than inlined there, which read more directly: the two
@@ -564,51 +737,81 @@ def _tally(fences: list[Fence]) -> tuple[int, int, int, list[tuple[str, int]]]:
     separate jobs, so this is the decomposition the metric asks for rather than a contortion
     to satisfy it.
 
+    Since toml and yaml joined, that argument has stopped being about taste: at B (7) here and
+    B (10) there, one function doing both would land above ``complexity_max`` and fail
+    ``rhiza-task complexity`` outright. So this split is now held by the gate rather than by
+    the reader who remembers why it is here.
+
     Args:
         fences: Every fence in the tree.
 
     Returns:
-        ``(python, shell, diffed, unchecked)``, where ``unchecked`` pairs each remaining
-        language with its count, commonest first and then alphabetically so the line is
-        diffable between runs. A fence with no language is counted under ``(none)``.
+        The counts, as a :class:`Tally`.
     """
     tally = Counter(fence.language or "(none)" for fence in fences)
     unchecked = sorted(
         ((language, count) for language, count in tally.items() if language not in CHECKED_FENCE_LANGUAGES),
         key=lambda item: (-item[1], item[0]),
     )
-    return (
-        tally[PYTHON_FENCE_LANGUAGE],
-        sum(tally[language] for language in SHELL_FENCE_LANGUAGES),
-        tally[RESULT_FENCE_LANGUAGE],
-        unchecked,
+    return Tally(
+        python=tally[PYTHON_FENCE_LANGUAGE],
+        # B604 matches the *keyword name* here and reads this as a subprocess call being handed
+        # a shell. It is a field assignment on a frozen dataclass of integers, and the nearest
+        # subprocess is two hundred lines away. Renaming the field to dodge the pattern would
+        # cost the symmetry with `python`, `toml`, `yaml` and `diffed` -- which is the whole
+        # reason the tuple became a record -- so suppressing the one low-confidence match is
+        # the cheaper trade. The marker carries no prose for the reason this file's header
+        # gives: bandit reads anything after it as more test IDs.
+        shell=sum(tally[language] for language in SHELL_FENCE_LANGUAGES),  # nosec B604
+        toml=tally[TOML_FENCE_LANGUAGE],
+        yaml=sum(tally[language] for language in YAML_FENCE_LANGUAGES),
+        diffed=tally[RESULT_FENCE_LANGUAGE],
+        unchecked=unchecked,
     )
 
 
-def _report(fences: list[Fence], bash: str | None, files: int) -> bool:
+def _report(fences: list[Fence], bash: str | None, yaml_ran: bool, files: int) -> bool:
     """Print the inventory and report whether anything was checkable.
 
     The unchecked count is printed rather than dropped because "0 examples" and "43 fences
     nothing looks at" both pass every other gate in this repository while documenting nothing
     verifiable. A reader seeing only a green line would take it for full coverage.
 
+    Two of the five kinds can go unchecked on a machine that runs the gate fine otherwise --
+    shell without bash, yaml without a provisioned parser -- and each gets its own line saying
+    so. They are counted out of ``checked`` in that case rather than assumed sound, which is
+    the same rule the tool guards elsewhere in this package follow.
+
+    B (10) after toml and yaml were added, from B (6). The growth is one branch per kind that
+    can be unavailable, which is open-ended rather than closed, so it gets a ceiling: **a
+    sixth checkable language that needs provisioning takes this to C (12)**, and at that point
+    the availability lines want a loop over ``(count, ran, noun)`` triples rather than a
+    branch each. A kind that cannot go unavailable -- anything stdlib, as toml is -- costs
+    nothing here and does not count against that.
+
     Args:
         fences: Every fence in the tree.
         bash: Path to bash, or None when it is absent.
+        yaml_ran: Whether the yaml parser could be provisioned.
         files: How many markdown files were read.
 
     Returns:
         True when at least one fence was checked, so the caller can skip rather than pass.
     """
-    python, shell, diffed, unchecked = _tally(fences)
-    checked = python + diffed + (shell if bash else 0)
+    tally = _tally(fences)
+    checked = tally.python + tally.diffed + tally.toml + (tally.shell if bash else 0) + (tally.yaml if yaml_ran else 0)
     print(f"\n[INFO] {files} file(s), {len(fences)} fence(s): {checked} checked")
-    print(f"[INFO] {python} python, {shell} shell, {diffed} diffed")
-    if bash is None and shell:
-        print(f"[INFO] bash not found: {shell} shell fence(s) went unchecked")
-    if unchecked:
-        listing = ", ".join(f"{count} {language}" for language, count in unchecked)
-        print(f"[INFO] {sum(count for _, count in unchecked)} fence(s) not checkable: {listing}")
+    print(
+        f"[INFO] {tally.python} python, {tally.shell} shell, "
+        f"{tally.toml} toml, {tally.yaml} yaml, {tally.diffed} diffed"
+    )
+    if bash is None and tally.shell:
+        print(f"[INFO] bash not found: {tally.shell} shell fence(s) went unchecked")
+    if not yaml_ran and tally.yaml:
+        print(f"[INFO] yaml parser unavailable: {tally.yaml} yaml fence(s) went unchecked")
+    if tally.unchecked:
+        listing = ", ".join(f"{count} {language}" for language, count in tally.unchecked)
+        print(f"[INFO] {sum(count for _, count in tally.unchecked)} fence(s) not checkable: {listing}")
     return checked > 0
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1241,13 +1241,18 @@ class TestComplexity:
 
 
 class TestDocsExamples:
-    """``docs-examples``: the fence parser, the three checks, and the inventory.
+    """``docs-examples``: the fence parser, the five checks, and the inventory.
 
     Hermetic like the rest of the suite. ``bash`` and ``uv_run`` are both patched, so the
     tests assert the argument vector each check *would* run -- ``bash -n`` over a throwaway
     script, ``uv run python`` over a generated one -- rather than provisioning either. That
     matters more here than elsewhere: this gate's whole job is to run other people's code,
     and a test that really ran it would execute the repository's own documentation.
+
+    The toml check is the one exception, and it is asserted directly: :mod:`tomllib` is stdlib
+    at this package's Python floor, so there is no subprocess to stand in for and no vector to
+    assert -- the parse either happens in-process or the interpreter could not have run the
+    test.
     """
 
     @staticmethod
@@ -1358,6 +1363,147 @@ class TestDocsExamples:
         violations = quality._shell_violations(fences, "/bin/bash", tmp_path)
         assert violations == ["d.md:1: shell fence does not parse: exit 2"]
 
+    def test_reports_a_toml_fence_that_does_not_parse(self) -> None:
+        """A malformed toml fence is a violation, and a table-less fragment is not.
+
+        The fragment half is the one that matters: most toml under ``docs/`` is a handful of
+        ``key = value`` lines quoted out of a ``[tool.rhiza-task]`` table, and rejecting those
+        would report the documentation as broken for being an excerpt.
+        """
+        fences = quality._fences(
+            "d.md",
+            "```toml\n[tool.rhiza-task\n```\n\n```toml\ncoverage_fail_under = 100\n```\n",
+        )
+        violations = quality._toml_violations(fences)
+        assert len(violations) == 1
+        assert violations[0].startswith("d.md:1: toml fence does not parse:")
+
+    def test_treats_a_tree_with_no_yaml_fence_as_nothing_to_provision(self, cfg: Config, recorder: Recorder) -> None:
+        """No yaml fence means no subprocess at all, rather than an empty one.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder, which must stay empty.
+        """
+        fences = quality._fences("d.md", "```python\nx = 1\n```\n")
+        assert quality._yaml_violations(fences, cfg, cfg.root) == []
+        assert recorder.tools() == []
+
+    def test_provisions_a_yaml_parser_rather_than_depending_on_one(self, cfg: Config, recorder: Recorder) -> None:
+        """The yaml check runs ``uv run --no-project --with pyyaml python <script>``.
+
+        ``rhiza-task`` is a published CLI, so a runtime dependency is an install cost every
+        consumer pays on every invocation. Two fences in this repository's own docs do not
+        justify one, which is why the parser is provisioned for the length of a single call.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+        fences = quality._fences("d.md", "```yaml\na: 1\n```\n")
+        # None, not []: uv_run is recorded rather than run, so the report file never appears --
+        # which is exactly the "could not measure" case, and must not read as "all sound".
+        assert quality._yaml_violations(fences, cfg, scratch) is None
+        call = recorder.find("python")
+        assert call.kind == "uv_run"
+        assert call.flags == ["_tests/docs-examples/fence_yaml.py"]
+        assert call.kwargs["withs"] == ("pyyaml",)
+        assert call.kwargs["no_project"] is True
+        # The fence reaches the parser as a file, so no escaping can corrupt indentation.
+        assert (scratch / "yaml" / "0000.yaml").read_text() == "a: 1"
+        assert (scratch / "yaml" / "index.txt").read_text() == "d.md:1"
+
+    def test_returns_the_violations_the_yaml_parser_reported(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A report file written by the subprocess becomes one violation per line.
+
+        ``uv_run`` is patched with a stand-in producing the *effect* the real script has --
+        the report file -- which covers the path the verdict depends on without a parser.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+
+        def fake_uv_run(*_args: object, **_kwargs: object) -> int:
+            """Write the report the provisioned script would have written.
+
+            Args:
+                *_args: Ignored.
+                **_kwargs: Ignored.
+
+            Returns:
+                Zero, as the script does whatever it found.
+            """
+            (scratch / "yaml" / "report.txt").write_text("d.md:1: yaml fence does not parse: bad\n")
+            return 0
+
+        monkeypatch.setattr(quality, "uv_run", fake_uv_run)
+        fences = quality._fences("d.md", "```yaml\na: '\n```\n")
+        assert quality._yaml_violations(fences, cfg, scratch) == ["d.md:1: yaml fence does not parse: bad"]
+
+    def test_discards_a_yaml_report_left_by_an_earlier_run(self, cfg: Config, recorder: Recorder) -> None:
+        """A stale report is removed first, so its verdict cannot be read as this run's.
+
+        Without the unlink a run whose parser could not be provisioned would return the
+        *previous* run's violations, which is worse than either honest answer.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder, which records rather than runs the script.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        (scratch / "yaml").mkdir(parents=True, exist_ok=True)
+        (scratch / "yaml" / "report.txt").write_text("d.md:9: last time's verdict\n")
+        fences = quality._fences("d.md", "```yaml\na: 1\n```\n")
+        assert quality._yaml_violations(fences, cfg, scratch) is None
+        assert recorder.tools() == ["python"]
+
+    def test_counts_yaml_fences_as_unchecked_when_the_parser_is_unavailable(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unprovisionable parser leaves the yaml fences counted, not assumed sound.
+
+        The same rule the missing-bash line follows: a fact about the machine must not fail
+        the gate, and must not be reported as coverage either.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder, which stands in for the unprovisionable parser.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: None)
+        self._docs(cfg, "g.md", "```yaml\na: 1\n```\n\n```python\nx = 1\n```\n")
+        quality.docs_examples(cfg)
+        out = capsys.readouterr().out
+        assert "yaml parser unavailable: 1 yaml fence(s) went unchecked" in out
+        assert "1 file(s), 2 fence(s): 1 checked" in out
+        assert recorder.tools() == ["python"]
+
+    def test_counts_the_toml_and_yaml_fences_in_the_inventory_line(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The summary names all five kinds, so a reader can see which half was measured.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(quality, "_yaml_violations", lambda *_args: [])
+        self._docs(cfg, "g.md", "```toml\nx = 1\n```\n\n```yaml\na: 1\n```\n")
+        quality.docs_examples(cfg)
+        out = capsys.readouterr().out
+        assert "0 python, 0 shell, 1 toml, 1 yaml, 0 diffed" in out
+        assert "1 file(s), 2 fence(s): 2 checked" in out
+
     def test_runs_the_generated_script_through_the_project_environment(self, cfg: Config, recorder: Recorder) -> None:
         """The fences run as ``uv run python <script>``, so imports see the project's deps.
 
@@ -1463,19 +1609,23 @@ class TestDocsExamples:
     def test_skips_when_the_docs_folder_holds_no_checkable_fence(
         self, cfg: Config, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """A tree of ``toml`` and unlabelled fences measured nothing, so it skips.
+        """A tree of ``mermaid`` and unlabelled fences measured nothing, so it skips.
 
         Passing would be the failure this gate exists to prevent: 100 percent docstring
         coverage over documentation carrying nothing runnable already reads as green.
+
+        ``mermaid`` rather than the ``toml`` this used to use: toml is checked now, so a toml
+        fence is no longer an example of something nothing looks at. Keeping it would have
+        left a test asserting a skip that the gate is right not to take.
 
         Args:
             cfg: The resolved config.
             capsys: pytest's output capture.
         """
-        self._docs(cfg, "conf.md", "```toml\nx = 1\n```\n\n```\nplain\n```\n")
+        self._docs(cfg, "conf.md", "```mermaid\ngraph TD;\n```\n\n```\nplain\n```\n")
         with pytest.raises(Skip, match="no checkable fence"):
             quality.docs_examples(cfg)
-        assert "2 fence(s) not checkable: 1 (none), 1 toml" in capsys.readouterr().out
+        assert "2 fence(s) not checkable: 1 (none), 1 mermaid" in capsys.readouterr().out
 
     def test_counts_shell_fences_as_unchecked_when_bash_is_absent(
         self, cfg: Config, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Closes the three findings from the `/rhiza:quality` run. Each was verified by running the
thing it changes rather than by reading it.

## #107 — `docs-examples` counted more fences than it checked

`toml` and `yaml` are now parsed: **31 → 44 checked**, and the not-checkable tally drops to
18 (9 text, 5 mermaid, 4 makefile — the three with no parser available here).

```
[INFO] 11 file(s), 62 fence(s): 44 checked
[INFO] 8 python, 22 shell, 11 toml, 2 yaml, 1 diffed
[INFO] 18 fence(s) not checkable: 9 text, 5 mermaid, 4 makefile
```

The **toml** half is in-process `tomllib` — stdlib at this package's `>=3.11` floor, so it
costs nothing to provision and is checked on every machine that can run the gate at all. It
covers the eleven fences quoting this repo's own `[tool.rhiza-task]` and `[tool.bumpversion]`
settings, which is the class that goes stale when a setting is renamed.

The **yaml** half is a provisioned subprocess (`uv run --no-project --with pyyaml`),
deliberately *not* a dependency: `rhiza-task` is a published CLI, so a runtime dependency is
an install cost every consumer pays on every `uvx` invocation, and two fences do not justify
one. That makes yaml the second check after `bash -n` that can go **unavailable** on an
otherwise working machine, and it follows the same rule already established there — the
fences are counted out of `checked` and named on their own `[INFO]` line, never assumed
sound.

Both halves were confirmed to actually go red, on a throwaway tree with a deliberately
malformed fence of each kind. Parsing is not validation, and the docstring says so: a fence
that parses may still name a setting that does not exist. What this closes is the narrower
gap where a fence stopped being the language it claims.

Two structural notes:

- `_tally` returns a `Tally` record rather than a tuple. Four positional ints were already at
  the edge of readable; six is past it, and a transposed pair would have reported shell
  fences as toml with nothing failing.
- Its split from `_report` has stopped being a matter of taste. At B (7) and B (10), one
  function doing both scores 16 and fails `rhiza-task complexity` outright — so the
  decomposition is now held by the gate rather than by a reader who remembers why it is
  there. `_report`'s docstring carries the ceiling the house style requires: a sixth
  *provisionable* language takes it to C (12), and at that point the availability lines want
  a loop rather than a branch each.

## #108 — eighteen shipped vectors met no real toolchain

The three language-layer jobs exist because a vector that is well-formed and *wrong* passes
every other gate here and breaks in the first consumer that runs it. That argument was never
specific to the language layers: `docker`, `presentation`, `marimo`, `lfs` and the GitHub
helpers had no real execution anywhere.

New `bundle-layer` job — one job rather than five, because docker, node, git-lfs and `gh` are
all preinstalled on `ubuntu-latest`, whereas the language layers are separate only because
each needs its own toolchain installed.

**All twelve vectors were run locally before the job was written**, which is how the
fixture's missing `src/demo` was found: `marimo-validate` names `install` as a prerequisite,
and a manifest declaring hatchling with nothing to package fails the build before the vector
is ever reached. The other four families have no prerequisite and would not have noticed.
Same class of discovery as `rust-layer` learning that `cargo new crate` is rejected.

Four vectors are deliberately absent and **cannot** be added — each blocks forever by design,
so a step running one would hang to the timeout rather than report:

| vector | why |
| --- | --- |
| `docker-run` | `docker run --rm -it`, an interactive terminal |
| `presentation-serve` | Marp's watching preview server |
| `marimo` | the Marimo editor, a headless server with no exit |
| `serve` | `python -m http.server`, already covered by `rhiza_book.yml` |

`presentation-pdf` is out for a weaker reason (Marp renders PDF through headless Chrome, so
it would download a browser per run; its vector differs from `presentation`'s by one flag the
suite already asserts), and `lfs-pull` needs a remote holding LFS objects that the fixture
has no way to provide.

## #109 — the finding was partly wrong, and the fix reflects that

The original finding said `tasks/python.py`'s note "cites an authority this repo has
otherwise declined". Reading it in full, that is not what it does: it argues that a scan in
the **shipped task** would put a gate in consumers' CI that the template they also follow
says is not there, and that a transitive advisory with no fix available would then fail a run
the template would have passed. That argument holds, so **the task is unchanged** and no
consumer inherits anything.

What the argument does not cover is this repository auditing its *own* lockfile. `weekly.yml`
now does — `uv export --frozen --all-extras --all-groups --no-emit-project` into
`uvx pip-audit`, which currently reports **no known vulnerabilities**. Nothing about it
reaches a consumer: no task name, no prerequisite of `all`, nothing a `uvx rhiza-task`
invocation can find.

Deliberately **not** `continue-on-error`, unlike `mutation`: a surviving mutant is a prompt to
write an assertion, whereas a published advisory against a pinned dependency is a fact that
wants someone to look. Red is the whole signal and it blocks nothing. If an advisory ever
lands with no fixed version, the escape hatch is `--ignore-vuln <ID>` carrying its reason —
not `continue-on-error`, which would silence every future one too.

The docstring now records that the gap is closed here and open for consumers, deliberately
and in that order, so the next reader does not have to re-derive which.

## Gates

All green locally:

- `rhiza-task all` — every gate passes
- `rhiza-task complexity` — no block above 15; average stays A (3.31), no new C block
- `rhiza-task docs-examples` — 44 checked
- **360 tests, 100% coverage** (up from 353; the floor is load-bearing for the test-layout
  opt-out, so it held rather than moved)

One suppression added, at the placement the house style requires — reason above, marker bare:
B604 matches the keyword name `shell=` in the `Tally` constructor and reads it as a shell
being handed to a subprocess. It is a field assignment on a frozen dataclass of integers.

## Two things to watch on the first real run

- **The GitHub helpers were verified with local credentials.** On CI they run against
  `github.token`, and the job declares `pull-requests`, `issues` and `actions: read` for
  them. If a scope is still short those six steps 403 rather than skip.
- **`bundle-layer` touches the network** — npx fetches Marp, buildx pulls Alpine — so it is
  the one per-PR job that can fail for reasons the author did not cause. If that proves
  flaky, the fix is moving it to `weekly.yml`, not `continue-on-error`.

Closes #107
Closes #108
Closes #109
