### PR TITLE
fix: make a release PR possible — the tag check and the docs version pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,48 @@ filename = "README.md"
 search = "rhiza-task@{current_version}"
 replace = "rhiza-task@{new_version}"
 
+# The same argument, and it was left unmade for a release: `docs/` carries thirty-one of the
+# same pins across six files -- getting_started.md alone has thirteen -- and the entry above
+# covered only README.md. Cutting v1.1.0 was what surfaced it, one step after the bump and one
+# before the tag, which is late.
+#
+# Nothing catches this. `docs-examples` parses those fences as shell and they parse fine at any
+# version; lychee resolves links, not arguments; and a stale pin is a *working* command that
+# installs the wrong release, so it does not fail for the reader either -- it just silently
+# gives them the version before the one they are reading about.
+#
+# `glob`, not one entry per file: six filenames would be a list to forget to extend the next
+# time a page is added, which is the failure being fixed rather than a different one. Every
+# occurrence in every matched file is rewritten, so a new page needs no config change at all.
+#
+# `ignore_missing_version` is what makes the glob usable, and it is not optional here: the glob
+# matches all eleven pages while only six carry a pin, and without this bump-my-version treats
+# the first pin-less page as an error -- `Did not find 'rhiza-task@1.0.0' in file:
+# 'docs/api.md'`. Worse, it fails *partway*: the first attempt at v1.1.0 had already rewritten
+# README.md and __init__.py before it reached api.md and stopped, leaving a half-bumped tree
+# that looked like a successful run to anything not reading the exit status. That is the reason
+# the release flow shows `git diff --stat` after this command rather than trusting it.
+#
+# The cost is real and accepted: a page that *should* carry a pin and does not is now silently
+# fine. That trade only works because the glob is over a whole directory rather than a list --
+# the failure it removes (a seventh page nobody adds to a list) is the likelier one.
+[[tool.bumpversion.files]]
+glob = "docs/*.md"
+ignore_missing_version = true
+search = "rhiza-task@{current_version}"
+replace = "rhiza-task@{new_version}"
+
+# The paper is the last pin, and it needs its own entry twice over: it is `.tex` rather than
+# `.md`, and it sits one directory down, which `docs/*.md` does not reach on either count. It
+# was the one occurrence the glob above still left at the old version, found by grepping for
+# the old pin after the bump rather than by trusting the config -- worth doing, because the
+# next such file will be missed the same way. `docs/` is otherwise flat, so there is nothing
+# else a recursive glob would pick up today.
+[[tool.bumpversion.files]]
+filename = "docs/paper/paper.tex"
+search = "rhiza-task@{current_version}"
+replace = "rhiza-task@{new_version}"
+
 # The lockfile records this package's own version, and `uv lock --check` is the first
 # command `install` runs -- so a bump that leaves uv.lock behind fails every gate that
 # names `install` as a prerequisite, which is all of them. v1.0.0 shipped that way: the

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -27,6 +27,7 @@ import shutil
 # reads everything after that marker as a comma-separated list of test IDs, so a trailing
 # explanation becomes one `Test in comment:` warning per word.
 import subprocess  # nosec B404
+import tomllib
 from pathlib import Path
 
 from ..config import Config
@@ -52,6 +53,21 @@ TODO_SKIP_DIRS = frozenset(
         "__pycache__",
     }
 )
+
+TAG_VERSION_CHECK = "test_latest_tag_matches_pyproject_version"
+"""pytest-rhiza's assertion that the newest tag equals the declared version.
+
+Correct about a released tree and **false by construction during a release**, which is the
+window :func:`_release_pending` exists to detect. A repository cannot satisfy it between the
+version bump and the tag: the bump is what the release PR contains, and the tag is cut from
+that PR's merge commit, so for the length of the PR the declared version is ahead of every
+tag that exists.
+
+That mattered here because `the gates this package applies to others` is a **required** status
+check and runs ``rhiza-task all``, which runs this gate -- so a release PR could not go green,
+and v1.0.0's was merged with the job red. A required check that can never pass teaches people
+to merge red, which is a worse outcome than the check's own value. See #115.
+"""
 
 CLEAN_ARTIFACTS = ("dist", "build", ".coverage", ".pytest_cache", ".benchmarks", "_tests", "_book")
 
