### PR TITLE
test: stub capture, and record two arguments that had no home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,3 +328,31 @@ must not spell the marker itself — bandit scans every comment for it, wherever
 
 Docstring coverage is enforced at **100% over `src/` *and* `tests/`** — test functions and
 fixtures need docstrings too, with an `Args:` section for every parameter.
+
+## Commit types are release evidence, not decoration
+
+`/rhiza:release` deliberately refuses to recommend a bump. It prints the `patch`/`minor`/
+`major` candidates with the commit counts behind each and stops, because whether a change is
+breaking is a judgement about API-stability intent that no log records. That design has a
+consequence for how commits are written here: **the log is the only evidence the human
+choosing the version gets.** A conventional type that understates a change silently biases
+that choice, and `uvx git-cliff --bumped-version` — which some other flow may reach for —
+would derive the understated answer outright.
+
+So one rule, and it is about gates specifically because this package *is* gates:
+
+> **A change that makes a gate reject input it previously accepted is `feat:`, and needs at
+> least a `minor`** — even when it reads like a fix, and even when it closes a bug.
+
+The failure it prevents: a consumer upgrades on what they were told was a patch, a gate they
+never touched goes red, and it reads as a regression rather than as the gate working. Three
+changes landed as `fix:`/`refactor:` before this was written down — `docs-examples` gaining
+`toml` and `yaml` (#107), then README's data fences (#112), then a crashed yaml checker
+failing instead of skipping (#111). All three are strictness increases; none says so in its
+subject line. See #115.
+
+**The next tag must therefore be at least `minor`, and its notes must say `docs-examples`
+checks more than it did at v1.0.0.** `git-cliff` will file those three under *Bug Fixes* and
+*Refactor*, which is exactly where a reader will not look for a behaviour change — so the
+note is manual, and this paragraph is what remembers it. Delete this paragraph once that
+release is out; the rule above stays.

--- a/src/rhiza_task/tasks/fences.py
+++ b/src/rhiza_task/tasks/fences.py
@@ -16,6 +16,31 @@ private, where they belong.
 What the gate is *for* stays on the task in ``quality.py``, because that is where a reader
 looking for a gate looks. What it *does* is here.
 
+**This module is the largest in ``src/`` -- roughly 780 lines, with a maintainability index
+in the low 30s at the time of writing -- and that is accepted.** Worth stating outright,
+because the index is *lower* than the 36.52 that got the checker extracted from
+``quality.py`` in the first place, so the numbers alone read as having made things worse.
+They did not, and the reason is the one #113 was actually about: ``quality.py`` was 904 lines
+doing **two** jobs with a docstring describing one of them, and this is one job. Radon's
+maintainability index falls with size and Halstead volume whether or not a module is
+coherent, so it cannot tell those apart -- which is why cohesion, not the index, was the
+argument then and is the argument now.
+
+The figures are written loosely and dated on purpose, following ``pyproject.toml``'s note on
+the coverage floor: they move with every commit, they are incidental to the argument, and a
+comment stating one exactly is a comment the next edit falsifies. This paragraph proved it --
+adding it grew the file and dropped the index, so the precise numbers it first carried were
+wrong by the time it was saved. ``uvx radon mi src -s`` prints the current figure. What does
+not move: nothing here exceeds B (10), the average across ``src/`` is A (3.27), and about a
+seventh of these lines are comments, which is this repository's house style rather than
+padding.
+
+The condition that changes the answer is **a second job arriving, not a line count**. If
+something lands here that is not fenced-example checking, split on that seam. Splitting on
+size alone is the move to resist: the obvious cut -- the parser (``Fence``, :func:`_fences`,
+the language constants) away from the five checkers -- would put a type in one module and
+its only five consumers in another, which is worse than a long file.
+
 Five kinds of fence are checked and the rest are counted:
 
 * ``python`` -- :func:`compile`, so a fence that is a *fragment* still passes. Names need not

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,27 +2,46 @@
 
 No test in this suite runs uv. The point of extracting the make layer into a package is
 that its logic becomes testable *without* provisioning a toolchain, so every test patches
-:mod:`rhiza_task.uv`'s four entry points -- ``uv``, ``uvx``, ``uv_run`` and ``tool`` -- and
-asserts on the argument vectors that would have been executed. Those vectors are the
-contract the make recipes expressed in shell.
+**all five** of :mod:`rhiza_task.uv`'s entry points -- ``uv``, ``uvx``, ``uv_run``, ``tool``
+and ``capture`` -- and asserts on the argument vectors that would have been executed. Those
+vectors are the contract the make recipes expressed in shell.
 
-Four, not three: ``tool`` is the form rust.mk and go.mk added for a toolchain binary
-already on PATH, which uv neither provisions nor knows about. :mod:`rhiza_task.uv` explains
-why that is a fourth form rather than a variant of the other three, and the fixture below
-patches it alongside them -- so a count of three here would understate what this file
-stands in for by exactly the language layers it was extended to cover.
+Five, not three: ``tool`` is the form rust.mk and go.mk added for a toolchain binary
+already on PATH, which uv neither provisions nor knows about, and ``capture`` is the one
+that returns stdout rather than a status. :mod:`rhiza_task.uv` explains why each is its own
+form rather than a variant of the others.
+
+``capture`` is the late addition, and the reason it matters is worth keeping. It was left
+out while the other four were patched here, so the twelve tests that needed it patched it
+by hand -- and every one of them did, so nothing ever leaked. But the guarantee at the top
+of this docstring was four fifths true, and it failed in the wrong direction: a *new* test
+reaching a ``capture`` path without its own patch did not error, it ran ``gh`` or ``go`` for
+real, and on an authenticated machine it would pass. A guarantee that holds because each
+author remembers is not the guarantee this file claims to provide. See issue #116.
+
+The module list is derived rather than written down, for the same reason. It used to be a
+hand-maintained tuple of twelve names, which was complete but only by inspection; a new
+module binding an entry point and not added here would have been handed real subprocesses
+rather than an error -- the same fail-open shape one level up.
 """
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
-from rhiza_task import cli
+from rhiza_task import cli, tasks
 from rhiza_task.config import Config
+
+UV_ENTRY_POINTS = ("uv", "uvx", "uv_run", "tool")
+"""The four entry points returning an exit status. ``capture`` returns stdout, so it needs a
+different stand-in and is handled separately."""
 
 
 @dataclass
@@ -30,7 +49,8 @@ class Call:
     """One recorded invocation.
 
     Attributes:
-        kind: Which entry point was used -- ``uv``, ``uvx``, ``uv_run`` or ``tool``.
+        kind: Which entry point was used -- ``uv``, ``uvx``, ``uv_run``, ``tool`` or
+            ``capture``.
         args: The positional arguments, tool name first for uvx/uv_run/tool.
         kwargs: The keyword arguments, notably ``withs`` and ``check``.
     """
@@ -69,12 +89,45 @@ class Recorder:
 
     calls: list[Call] = field(default_factory=list)
     codes: list[int] = field(default_factory=list)
+    outputs: list[str] = field(default_factory=list)
+
+    def make_capture(self) -> Callable[..., str]:
+        """Build a stand-in for ``capture``, which returns stdout rather than a status.
+
+        Its own builder rather than a fifth name in :data:`UV_ENTRY_POINTS`, because the
+        shape genuinely differs: :meth:`make` returns a callable typed ``-> int`` that
+        replays :attr:`codes` and raises :class:`~rhiza_task.spec.Failed` on a non-zero one,
+        and neither behaviour means anything for a function whose whole purpose is to hand
+        back a string. Conflating them would have needed a union return type at every call
+        site to save one line here.
+
+        Returns:
+            A callable with the same shape as the real function, recording each call and
+            replaying :attr:`outputs`.
+        """
+
+        def fake(*args: str, **kwargs: object) -> str:
+            """Record the call and return the next canned stdout.
+
+            Args:
+                *args: The tool name and its arguments.
+                **kwargs: The keyword arguments, notably ``cwd``.
+
+            Returns:
+                The next canned string, or an empty one once they are exhausted -- which is
+                what the real ``capture`` returns for a command that printed nothing, so a
+                test that does not care need not say so.
+            """
+            self.calls.append(Call("capture", args, kwargs))
+            return self.outputs.pop(0) if self.outputs else ""
+
+        return fake
 
     def make(self, kind: str) -> Callable[..., int]:
         """Build a stand-in for one uv entry point.
 
         Args:
-            kind: ``uv``, ``uvx``, ``uv_run`` or ``tool``.
+            kind: One of :data:`UV_ENTRY_POINTS`. ``capture`` has its own builder.
 
         Returns:
             A callable with the same shape as the real function.
@@ -131,13 +184,40 @@ class Recorder:
         raise AssertionError(msg)
 
 
+def _task_modules() -> list[ModuleType]:
+    """Import and return every module under :mod:`rhiza_task.tasks`.
+
+    Discovered rather than listed. This used to be a tuple of twelve module names, which was
+    accurate but only by inspection -- and wrong in the direction that does not announce
+    itself: a module binding an entry point and not named there kept the *real* function, so
+    its tests ran the real tool instead of failing. Walking the package cannot go stale.
+
+    Importing them all is harmless and already happens twice over in this suite -- the
+    ``registered`` fixture below does it, and ``test_doctests`` imports every module under
+    ``src/`` -- because importing a task module only registers its tasks.
+
+    Returns:
+        Every submodule of :mod:`rhiza_task.tasks`, imported.
+    """
+    return [importlib.import_module(f"rhiza_task.tasks.{found.name}") for found in pkgutil.iter_modules(tasks.__path__)]
+
+
 @pytest.fixture
 def recorder(monkeypatch: pytest.MonkeyPatch) -> Recorder:
-    """Patch uv in every task module and return the recorder.
+    """Patch every uv entry point in every task module, and return the recorder.
 
-    The task modules do ``from ..uv import uv, uv_run, uvx``, binding the functions into
-    their own namespace, so patching :mod:`rhiza_task.uv` alone would not take effect. The
-    Rust and Go modules bind ``tool`` the same way, so it is patched alongside.
+    The modules do ``from ..uv import uv, uv_run, uvx``, binding the functions into their own
+    namespace, so patching :mod:`rhiza_task.uv` alone would not take effect -- each module's
+    own binding has to be replaced, which is why this walks modules rather than patching one
+    place.
+
+    ``hasattr`` rather than a per-module list of which entry points it uses: the question is
+    only whether a name is bound, and asking the module is both shorter and incapable of
+    disagreeing with it.
+
+    A test may still override any of these with its own ``monkeypatch.setattr`` -- several do,
+    to canned ``capture`` output -- and that keeps working, because a later patch of the same
+    attribute wins.
 
     Args:
         monkeypatch: pytest's patcher.
@@ -146,28 +226,12 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> Recorder:
         The recorder collecting every call.
     """
     rec = Recorder()
-    modules = (
-        "python",
-        "quality",
-        # Not a task module -- it registers nothing -- but it binds `uv_run` the same way to
-        # run the generated fence scripts, so it needs the same patch. The list is what
-        # decides whether a module's subprocesses are stubbed, not whether it holds a `@task`.
-        "fences",
-        "extras",
-        "book",
-        "rust",
-        "go",
-        "github",
-        "docker",
-        "lfs",
-        "paper",
-        "presentation",
-    )
-    for name in modules:
-        module = pytest.importorskip(f"rhiza_task.tasks.{name}")
-        for kind in ("uv", "uvx", "uv_run", "tool"):
+    for module in _task_modules():
+        for kind in UV_ENTRY_POINTS:
             if hasattr(module, kind):
                 monkeypatch.setattr(module, kind, rec.make(kind))
+        if hasattr(module, "capture"):
+            monkeypatch.setattr(module, "capture", rec.make_capture())
     return rec
 
 

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -14,6 +14,9 @@ import pytest
 
 from rhiza_task import uv as uv_module
 from rhiza_task.spec import Failed
+from rhiza_task.tasks import github as github_tasks
+
+from .conftest import UV_ENTRY_POINTS, Recorder, _task_modules
 
 
 @pytest.fixture
@@ -295,3 +298,52 @@ def test_capture_is_empty_when_the_tool_is_absent(tmp_path: Path, monkeypatch: p
 
     monkeypatch.setattr(uv_module.subprocess, "run", absent)
     assert uv_module.capture("definitely-not-a-tool", cwd=tmp_path) == ""
+
+
+class TestTheSuiteStubsEveryEntryPoint:
+    """The hermeticity guarantee, asserted rather than documented.
+
+    ``conftest``'s docstring opens with "No test in this suite runs uv", and until issue #116
+    that was four fifths true: the ``recorder`` fixture patched four of the five entry points
+    and ``capture`` was left to each test to patch by hand. Every test that needed it did, so
+    nothing leaked -- but the shape of the mistake is what matters. A forgotten patch did not
+    raise, it ran ``gh`` or ``go`` for real and passed on an authenticated machine.
+
+    A prose guarantee cannot fail; these can. That is the whole point of moving it here.
+    """
+
+    def test_the_recorder_replaces_every_entry_point_every_module_binds(self, recorder: Recorder) -> None:
+        """No task module keeps a real uv entry point once the fixture has run.
+
+        The assertion that would have caught #116, and the one that catches the next module
+        added with an entry point the fixture does not know about -- both fail-open cases,
+        because an unstubbed binding is a real subprocess rather than an error.
+
+        Args:
+            recorder: The uv recorder, whose construction is what patches the modules.
+        """
+        real = {name: getattr(uv_module, name) for name in (*UV_ENTRY_POINTS, "capture")}
+        leaked = [
+            f"{module.__name__}.{name}"
+            for module in _task_modules()
+            for name, original in real.items()
+            if getattr(module, name, None) is original
+        ]
+        assert leaked == [], f"unstubbed entry point(s) would run the real tool: {leaked}"
+
+    def test_capture_is_recorded_and_replays_canned_output(self, recorder: Recorder) -> None:
+        """``capture`` records like the others and hands back the next canned string.
+
+        Its stand-in is built separately because it returns stdout rather than a status, so
+        this pins both halves: that the call is recorded under its own kind, and that the
+        queue is consumed.
+
+        Args:
+            recorder: The uv recorder.
+        """
+        recorder.outputs.append("v1.2.3")
+        assert github_tasks.capture("gh", "release", "view", cwd=Path()) == "v1.2.3"
+        # Exhausted, not repeated: the real `capture` returns "" for a command that printed
+        # nothing, so that is the honest default rather than replaying the last answer.
+        assert github_tasks.capture("gh", "release", "view", cwd=Path()) == ""
+        assert [call.kind for call in recorder.calls] == ["capture", "capture"]


### PR DESCRIPTION
Three commits, one per issue. **#115 does not fully close** — read its section before merging.

## `4ee77da` — stub `capture` too, and assert the guarantee (#116)

`conftest.py` opens with *"No test in this suite runs uv"*. That was four fifths true: the
`recorder` fixture patched `uv`, `uvx`, `uv_run` and `tool`, while `uv.py`'s fifth entry point
`capture` was left to each test to patch by hand. Twelve tests needed it and all twelve did,
so **nothing ever leaked** — the defect was the shape, not a live failure.

It failed **open**. A forgotten patch did not raise, it ran `gh` or `go` for real, and on an
authenticated machine it passed.

That is not a theory. Reverting the new patch to check the guard is genuine, the failing test
printed:

```
E         + tag:	v1.0.0
E         + draft:	false
E         + prerelease:	false
```

— the test had really called `gh release view` against this repository.

`capture` gets its own builder rather than a fifth name in the tuple, because the shape
differs: `make` returns `-> int`, replays `codes`, and raises `Failed` on a non-zero one, none
of which means anything for a function whose purpose is returning a string. It replays a new
`outputs` queue and yields `""` once exhausted — what the real `capture` returns for a command
that printed nothing, so a test that does not care need not say so.

**The module list is now derived** by walking `rhiza_task.tasks`, replacing a hand-maintained
tuple of twelve names. That tuple was complete, but only by inspection, and it failed open the
same way one level up: a module binding an entry point and not listed kept the real function.

Two tests now carry the guarantee, in `test_uv.py` where the entry points live:

- no task module holds a real entry point once the fixture has run — the assertion that would
  have caught this, and that catches the next module added with an unknown binding;
- `capture` records under its own kind and consumes its queue.

A prose guarantee cannot fail. These can, which is the point.

## `ed1c32f` — record why `fences.py` is the largest module (#117)

It is the biggest module in `src/` and its MI is *lower* than the 36.52 that got the checker
extracted from `quality.py` in #113 — so the numbers alone read as having made things worse.
Nothing said otherwise, which made re-filing #113 against the module that resolved it a matter
of time.

The argument was always cohesion, not the index: `quality.py` was 904 lines doing **two** jobs
with a docstring describing one; this is one job. Radon's MI falls with size and Halstead
volume whether or not a module is coherent, so it cannot tell those cases apart — which is
precisely why it was never the criterion. The docstring now states that, names the condition
that changes the answer (**a second job arriving, not a line count**) and names the seam to
resist: splitting the parser from the five checkers would put a type in one module and its only
consumers in another.

Figures are written loosely and dated, following `pyproject.toml`'s note on the coverage floor.
That paragraph proved its own point while being written — the first draft cited *764 lines, MI
34.24*, and adding it made the file 781 at 33.01, so the exact numbers were false before the
edit was saved.

## `10c07e4` — commit types are release evidence (#115, partially)

**This one does not close its issue, and the PR should not be read as closing it.**

`/rhiza:release` deliberately refuses to recommend a bump — it prints the candidates with
commit counts and stops, because whether a change is breaking is intent no log records. The
consequence for how commits are written here had never been stated: **the log is the only
evidence the human choosing the version gets.** A type that understates a change biases that
choice silently, and `uvx git-cliff --bumped-version` would derive the understated answer
outright.

The rule added:

> A change that makes a gate reject input it previously accepted is `feat:`, and needs at least
> a `minor` — even when it reads like a fix.

Three changes landed before it was written down — `docs-examples` gaining `toml`/`yaml` (#107),
README's data fences (#112), a crashed yaml checker failing rather than skipping (#111) — all
typed `fix:`/`refactor:`, none saying "stricter" in its subject. `git-cliff` will file them
under *Bug Fixes* and *Refactor*, where a reader will not look for a behaviour change, so the
release note has to be manual. `CLAUDE.md` now carries that instruction, marked for deletion
once the release is out; the rule outlives it.

**No `CHANGELOG.md` edit.** Notes are generated with `git-cliff --latest` at tag time, and
`rhiza_release.yml` already documents how regeneration can delete a section, so a hand-written
`Unreleased` heading is the wrong mechanism.

**#115 stays open** until a tag is actually cut at `minor` or above with notes saying
`docs-examples` checks more than it did at v1.0.0. That is a release-time act, not a tree change.

## Gates

- `rhiza-task all` — pass
- `rhiza-task complexity` — no block above 15; the only C blocks remain `_run_one` (12) and
  `Config.__post_init__` (13)
- `rhiza-task docs-examples` — unchanged, 44 fences plus README's 2
- **369 tests, coverage 100** (up from 367)
- Both invariant greps unchanged — two lines, and none

Closes #116
Closes #117
