### PR TITLE
fix: close the three regressions the quality re-run found

### DIFF
--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -79,6 +79,40 @@ TOML_FENCE_LANGUAGE = "toml"
 # failed to name would be silently counted as unchecked rather than parsed -- the exact
 # silence this gate exists to break.
 YAML_FENCE_LANGUAGES = frozenset({"yaml", "yml"})
+
+# The driver :func:`_yaml_violations` writes out and runs. A module-level constant with its
+# body at column 0, rather than an indented literal inside that function, and the indentation
+# is the whole point: `CLAUDE.md` documents
+# `grep -rnE '^\s+(from|import) ' src/` as the way to check this package for deferred imports,
+# and tells the reader it returns two lines. An indented `import yaml` inside a string literal
+# matched that pattern and took it to four -- two false positives in the one check the
+# layering invariant is verified by, which is worse than the invariant being unchecked because
+# it teaches the reader to ignore the output. At column 0 nothing matches and the documented
+# count holds.
+#
+# `started.txt` is written before any parsing and `report.txt` after all of it, so the caller
+# can tell three outcomes apart that would otherwise collapse into one: the parser could not
+# be provisioned (no marker at all), the checker ran and crashed (marker, no report), and the
+# checker finished (both). Without the first marker a bug in this script is indistinguishable
+# from a machine with no network, and the gate passes green either way.
+YAML_CHECKER_SCRIPT = """\
+import pathlib
+
+import yaml
+
+here = pathlib.Path(__file__).parent / "yaml"
+(here / "started.txt").write_text("ok")
+broken = []
+for number, where in enumerate((here / "index.txt").read_text().splitlines()):
+    try:
+        yaml.safe_load((here / f"{number:04d}.yaml").read_text())
+    except yaml.YAMLError as exc:
+        # Flattened: a YAMLError's str spans four lines with a caret diagram, and the
+        # report this joins is one line per violation.
+        detail = " ".join(str(exc).split())
+        broken.append(f"{where}: yaml fence does not parse: {detail}")
+(here / "report.txt").write_text("\\n".join(broken))
+"""
 CHECKED_FENCE_LANGUAGES = (
     SHELL_FENCE_LANGUAGES | YAML_FENCE_LANGUAGES | {PYTHON_FENCE_LANGUAGE, RESULT_FENCE_LANGUAGE, TOML_FENCE_LANGUAGE}
 )
