### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,113 @@
 # Changelog
 
+## [1.1.0] - 2026-08-21
+
+### ⚠️ Upgrade note
+
+`docs-examples` checks more than it did at v1.0.0, so a repository whose documentation passed
+that gate can see it go red on upgrade without having changed anything. That is the gate
+working, not a regression. Three changes compound:
+
+- **`toml` and `yaml` fences are parsed**, where they were previously counted as uncheckable.
+  A malformed configuration example under the docs folder now fails.
+- **`README.md`'s `toml` and `yaml` fences are checked too.** Its `python` and `bash` fences
+  remain pytest-rhiza's, under `rhiza-test`, so no fence is checked twice.
+- **A yaml checker that crashes now fails** instead of reporting "parser unavailable", which
+  passed.
+
+To see what a repository would report before upgrading, run `uvx rhiza-task@1.1.0 docs-examples`
+against it.
+
+This note is here because the three changes landed as `fix:` and `refactor:` commits, so the
+generated sections below file them where a reader does not look for a behaviour change. The
+convention that a gate getting stricter is a `feat:` was written down after the fact, in
+`CLAUDE.md`.
+
+
+### 🚀 Features
+
+- *(book)* Add the mkdocs book, built by the existing book task
+- Gate the docs tree's fenced examples, and correct four drifted figures
+
+### 🐛 Bug Fixes
+
+- *(bumpversion)* Relock, and carry uv.lock through the bump
+- *(runner)* Propagate the failing task's own exit status
+- Contain *_folder settings, record the unwired gates, fold a deferred import
+- *(security)* Stop the security gate warning about this repo's own suppressions
+- Reject a --root that is not an existing directory
+- Stop publishing local build paths in the book's reports
+- Close the seven findings from the quality run
+- Decompose Guard to A (5), and retire the orphaned Scorecard comments
+- Close the three findings from the quality run
+- Close the three regressions the quality re-run found
+- Check README's data fences, which nothing was checking
+- Bump the version pins in docs/, not just README.md
+- Let a release PR go green by deselecting the tag-version check
+
+### 💼 Other
+
+- Add a pre-commit config, so fmt measures something
+- Raise the coverage floor to 100, and make the stronger claim it unlocks
+- Automate the pins, test the parsing, and write down the invariants
+- Bump the actions group with 3 updates
+- Pin this repo's typechecker rather than inheriting the default
+- Run both typecheckers, and fix the one finding mypy --strict adds
+
+### 🚜 Refactor
+
+- Promote the name normaliser, and record why Python's security gate differs
+- Extract the fence checker into tasks/fences.py
+- Promote task_modules, and say where the layering rules stop
+
+### 📚 Documentation
+
+- *(readme)* Add five badges and cut the prose back by a fifth
+- Make the examples executable, and declare the layout opt-out
+- Say why the four C-complexity blocks are shaped as they are
+- Link the book and widen the package description
+- *(ci)* Correct the comments the pre-commit config made stale
+- *(design)* Introduce jointview, so the comments citing it have an antecedent
+- *(build)* Fix the stale premise about how the opt-out reason spells its floor
+- Give Config.__post_init__'s growth rule a ceiling
+- Add a security policy
+- Correct the --strict answer, which had gone stale twice
+- Link upstream's decision records from the design page
+- Add docs/paper/paper.tex describing the package
+- Publish the compiled paper in the mkdocs book
+- Correct drifted figures and split the three example gates
+- Describe the toml and yaml fence checks in tasks.md
+- Record why fences.py is the largest module in src/
+- Make commit types release evidence, and flag the pending minor
+- CLAUDE.md still said four entry points
+
+### 🧪 Testing
+
+- Assert exit-status and outcome contracts, not only argument vectors
+- Assert the propagated exit code, not the collapsed one
+- Cover the last 37 statements, without touching src
+- Execute the 39 doctests, so the documented contracts are gated
+- Cover the two defensive except branches, retiring their pragmas
+- Assert the installed version matches the declared one
+- Stub capture too, and assert the hermeticity guarantee
+
+### ⚙️ Miscellaneous Tasks
+
+- *(bumpversion)* Keep the README's `rhiza-task@` pin in step
+- *(release)* Re-sync from rhiza v1.4.2, keeping the local trim
+- Adopt rhiza's scorecard, codeql and quality-review stubs
+- Test both ends of the declared dependency range
+- Enforce ruff.toml in a gate CI runs
+- Lift the book and paper workflows from rhiza
+- Invoke the CLI end-to-end on every matrix leg, not just ubuntu
+- SHA-pin the two reusable workflow calls
+- Add CODEOWNERS and the branch and tag ruleset definitions
+- Add an editorconfig
+- Close the four gaps /quality found, and gate the complexity ceiling
+- Drop the two upstream workflow delegations, and correct CLAUDE.md
+- Install TeX Live on the ref the book deploys, fixing the paper 404
+# Changelog
+
 ## [1.0.0] - 2026-08-20
 
 ### 🚀 Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,8 +375,13 @@ changes landed as `fix:`/`refactor:` before this was written down — `docs-exam
 failing instead of skipping (#111). All three are strictness increases; none says so in its
 subject line. See #115.
 
-**The next tag must therefore be at least `minor`, and its notes must say `docs-examples`
-checks more than it did at v1.0.0.** `git-cliff` will file those three under *Bug Fixes* and
-*Refactor*, which is exactly where a reader will not look for a behaviour change — so the
-note is manual, and this paragraph is what remembers it. Delete this paragraph once that
-release is out; the rule above stays.
+That was discharged by **v1.1.0**, a `minor` carrying an `⚠️ Upgrade note` at the top of its
+`CHANGELOG.md` section that names all three. The dated reminder that stood here is gone, as it
+said it would be.
+
+Two things that release established, both worth keeping. **`git-cliff` files a strictness
+increase wherever its commit type puts it, so the upgrade note is always manual** — and
+`CHANGELOG.md` is where to put it, because `rhiza_release.yml` generates the *GitHub release
+body* separately with `git-cliff --latest` from commits, so a note added here does **not** reach
+it. And **`git-cliff --prepend` eats this file's `# Changelog` heading**: prior sections survive,
+the title does not, so restore it and diff before committing. Both of v1.1.0's prepends did it.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The rhiza developer tasks as a **pinned CLI** rather than a synced make layer �
 of task names across Python, Rust and Go**.
 
 ```bash
-uvx rhiza-task@1.0.0 test
+uvx rhiza-task@1.1.0 test
 ```
 
 📖 **[Documentation](https://jebel-quant.github.io/rhiza-task/)** — the task catalogue,
@@ -44,9 +44,9 @@ v1.3.3 and hope nobody edited them."
 Nothing to install. `uvx` provisions it per invocation:
 
 ```bash
-uvx rhiza-task@1.0.0 list          # what is available
-uvx rhiza-task@1.0.0 all           # every gate, as CI runs them
-uvx rhiza-task@1.0.0 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.1.0 list          # what is available
+uvx rhiza-task@1.1.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.1.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 Task names are unchanged from the retired make layer, so a repo that wants `make test` to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,8 +87,8 @@ and wins when both are present.
 value a task will actually see:
 
 ```bash
-uvx rhiza-task@1.0.0 print coverage_fail_under
-uvx rhiza-task@1.0.0 print COVERAGE_FAIL_UNDER   # either spelling
+uvx rhiza-task@1.1.0 print coverage_fail_under
+uvx rhiza-task@1.1.0 print COVERAGE_FAIL_UNDER   # either spelling
 ```
 
 Field names are the lowercased make variables, so the mapping to what a consumer already
@@ -100,7 +100,7 @@ In the two string-valued layers, an empty value **leaves the layer below it alon
 than resolving to `""`:
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.0.0 ci-os-matrix   # still the default
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.1.0 ci-os-matrix   # still the default
 ```
 
 That is make's `$(or ...)` rule, and the reusable workflows depend on it: `rhiza_ci.yml`
@@ -209,7 +209,7 @@ layers = ["rust"]
 ```
 
 ```bash
-RHIZA_LAYERS=rust uvx rhiza-task@1.0.0 test
+RHIZA_LAYERS=rust uvx rhiza-task@1.1.0 test
 ```
 
 ## No `+=` successor, and none needed

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ language layers this repository does not have.
 
 You should. An unpinned task layer can change under a green pull request without a commit
 touching your repository — which is the failure mode the whole package exists to remove.
-`rhiza-task@1.0.0` makes a bump a deliberate commit that carries whatever fixes it wants.
+`rhiza-task@1.1.0` makes a bump a deliberate commit that carries whatever fixes it wants.
 
 ### A gate says `skipped`. Is that bad?
 
@@ -30,7 +30,7 @@ folder. The reason is printed next to it.
 It *is* bad when the subject was supposed to be there. That is what `--strict` is for:
 
 ```bash
-uvx rhiza-task@1.0.0 all --strict
+uvx rhiza-task@1.1.0 all --strict
 ```
 
 In a consumer repository `--strict` is usually the right setting, because a skip means a
@@ -68,7 +68,7 @@ Two likely causes:
 ### How do I run the gates for another repository?
 
 ```bash
-uvx rhiza-task@1.0.0 all --root ../other-repo
+uvx rhiza-task@1.1.0 all --root ../other-repo
 ```
 
 ## Configuration
@@ -78,7 +78,7 @@ uvx rhiza-task@1.0.0 all --root ../other-repo
 Check what actually resolved, rather than what you wrote:
 
 ```bash
-uvx rhiza-task@1.0.0 print coverage_fail_under
+uvx rhiza-task@1.1.0 print coverage_fail_under
 ```
 
 The usual causes, in order of likelihood:
@@ -101,7 +101,7 @@ Move anything CI depends on into `rhiza.toml` or `[tool.rhiza-task]`.
 ### Why is an empty value not empty?
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.0.0 ci-os-matrix   # still ["ubuntu-latest"]
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.1.0 ci-os-matrix   # still ["ubuntu-latest"]
 ```
 
 That is make's `$(or ...)` rule, kept because the reusable workflows depend on it:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,13 +10,13 @@ icon: material/rocket-launch
 project's dependencies:
 
 ```bash
-uvx rhiza-task@1.0.0 list          # what is available
-uvx rhiza-task@1.0.0 all           # every gate, as CI runs them
-uvx rhiza-task@1.0.0 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.1.0 list          # what is available
+uvx rhiza-task@1.1.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.1.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 !!! tip "Pin the version"
-    `rhiza-task@1.0.0` rather than `rhiza-task`. The pin is the whole point of the
+    `rhiza-task@1.1.0` rather than `rhiza-task`. The pin is the whole point of the
     package — an unpinned task layer is a layer that can change under a green pull
     request without a commit touching your repository. Bumping it is then a deliberate
     commit that carries whatever the new version wants.
@@ -30,7 +30,7 @@ it would have to provision the runtime that every task already runs under.
 Start by asking what this repository has:
 
 ```bash
-uvx rhiza-task@1.0.0 list
+uvx rhiza-task@1.1.0 list
 ```
 
 ```text
@@ -56,7 +56,7 @@ other layers call things.
 Then run the aggregate:
 
 ```bash
-uvx rhiza-task@1.0.0 all
+uvx rhiza-task@1.1.0 all
 ```
 
 ## `run`, and the bare shorthand
@@ -64,9 +64,9 @@ uvx rhiza-task@1.0.0 all
 `rhiza-task <task>` is shorthand for `rhiza-task run <task>`:
 
 ```bash
-uvx rhiza-task@1.0.0 test          # shorthand
-uvx rhiza-task@1.0.0 run test      # the same thing
-uvx rhiza-task@1.0.0 run fmt test  # several, in order, prerequisites deduplicated
+uvx rhiza-task@1.1.0 test          # shorthand
+uvx rhiza-task@1.1.0 run test      # the same thing
+uvx rhiza-task@1.1.0 run fmt test  # several, in order, prerequisites deduplicated
 ```
 
 This is a compatibility contract rather than sugar. The reusable workflows and a
@@ -98,7 +98,7 @@ different bundles installed. But a skip is also how a gate silently stops measur
 anything — so `--strict` turns every skip into a failure:
 
 ```bash
-uvx rhiza-task@1.0.0 all --strict
+uvx rhiza-task@1.1.0 all --strict
 ```
 
 !!! note "Which one belongs in your CI"
@@ -145,7 +145,7 @@ rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.0.0
+RHIZA_TASK := rhiza-task@1.1.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -167,11 +167,11 @@ same configuration the tasks read:
     enable-cache: true
 
 - name: Gates
-  run: uvx rhiza-task@1.0.0 all --strict
+  run: uvx rhiza-task@1.1.0 all --strict
 ```
 
 ```bash
-uvx rhiza-task@1.0.0 ci-os-matrix
+uvx rhiza-task@1.1.0 ci-os-matrix
 ```
 
 ```text

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ hide:
 ## 📋 Overview
 
 ```bash
-uvx rhiza-task@1.0.0 test
+uvx rhiza-task@1.1.0 test
 ```
 
 There is nothing to install and nothing to sync. One command runs a project's gates, and
@@ -65,7 +65,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Tasks, grouped by section, with prerequisites and a one-line description.
 
     ```bash
-    uvx rhiza-task@1.0.0 list
+    uvx rhiza-task@1.1.0 list
     ```
 
     [→ The task catalogue](tasks.md)
@@ -77,7 +77,7 @@ files at tag v1.3.3 and hope nobody edited them."
     The aggregate CI runs: format, deps, test, docs, security, licence, types.
 
     ```bash
-    uvx rhiza-task@1.0.0 all
+    uvx rhiza-task@1.1.0 all
     ```
 
     [→ Getting started](getting_started.md)
@@ -89,7 +89,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Six configuration layers, collapsed to the one value a task will actually see.
 
     ```bash
-    uvx rhiza-task@1.0.0 print coverage_fail_under
+    uvx rhiza-task@1.1.0 print coverage_fail_under
     ```
 
     [→ Configuration](configuration.md)

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -53,7 +53,7 @@ lookup("test", ["rust", "python"]).key  # 'rust:test'
 that did not win:
 
 ```bash
-uvx rhiza-task@1.0.0 rust:test
+uvx rhiza-task@1.1.0 rust:test
 ```
 
 Pinning the layer list does the same thing globally:
@@ -75,7 +75,7 @@ layer showed, having synced exactly one fragment.
 `--all` answers the question the make layer could not:
 
 ```bash
-uvx rhiza-task@1.0.0 list --all   # what the layers you do not have call things
+uvx rhiza-task@1.1.0 list --all   # what the layers you do not have call things
 ```
 
 ## A missing name is `None`, not an error

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,14 +26,14 @@ rewrite.
 Either invoke the CLI directly in CI and locally:
 
 ```bash
-uvx rhiza-task@1.0.0 all --strict
+uvx rhiza-task@1.1.0 all --strict
 ```
 
 …or keep `make test` working with a repo-owned `Makefile` that forwards — one rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.0.0
+RHIZA_TASK := rhiza-task@1.1.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -131,7 +131,7 @@ order.
 Add `--strict` in CI once the migration is quiet:
 
 ```bash
-uvx rhiza-task@1.0.0 all --strict
+uvx rhiza-task@1.1.0 all --strict
 ```
 
 A skip in a consumer repository means a gate lost its subject, and `--strict` is what turns

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -129,7 +129,7 @@ Windows. That probe is not incidental complexity; it is the price of the impleme
 language.
 
 Replacing the layer with a published package addresses both at once. A dependency
-\emph{is} a reference: \texttt{uvx rhiza-task@1.0.0 test} names a version, resolves it, and
+\emph{is} a reference: \texttt{uvx rhiza-task@1.1.0 test} names a version, resolves it, and
 leaves nothing in the working tree to drift or exclude. And a package is written in a
 language with data structures, so the retry loop becomes a \texttt{for} statement.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "1.0.0"
+version = "1.1.0"
 description = "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@1.0.0 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@1.1.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
**1.0.0 → 1.1.0.** Phase A of `/rhiza:release`: this PR is the version bump and the changelog.
**No tag exists yet, and merging this does not publish the release** — the tag is cut afterwards
from this PR's merge commit by a second `/rhiza:release` run, which is what triggers publishing.

Closes #115.

## The version

`v1.1.0` strictly increases past every prior release — guarded, not assumed:

```
current  1.0.0        highest  v1.0.0        floor  v1.0.0
target   v1.1.0       ok       v1.1.0 > v1.0.0
```

`minor` because the release contains two `feat:` commits and, more importantly, three
**strictness increases** to `docs-examples` that a consumer will feel. It is not a `patch`.

## Every location the bump touched

All through `[[tool.bumpversion.files]]` — nothing hand-edited:

| Location | |
| --- | --- |
| `pyproject.toml` `[project].version` | 1.1.0 |
| `src/rhiza_task/__init__.py` `__version__` | 1.1.0 |
| `uv.lock` (this package's own entry) | 1.1.0 |
| `README.md` + 6 `docs/*.md` + `docs/paper/paper.tex` | **36 `rhiza-task@` pins moved, 0 stale** |

Those 32 documentation pins are new coverage, added in #120 after the first attempt at this
release was about to ship docs telling readers to run `uvx rhiza-task@1.0.0`.

## The changelog

62 entries across 7 generated sections, prepended with
`git-cliff --unreleased --tag v1.1.0 --prepend`. Verified that the old file is reproduced
**byte-for-byte** plus the new section.

Two manual edits on top, both deliberate:

- **An `⚠️ Upgrade note` heading the 1.1.0 section.** This is what #115 is actually about:
  `docs-examples` now parses `toml`/`yaml`, reads `README.md`'s data fences, and fails when its
  yaml checker crashes instead of reporting "parser unavailable". All three landed as `fix:` and
  `refactor:` commits, so `git-cliff` files them under *Bug Fixes* and *Refactor* — where a
  reader does not look for a behaviour change. The note says it plainly and points at
  `uvx rhiza-task@1.1.0 docs-examples` as the way to check a repo before upgrading.
- **`git-cliff --prepend` ate the `# Changelog` H1 again** and I restored it. Reproducible: both
  prepends during this release did it. Prior sections always survive; the title does not.

## `CLAUDE.md`

The dated reminder that said *"the next tag must be at least `minor`… delete this paragraph once
that release is out"* is discharged, as it instructed. What replaces it keeps the two durable
lessons: the upgrade note is always manual and belongs in `CHANGELOG.md` (the GitHub release
body is generated separately by `rhiza_release.yml` with `git-cliff --latest`, so a note here
does **not** reach it), and `--prepend` eats the heading.

## What to expect from CI

`rhiza-test` passes on this branch, and it is worth knowing why, because it did not before #120:

```
[INFO] release in flight: the declared version leads every tag,
       so test_latest_tag_matches_pyproject_version is deselected
33 passed, 1 deselected
```

That check cannot hold during a release — the tag does not exist until this PR merges — so
`_release_pending` detects the window from repository state and it returns of its own accord
afterwards. In CI it would have skipped anyway, for want of tags in the checkout.

## Not included

**#121 is not in this branch.** It is green and mergeable, and it corrects two docstrings whose
rationale #120 overstated. If you merge #121 before this PR, the **tag will still cover its
content**, because Phase B tags the merge commit on `main` — only the changelog section above
will not list that one docs commit. If you would rather the changelog be complete, merge #121
first and say so, and I will regenerate this section before you merge this.

## After merging

Re-run `/rhiza:release`. It will detect Phase B from the repo's state (declared version ahead of
the highest tag), re-run the guard against the merged history, tag the merge commit and push the
tag — which starts `rhiza_release.yml`: SBOMs, build attestations, and the PyPI publish.
