### PR TITLE
refactor: promote task_modules, and say where the layering rules stop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,10 +143,17 @@ explains them:
 
 ## Tests assert argument vectors, and never run uv
 
-**No test in this suite runs `uv`, or any other tool.** Every test patches
-`rhiza_task.uv`'s entry points — `uv`, `uvx`, `uv_run`, `tool` — through the `Recorder`
-fixture in `tests/conftest.py`, and asserts on the argument vector that *would* have been
-executed.
+**No test in this suite runs `uv`, or any other tool.** Every test patches all **five** of
+`rhiza_task.uv`'s entry points — `uv`, `uvx`, `uv_run`, `tool`, `capture` — through the
+`Recorder` fixture in `tests/conftest.py`, and asserts on the argument vector that *would*
+have been executed.
+
+Five, and it was four until #116. `capture` was left out of the fixture while the other four
+were patched, so each test that needed it patched it by hand; all of them did, so nothing
+ever leaked, but the guarantee this paragraph makes was four fifths true and failed *open* —
+a forgotten patch ran `gh` for real rather than erroring. `tests/test_uv.py` now asserts that
+no task module holds a real entry point once the fixture has run, so the sentence above is
+checked by a test rather than by this file being kept up to date.
 
 This is the point of the package rather than a shortcut: the make recipes expressed their
 contract as shell, and the vectors are that contract made assertable without provisioning a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,23 @@ to begin with the word "from" — a false positive of matching text rather than 
 worth knowing so it is not read as a violation to fix. The second command should return
 nothing at all.
 
+**Both greps read `src/`, and the two rules do not carry over to `tests/` identically.**
+Worth stating, because running them repo-wide returns about twenty-five hits and nothing
+explains them:
+
+- **Rule 3 (no deferred imports) does not apply to `tests/`, and should not.** A test that
+  registers a task with `@task` wants that import *inside* the test, so the registry is
+  mutated within the scope the `registered` fixture cleans up; hoisting it to module level
+  would leak a task into every other test in the file. `test_cli.py` is most of the count and
+  every occurrence is that pattern. The rule exists because a deferred import in `src/` hides
+  a cycle for years — a test function has no cycle to hide.
+- **Rule 4 (no private name crosses a module boundary) *does* carry over**, because its
+  reason is about callers rather than layers. `tests/test_uv.py` importing `_task_modules`
+  from `conftest.py` was the one violation, introduced by #118 and caught by running the
+  second grep over `tests/` rather than by any gate. It is now `task_modules`, public with a
+  docstring saying why — the promotion the rule asks for. So: `grep … tests/` for the second
+  command should also return nothing, and that is worth checking when you touch `conftest.py`.
+
 ## Tests assert argument vectors, and never run uv
 
 **No test in this suite runs `uv`, or any other tool.** Every test patches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,8 +184,16 @@ class Recorder:
         raise AssertionError(msg)
 
 
-def _task_modules() -> list[ModuleType]:
+def task_modules() -> list[ModuleType]:
     """Import and return every module under :mod:`rhiza_task.tasks`.
+
+    Public, and named without a leading underscore on purpose. It has two callers -- the
+    ``recorder`` fixture below, which patches what it finds, and ``test_uv``'s assertion that
+    nothing was left unpatched -- and ``CLAUDE.md``'s fourth layering rule says that a private
+    helper needed in a second place gets promoted and documented rather than imported as-is.
+    That rule is written about ``src/``, and the grep that checks it only reads ``src/``, but
+    the reason it exists does not stop at a directory boundary: the pair below is exactly the
+    "two callers need the same spelling" case the rule names.
 
     Discovered rather than listed. This used to be a tuple of twelve module names, which was
     accurate but only by inspection -- and wrong in the direction that does not announce
@@ -226,7 +234,7 @@ def recorder(monkeypatch: pytest.MonkeyPatch) -> Recorder:
         The recorder collecting every call.
     """
     rec = Recorder()
-    for module in _task_modules():
+    for module in task_modules():
         for kind in UV_ENTRY_POINTS:
             if hasattr(module, kind):
                 monkeypatch.setattr(module, kind, rec.make(kind))

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -16,7 +16,7 @@ from rhiza_task import uv as uv_module
 from rhiza_task.spec import Failed
 from rhiza_task.tasks import github as github_tasks
 
-from .conftest import UV_ENTRY_POINTS, Recorder, _task_modules
+from .conftest import UV_ENTRY_POINTS, Recorder, task_modules
 
 
 @pytest.fixture
@@ -325,7 +325,7 @@ class TestTheSuiteStubsEveryEntryPoint:
         real = {name: getattr(uv_module, name) for name in (*UV_ENTRY_POINTS, "capture")}
         leaked = [
             f"{module.__name__}.{name}"
-            for module in _task_modules()
+            for module in task_modules()
             for name, original in real.items()
             if getattr(module, name, None) is original
         ]


### PR DESCRIPTION
One finding from a `/rhiza:quality` run against `main` at `330efb6`, in two halves: the
violation, and the reason no gate could see it.

## The violation

`tests/test_uv.py:19` was:

```python
from .conftest import UV_ENTRY_POINTS, Recorder, _task_modules
```

`CLAUDE.md`'s fourth layering rule:

> **No underscore-prefixed name crosses a module boundary.** […] If a private helper turns out
> to be needed elsewhere, promote it and document why it is public — do not import it as-is.

#118 introduced this, and it is the case the rule names precisely: `task_modules` now has two
callers — the `recorder` fixture that patches what it finds, and `test_uv`'s assertion that
nothing was left unpatched. Promoted, public, with a docstring saying why.

## Why it was invisible

`CLAUDE.md` states four layering rules, offers two greps "to check the whole invariant", and
scopes both to `src/` without ever saying that is deliberate. Run them repo-wide and you get
about twenty-five hits and no explanation — which teaches a reader to ignore the output. That
is the same failure the indented `import yaml` inside a string literal caused two PRs ago, and
the reason it was worth fixing then applies here.

So the section now says which rule carries over and why, rather than just asserting a count:

- **Rule 3 (no deferred imports) does not apply to `tests/`, and should not.** A test that
  registers a task with `@task` wants that import *inside* the test, so the registry mutation
  stays in the scope the `registered` fixture cleans up; hoisting it to module level would leak
  a task into every other test in the file. `test_cli.py` is most of the twenty-five and every
  occurrence is that pattern. The rule exists because a deferred import in `src/` hides a cycle
  for years — a test function has no cycle to hide.
- **Rule 4 does carry over**, because its reason is about callers rather than layers. So the
  second grep should return nothing over `tests/` as well, and now does.

## Verification

```
grep -rnE '^\s+(from|import) ' src/                          → 2   (as documented)
grep -rnE 'from \.{1,2}[a-z_.]* import .*\b_[a-z]' src/      → 0   (as documented)
grep -rnE 'from \.{1,2}[a-z_.]* import .*\b_[a-z]' tests/    → 0   (newly documented)
```

- `rhiza-task all` — pass
- `rhiza-task complexity` — no block above 15
- `rhiza-task docs-examples` — unchanged
- **369 tests, coverage 100**