@@ -578,6 +612,14 @@ def _yaml_violations(fences: list[Fence], cfg: Config, scratch: Path) -> list[st
     quotes, backslashes, indentation that carries meaning -- where an escaping bug would look
     like a parse failure in the document. Files move the bytes without reinterpreting them.
 
+    Three outcomes, deliberately distinguished by two marker files rather than by an exit
+    status. ``uv`` exits non-zero both when it cannot resolve ``pyyaml`` and when the script it
+    provisioned crashes, so the status alone cannot separate a machine's missing network from
+    this repository's bug -- and collapsing them is the worse error, because "unavailable" is a
+    pass. ``started.txt`` is written immediately after ``import yaml`` and ``report.txt`` after
+    the last fence, so their presence answers it: neither means the parser never arrived, the
+    first alone means the checker died mid-run, and both mean it finished.
+
     Args:
         fences: Every fence in the tree.
         cfg: The resolved config.
@@ -585,8 +627,9 @@ def _yaml_violations(fences: list[Fence], cfg: Config, scratch: Path) -> list[st
 
     Returns:
         Violation messages, one per broken fence; an empty list when the tree holds no yaml
-        fence or every one of them parsed; or None when the parser could not be provisioned,
-        so the caller can report them as unchecked rather than sound.
+        fence or every one of them parsed; a single-item list naming the script when it started
+        and did not finish, which fails the gate; or None when the parser could not be
+        provisioned at all, so the caller can report the fences as unchecked rather than sound.
     """
     targets = [fence for fence in fences if fence.language in YAML_FENCE_LANGUAGES]
     if not targets:
@@ -598,35 +641,16 @@ def _yaml_violations(fences: list[Fence], cfg: Config, scratch: Path) -> list[st
         (folder / f"{number:04d}.yaml").write_text(fence.code)
     (folder / "index.txt").write_text("\n".join(f"{fence.path}:{fence.line}" for fence in targets))
 
+    started = folder / "started.txt"
     report = folder / "report.txt"
-    # Unlinked first: the file's *existence* is how a run that happened is told from one that
-    # never started, so a stale copy from a previous invocation would report last run's
-    # verdict as this one's.
+    # Unlinked first: each file's *existence* is a verdict, so a stale copy from a previous
+    # invocation would report last run's outcome as this one's.
+    started.unlink(missing_ok=True)
     report.unlink(missing_ok=True)
     script = scratch / "fence_yaml.py"
-    script.write_text(
-        textwrap.dedent(
-            """\
-            import pathlib
+    script.write_text(YAML_CHECKER_SCRIPT)
 
-            import yaml
-
-            here = pathlib.Path(__file__).parent / "yaml"
-            broken = []
-            for number, where in enumerate((here / "index.txt").read_text().splitlines()):
-                try:
-                    yaml.safe_load((here / f"{number:04d}.yaml").read_text())
-                except yaml.YAMLError as exc:
-                    # Flattened: a YAMLError's str spans four lines with a caret diagram, and
-                    # the report this joins is one line per violation.
-                    detail = " ".join(str(exc).split())
-                    broken.append(f"{where}: yaml fence does not parse: {detail}")
-            (here / "report.txt").write_text("\\n".join(broken))
-            """
-        )
-    )
-
-    uv_run(
+    code = uv_run(
         "python",
         script.relative_to(cfg.root).as_posix(),
         cwd=cfg.root,
@@ -634,10 +658,19 @@ def _yaml_violations(fences: list[Fence], cfg: Config, scratch: Path) -> list[st
         no_project=True,
         check=False,
     )
-    if not report.is_file():
+    if not started.is_file():
+        # Never reached the first statement after `import yaml`: no network, no such package,
+        # no interpreter. A fact about the machine, so the caller counts these fences as
+        # unchecked rather than failing the gate.
         return None
+    if not report.is_file():
+        # Started and did not finish, which is this repository's bug and not the machine's --
+        # so it is a violation, and the gate goes red. Before `started.txt` existed this case
+        # returned None and read as "parser unavailable", meaning a broken checker reported
+        # itself as a clean skip.
+        return [f"{script.name}: the yaml checker started and did not finish (exit {code})"]
     # An empty report file is "ran, found nothing", which splitlines turns into [] -- distinct
-    # from the None above, and the distinction is the point of writing the file at all.
+    # from the None above, and the distinction is the point of writing the files at all.
     return report.read_text(errors="replace").splitlines()
 
 
@@ -753,16 +786,23 @@ def _tally(fences: list[Fence]) -> Tally:
         ((language, count) for language, count in tally.items() if language not in CHECKED_FENCE_LANGUAGES),
         key=lambda item: (-item[1], item[0]),
     )
-    return Tally(
+    # B604 matches the *keyword name* `shell=` below and reads this as a subprocess call being
+    # handed a shell. It is a field assignment on a frozen dataclass of integers, and the
+    # nearest subprocess is two hundred lines away. Renaming the field to dodge the pattern
+    # would cost the symmetry with `python`, `toml`, `yaml` and `diffed` -- which is the whole
+    # reason the tuple became a record -- so the suppression is the cheaper trade.
+    #
+    # The marker sits on this line and not on `shell=` itself, which is where the finding is
+    # reported and where it was first written. bandit locates a B604 at the keyword but does
+    # its nosec bookkeeping against the enclosing call node, so a marker on the keyword line
+    # suppresses the finding *and* then reports itself as unmatched -- one
+    # `nosec encountered ... but no failed test` line in every `fmt` and `security` run, which
+    # is noise in the two gates whose value is a clean signal. Here both agree and neither
+    # fires. The marker carries no prose for the reason this file's header gives: bandit reads
+    # anything after it as more test IDs.
+    return Tally(  # nosec B604
         python=tally[PYTHON_FENCE_LANGUAGE],
-        # B604 matches the *keyword name* here and reads this as a subprocess call being handed
-        # a shell. It is a field assignment on a frozen dataclass of integers, and the nearest
-        # subprocess is two hundred lines away. Renaming the field to dodge the pattern would
-        # cost the symmetry with `python`, `toml`, `yaml` and `diffed` -- which is the whole
-        # reason the tuple became a record -- so suppressing the one low-confidence match is
-        # the cheaper trade. The marker carries no prose for the reason this file's header
-        # gives: bandit reads anything after it as more test IDs.
-        shell=sum(tally[language] for language in SHELL_FENCE_LANGUAGES),  # nosec B604
+        shell=sum(tally[language] for language in SHELL_FENCE_LANGUAGES),
         toml=tally[TOML_FENCE_LANGUAGE],
         yaml=sum(tally[language] for language in YAML_FENCE_LANGUAGES),
         diffed=tally[RESULT_FENCE_LANGUAGE],

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1431,7 +1431,7 @@ class TestDocsExamples:
         scratch.mkdir(parents=True, exist_ok=True)
 
         def fake_uv_run(*_args: object, **_kwargs: object) -> int:
-            """Write the report the provisioned script would have written.
+            """Write both markers the provisioned script would have written.
 
             Args:
                 *_args: Ignored.
@@ -1440,12 +1440,66 @@ class TestDocsExamples:
             Returns:
                 Zero, as the script does whatever it found.
             """
+            (scratch / "yaml" / "started.txt").write_text("ok")
             (scratch / "yaml" / "report.txt").write_text("d.md:1: yaml fence does not parse: bad\n")
             return 0
 
         monkeypatch.setattr(quality, "uv_run", fake_uv_run)
         fences = quality._fences("d.md", "```yaml\na: '\n```\n")
         assert quality._yaml_violations(fences, cfg, scratch) == ["d.md:1: yaml fence does not parse: bad"]
+
+    def test_fails_when_the_yaml_checker_starts_and_does_not_finish(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash after ``import yaml`` is this repo's bug, so it is a violation, not a skip.
+
+        The case the two marker files exist for. ``uv`` exits non-zero both when it cannot
+        resolve pyyaml and when the script it provisioned dies, so the status cannot tell a
+        missing network from a broken checker -- and before ``started.txt`` this returned None
+        and reported itself as "parser unavailable", which is a pass.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        scratch.mkdir(parents=True, exist_ok=True)
+
+        def fake_uv_run(*_args: object, **_kwargs: object) -> int:
+            """Write only the started marker, as a script dying mid-run would leave it.
+
+            Args:
+                *_args: Ignored.
+                **_kwargs: Ignored.
+
+            Returns:
+                A non-zero status, as a crashing script does.
+            """
+            (scratch / "yaml" / "started.txt").write_text("ok")
+            return 1
+
+        monkeypatch.setattr(quality, "uv_run", fake_uv_run)
+        fences = quality._fences("d.md", "```yaml\na: 1\n```\n")
+        violations = quality._yaml_violations(fences, cfg, scratch)
+        assert violations == ["fence_yaml.py: the yaml checker started and did not finish (exit 1)"]
+
+    def test_discards_a_started_marker_left_by_an_earlier_run(self, cfg: Config, recorder: Recorder) -> None:
+        """A stale start marker is removed, so an unprovisionable run cannot look like a crash.
+
+        Without the unlink the previous run's marker would survive, `report.txt` would be
+        absent, and a machine with no network would be reported as a broken checker -- the
+        distinction the markers exist to draw, inverted.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder, which records rather than running the script.
+        """
+        scratch = cfg.root / "_tests" / "docs-examples"
+        (scratch / "yaml").mkdir(parents=True, exist_ok=True)
+        (scratch / "yaml" / "started.txt").write_text("last time")
+        fences = quality._fences("d.md", "```yaml\na: 1\n```\n")
+        assert quality._yaml_violations(fences, cfg, scratch) is None
+        assert recorder.tools() == ["python"]
 
     def test_discards_a_yaml_report_left_by_an_earlier_run(self, cfg: Config, recorder: Recorder) -> None:
         """A stale report is removed first, so its verdict cannot be read as this run's.


### PR DESCRIPTION
Three regressions from #110, found by running `/rhiza:quality` against that branch rather
than against `main`. All three are in code #110 added; none was caught by any gate, which is
itself part of what each one is about. #110 had already merged by the time the assessment
finished, so these come as a follow-up rather than as fixes on that PR.

## 1. The `nosec` marker suppressed the finding and then reported itself

`fmt` and `security` both printed, on every run:

```
[tester] WARNING  nosec encountered (B604), but no failed test on file src/rhiza_task/tasks/quality.py:765
```

The suppression **is** necessary — stripping it makes B604 fire on the `shell=` keyword. But
bandit locates the finding at the keyword while doing its `nosec` bookkeeping against the
enclosing call node, so a marker on the keyword line suppresses the finding *and* is then
reported as unmatched. Moving it to the `return Tally(` line makes both agree: `No issues
identified`, no warning.

That is noise in the two gates whose entire value is a clean signal, and `CLAUDE.md` already
treats bandit comment noise as worth fixing — the six `Test in comment:` warnings it records
are the same class of problem one line over.

## 2. The invariant check `CLAUDE.md` documents returned four lines, not two

`CLAUDE.md:111` tells a reader:

> The first returns **two** lines, and only one is an import

It returned four. `import pathlib` and `import yaml`, indented inside the `textwrap.dedent`
literal holding the yaml driver, matched `grep -rnE '^\s+(from|import) ' src/`. They are not
deferred imports — they are text in a string — but the check cannot tell, and **two false
positives in the one command the layering invariant is verified by is worse than the
invariant being unchecked**, because it teaches the reader to ignore the output.

Fixed by hoisting the driver to a module-level `YAML_CHECKER_SCRIPT` with its body at column
0, which fixes the check rather than editing the documented count. Back to two lines, exactly
as `CLAUDE.md` claims.

## 3. A broken checker reported itself as a clean skip

`_yaml_violations` called `uv_run(..., check=False)` and **discarded the exit code**, treating
a missing report file as "could not provision the parser". `uv` exits non-zero both when it
cannot resolve pyyaml *and* when the script it provisioned crashes, so the two collapsed into
one outcome — and that outcome counts the fences as unchecked and **passes the gate**. Since
the script's body is asserted by no test (the suite patches `uv_run`, correctly, and the
string's lines count as covered), a bug in it would have been invisible: green locally, green
in `gates`, reported as a machine without a network.

A second marker splits the three cases:

| `started.txt` | `report.txt` | meaning | verdict |
| --- | --- | --- | --- |
| absent | absent | parser never arrived | fences counted unchecked, gate passes |
| present | absent | checker died mid-run | **violation, gate fails** |
| present | present | checker finished | its findings |

`started.txt` is written immediately after `import yaml`, so its presence is exactly the
claim "the parser resolved and the interpreter reached our code". Verified for real by making
the generated script raise after the marker: exit 1, `started.txt` present, `report.txt`
absent, gate red.

## Gates

- `rhiza-task all` — pass, and `security`/`fmt` now emit no `nosec encountered` line
- `rhiza-task complexity` — no block above 15; the two C blocks are the pre-existing
  documented ones
- `rhiza-task docs-examples` — 44 of 62 fences checked, unchanged; a deliberately broken yaml
  fence still fails it
- **362 tests, coverage 100** (up from 360; the two new tests pin the crash path and the
  stale-marker unlink)
- `grep -rnE '^\s+(from|import) ' src/` — two lines, as documented

## Not addressed here

Two further findings from the same run are filed separately rather than fixed, because
neither is a regression from #110:

- README's two `toml` fences are gated by nothing — `docs-examples` deliberately excludes
  `README.md`, and pytest-rhiza's `test_readme_validation` contains no reference to `toml`.
- `tasks/quality.py` is 904 lines and holds a nine-function fence checker alongside seven
  unrelated task bodies.