@@ -120,13 +136,35 @@ def rhiza_test(cfg: Config) -> None:
     was the ``!.env`` negation, that file is gitignored and a CI checkout never has one.
     ``quality.mk`` exported the variable from ``DOCSTRING_FOLDERS``; this is that export.
 
+    One check is dropped while a release is in flight. :data:`TAG_VERSION_CHECK` asserts that
+    the newest tag equals the declared version, which a repository cannot satisfy between its
+    version bump and its tag -- and because that assertion runs inside this gate, and this gate
+    runs inside ``all``, and ``all`` is a required status check, a release PR could not go
+    green. v1.0.0's was merged with the job red. :func:`_release_pending` detects the window
+    from the repository's own state, so nothing has to be passed in and the check returns by
+    itself once the tag exists.
+
     Args:
         cfg: The resolved config.
     """
+    # `-k`, not `--deselect`: a deselect needs the collected node id, and under `--pyargs` that
+    # is the *installed* package's file path inside the uv cache -- a string this task would
+    # have to reconstruct and that changes with the pin. Matching on the test's name needs
+    # neither.
+    #
+    # Announced on stdout rather than passed over silently. A relaxed gate that says nothing is
+    # how a real mismatch would hide behind this, and the whole argument for relaxing it is
+    # that a permanently-red required check is worse than a visibly narrower one.
+    selection: tuple[str, ...] = ()
+    if _release_pending(cfg):
+        print(f"[INFO] release in flight: the declared version leads every tag, so {TAG_VERSION_CHECK} is deselected")
+        selection = ("-k", f"not {TAG_VERSION_CHECK}")
+
     uv_run(
         "pytest",
         "--pyargs",
         *cfg.rhiza_checks,
+        *selection,
         cwd=cfg.root,
         withs=(cfg.pytest_rhiza,),
         env={"RHIZA_DOCTEST_FOLDERS": cfg.source_folder},
@@ -290,6 +328,70 @@ def _walk(root: Path) -> list[Path]:
             elif entry.suffix in TODO_SUFFIXES:
                 found.append(entry)
     return found
+
+
+def _semver(text: str) -> tuple[int, int, int] | None:
+    """Parse a ``vX.Y.Z`` or ``X.Y.Z`` string into a comparable tuple.
+
+    Tuples of ints rather than a real version type, because comparing releases is all this
+    needs and ``packaging`` is not a dependency of this package -- three runtime dependencies
+    is a deliberate ceiling, each one paid for by every consumer on every ``uvx`` invocation.
+    A pre-release or build suffix returns None rather than sorting oddly: this is used to
+    decide whether to relax a gate, so anything it cannot read confidently must leave the gate
+    alone.
+
+    Args:
+        text: A tag or version string, with or without the leading ``v``.
+
+    Returns:
+        ``(major, minor, patch)``, or None when the string is not exactly that shape.
+    """
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", text.strip())
+    if match is None:
+        return None
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def _release_pending(cfg: Config) -> bool:
+    """Report whether the declared version is ahead of every tag in the repository.
+
+    That state is a release in flight: the version bump has been made and the tag has not been
+    cut yet, which is exactly what a release PR contains and what :data:`TAG_VERSION_CHECK`
+    cannot be satisfied during.
+
+    Every uncertain answer is False -- no manifest, an unreadable one, a version or tag shape
+    this cannot parse, no git, no tags at all. The gate is relaxed only on positive evidence
+    that a release is underway, because the failure modes are asymmetric: relaxing it wrongly
+    hides a real mismatch, while leaving it on wrongly costs one red job on a release PR, which
+    is the situation being fixed and is at least visible.
+
+    It also does not distinguish a release in flight from a bump nobody ever tagged. Nothing
+    local can: the two states are identical on disk. So the trade is stated rather than hidden
+    -- the *behind* direction stays gated, which is the one that shipped a wrong version before
+    (v1.0.0's release commit left uv.lock at the previous version), and the *ahead* direction
+    is announced on stdout by the caller rather than passed over.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        True when a release looks to be in flight.
+    """
+    manifest = cfg.root / "pyproject.toml"
+    if not manifest.is_file():
+        return False
+    try:
+        parsed = tomllib.loads(manifest.read_text(errors="replace"))
+    except tomllib.TOMLDecodeError:
+        return False
+    declared = _semver(str(parsed.get("project", {}).get("version", "")))
+    git = shutil.which("git")
+    if declared is None or git is None:
+        return False
+    listing = _git(git, ["tag", "--list", "v*"], cfg.root, capture=True)
+    tags = [parsed_tag for parsed_tag in (_semver(line) for line in listing.split()) if parsed_tag]
+    return bool(tags) and declared > max(tags)
 
 
 def _git(git: str, args: list[str], cwd: Path, capture: bool = False) -> str:

--- a/tests/test_rhiza_packaging.py
+++ b/tests/test_rhiza_packaging.py
@@ -70,8 +70,10 @@ def test_the_installed_version_matches_pyproject() -> None:
     in which the question is not askable rather than one in which the answer is wrong: a
     dynamic version has no static value to compare, and a ``uv`` *virtual* project (no
     ``[build-system]``) installs no distribution metadata at all. This repository is neither
-    -- it declares ``version = "1.0.0"`` statically and builds a real wheel -- so here the
-    assert is reached and the skips are the inherited generality, not slack.
+    -- it declares its version statically and builds a real wheel -- so here the assert is
+    reached and the skips are the inherited generality, not slack. Deliberately not naming the
+    version: the point is that it is static, and a figure quoted here is one more thing a
+    release has to remember to move.
     """
     project = _project_table()
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -401,6 +401,118 @@ class TestQuality:
         quality.rhiza_test(relocated)
         assert recorder.find("pytest").kwargs["env"] == {"RHIZA_DOCTEST_FOLDERS": "utils"}
 
+    @pytest.mark.parametrize(
+        ("declared", "tags", "pending"),
+        [
+            ("1.1.0", ("v1.0.0",), True),
+            ("1.0.0", ("v1.0.0",), False),
+            ("1.0.0", ("v1.1.0",), False),
+            ("1.10.0", ("v1.9.0",), True),
+            ("1.1.0", (), False),
+            ("1.1.0rc1", ("v1.0.0",), False),
+            ("1.1.0", ("nightly", "v1.0.0"), True),
+            ("", ("v1.0.0",), False),
+        ],
+    )
+    def test_detects_a_release_in_flight_from_the_version_and_the_tags(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, declared: str, tags: tuple[str, ...], pending: bool
+    ) -> None:
+        """A declared version ahead of every tag is a release in flight; anything unclear is not.
+
+        ``1.10.0`` against ``v1.9.0`` is the case a string comparison gets wrong, which is why
+        the parse returns a tuple. ``1.1.0rc1`` and an empty version return False because a
+        shape this cannot read confidently must leave the gate alone, and a non-version tag is
+        ignored rather than poisoning the maximum.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            declared: The version in ``[project]``.
+            tags: What the git probe reports.
+            pending: The expected verdict.
+        """
+        (cfg.root / "pyproject.toml").write_text(f'[project]\nname = "demo"\nversion = "{declared}"\n')
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: "/usr/bin/git")
+        monkeypatch.setattr(quality, "_git", lambda *_a, **_k: "\n".join(tags))
+        assert quality._release_pending(cfg) is pending
+
+    @pytest.mark.parametrize(
+        ("manifest", "reason"),
+        [
+            (None, "no pyproject.toml at all"),
+            ("[project\nname = 'demo'", "a manifest that does not parse"),
+            ('[tool.other]\nkey = "value"', "a manifest with no [project] table"),
+        ],
+    )
+    def test_treats_an_unreadable_manifest_as_no_release_in_flight(
+        self, cfg: Config, monkeypatch: pytest.MonkeyPatch, manifest: str | None, reason: str
+    ) -> None:
+        """Every uncertain answer leaves the gate alone, rather than relaxing it.
+
+        The asymmetry is the argument: relaxing the gate wrongly hides a real version mismatch,
+        while leaving it on wrongly costs one red job on a release PR -- visible, and the thing
+        being fixed.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+            manifest: Manifest content, or None to delete it.
+            reason: What this case represents, for the assertion message.
+        """
+        target = cfg.root / "pyproject.toml"
+        if manifest is None:
+            target.unlink()
+        else:
+            target.write_text(manifest)
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: "/usr/bin/git")
+        assert quality._release_pending(cfg) is False, reason
+
+    def test_treats_a_missing_git_as_no_release_in_flight(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without git there are no tags to compare against, so the gate stays as it is.
+
+        Args:
+            cfg: The resolved config.
+            monkeypatch: pytest's patcher.
+        """
+        (cfg.root / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "9.9.9"\n')
+        monkeypatch.setattr(quality.shutil, "which", lambda _name: None)
+        assert quality._release_pending(cfg) is False
+
+    def test_rhiza_test_deselects_the_tag_check_during_a_release(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The vector gains ``-k not <check>`` while a release is in flight, and says so.
+
+        The reason this exists at all: that assertion runs inside `rhiza-test`, which runs inside
+        `all`, which is a required status check -- so without this a release PR could never go
+        green, and v1.0.0's was merged red.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+            capsys: pytest's output capture.
+        """
+        monkeypatch.setattr(quality, "_release_pending", lambda _cfg: True)
+        quality.rhiza_test(cfg)
+        flags = recorder.find("pytest").flags
+        assert flags[-2:] == ["-k", f"not {quality.TAG_VERSION_CHECK}"]
+        assert "release in flight" in capsys.readouterr().out
+
+    def test_rhiza_test_passes_no_selection_outside_a_release(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A released tree runs every check, so the gate is not silently narrower.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(quality, "_release_pending", lambda _cfg: False)
+        quality.rhiza_test(cfg)
+        assert "-k" not in recorder.find("pytest").flags
+
     def test_fmt_skips_without_a_config(self, cfg: Config, recorder: Recorder) -> None:
         """No ``.pre-commit-config.yaml`` is a skip with a reason, not a failure.
 


### PR DESCRIPTION
Two blockers found by actually trying to cut v1.1.0 for #115. Neither is the release; both
should land before one. **#115 stays open** — this makes a correct release easier, it does not
perform one.

> **Correction.** The first version of this description claimed the required `gates` job could
> never go green during a release, and that v1.0.0's release PR was merged red. **Both were
> wrong**, and the CI log on this PR is what showed it — see *Scope* below. The change is still
> worth having, for a smaller reason.

## `f242f65` — the tag-version check fails a release in flight, locally

pytest-rhiza's `test_latest_tag_matches_pyproject_version` asserts the newest tag equals the
declared version. Right about a released tree, and false by construction during a release: the
bump is what the release PR contains, and the tag is cut from that PR's merge commit, so for
the length of the PR the declared version leads every tag that exists.

It runs inside `rhiza-test` → inside `all`, so `rhiza-task all` — what a developer runs before
pushing — goes red for the whole release. That is what stopped the v1.1.0 attempt.

### Scope, stated precisely

**This is a local-only failure.** `ci.yml`'s checkout sets no `fetch-depth` and no
`fetch-tags`, so **no CI job has any tags**, and that check already skips there:

```
collected 34 items
SKIPPED [1] .../pytest_rhiza/checks/test_release_tags.py:25: No version tags found in repository
SKIPPED [1] .../pytest_rhiza/checks/test_pyproject.py:334: No version tags found in repository
32 passed, 2 skipped
```

So the required `gates` job was never blocked, and there is no evidence v1.0.0's release PR was
red — I inferred that from a local run rather than checking a CI run, and said it as fact. What
this buys is therefore smaller than first claimed and still real: a releaser's own
`rhiza-task all` now agrees with CI instead of failing on a state CI cannot observe, and the
check returns of its own accord once the tag exists.

`gates` on this very PR confirms the other direction — no "release in flight" line, nothing
deselected, because the version still equals the tag.

### Details worth a reviewer's attention

- **`-k`, not `--deselect`.** Under `--pyargs` the node id is the installed package's path
  inside the uv cache — a string this task would have to reconstruct and that moves with the
  pin.
- **Every uncertain answer is `False`** — no manifest, one that will not parse, no `[project]`
  table, an unparseable version or tag, no git, no tags. Relaxing the gate wrongly hides a real
  mismatch; leaving it on wrongly costs one red local run, which is visible.
- **Tuples of ints, not `packaging.Version`** — three runtime dependencies is a deliberate
  ceiling. `1.10.0` against `v1.9.0` is the case a string comparison gets wrong; it is one of
  the parametrised cases.
- It does **not** distinguish a release in flight from a bump nobody tagged — nothing local
  can. The *behind* direction stays gated, which is the one that shipped wrong before (v1.0.0's
  release commit left `uv.lock` at the previous version), and the *ahead* direction is
  announced on stdout.

## `de95480` — the bump config covered README but not `docs/`

This one needs no correction and is the more consequential of the two.

`[[tool.bumpversion.files]]` covered `README.md`'s `rhiza-task@<version>` pins with a comment
giving the reason — *"without this entry those examples drift: they still read
`rhiza-task@0.1.0` two releases after 0.1.0"*. The same argument applies to `docs/`, which
carries **31 of the same pins across six files**, `getting_started.md` alone holding 13. Nobody
extended it, so **v1.1.0 was about to ship documentation telling readers to run
`uvx rhiza-task@1.0.0`.**

Nothing catches this, which is why it survived a release: `docs-examples` parses those fences as
shell and they parse at any version, the link checker resolves links rather than arguments, and
a stale pin is a **working** command that installs the previous release — so it does not fail
for the reader either. It just quietly gives them the version before the one they are reading.

`glob = "docs/*.md"` rather than six filenames, because a list of six is a list to forget to
extend when a seventh page is added. Two things that took a try each, both recorded in the
config comment:

- **`ignore_missing_version` is required.** The glob matches all eleven pages while six carry a
  pin; without it, `Did not find 'rhiza-task@1.0.0' in file: 'docs/api.md'`.
- **`bump-my-version` fails *partway*.** That first attempt had already rewritten `README.md`
  and `__init__.py` before it stopped, leaving a half-bumped tree that looks like a successful
  run to anything not reading the exit status. It is why the release flow diffs after bumping.

`docs/paper/paper.tex` needed its own entry — wrong extension *and* one directory down. Found by
grepping for the old pin after the bump rather than by trusting the config.

## Gates

- `rhiza-task all` — pass
- `rhiza-task complexity` — no block above 15; only the two pre-existing C blocks
- **383 tests, coverage 100** (up from 369)

## What this surfaced but does not fix

**No CI job has any tags, so two pytest-rhiza checks always skip** — including
`test_release_tags`, which asserts a tag is reachable from a branch. That is the check
`rhiza_release.yml` has a 15-line comment about, guarding against a tag orphaned by a
squash-merge. It has never run in CI. Two silently-skipped checks reading as green is the
pattern this repo treats as a finding elsewhere; worth its own issue rather than smuggling a
`fetch-tags` change in here.

Also, for whoever cuts the release: **`git-cliff --prepend` ate the `# Changelog` H1.** Every
prior section survived, but the title did not.
