### PR TITLE
fix: restore the step that strips non-distributions before publishing

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -464,6 +464,23 @@ jobs:
           fi
           cat "$GITHUB_OUTPUT"
 
+      - name: Remove non-distribution files before publish
+        # The dist artifact also carries the SLSA provenance bundle, staged into dist/ by the
+        # build job so the draft release can ship it as a recognised signature asset. twine
+        # rejects it as an unknown distribution format, so strip it here before publishing.
+        #
+        # This step existed, was deleted by 2e0977d ("re-sync from rhiza v1.4.2, keeping the
+        # local trim"), and v1.1.0's release failed on exactly the failure its own comment
+        # described: `Checking dist/provenance.intoto.jsonl: InvalidDistribution`. Restored
+        # rather than redesigned, because it was right.
+        #
+        # Do not "simplify" this away by narrowing `packages-dir` to a glob: that input takes a
+        # directory, not a pattern. The durable alternative is to stop staging the provenance
+        # into dist/ at all and give it its own artifact -- worth doing, and a bigger change
+        # than a release that has already failed once should carry.
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        run: rm -f dist/*.intoto.jsonl
+
       # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI


### PR DESCRIPTION
v1.1.0 tagged, built, drafted its release, then **failed to publish**:

```
Checking dist/provenance.intoto.jsonl:
ERROR    InvalidDistribution: Unknown distribution format
```

**Nothing reached PyPI.** The failure is in `twine check`, before upload — `1.0.0` is still
latest there and `1.1.0` is unused.

## This is a deleted fix, not a new bug

The build job stages the SLSA provenance into `dist/` on purpose, so the draft release can ship
it as a recognised signature asset. The publish job then hands `packages-dir: dist/` to
`gh-action-pypi-publish`, which twine-checks every file it finds. A step existed to reconcile
those two consumers:

```yaml
- name: Remove non-distribution files before publish
  # The dist artifact also carries the SLSA provenance bundle (staged for
  # the GitHub release). twine/pypi-publish rejects it as an unknown
  # distribution format, so strip it here before publishing.
  run: rm -f dist/*.intoto.jsonl
```

`2e0977d` — *"re-sync from rhiza v1.4.2, **keeping the local trim**"* — deleted it. The release
then failed on precisely the failure that step's own comment described. Someone had already hit
this, fixed it, and written the reason down; the re-sync dropped the local trim its own message
claims to have kept.

That is also why v1.0.0 published fine from what looks like identical config.

## What I checked

**Whether anything else was lost the same way.** Filtering that commit's deletions for
non-comment, non-pin lines returns this step and nothing else — so this was the only substantive
local fix dropped.

I had also claimed the container image differed between the two runs (`:v1.14.2` versus
`:dc37677b`). That is true and **irrelevant** — I reported it before finding the deleted step,
and the deleted step is the cause.

## What this PR does, and deliberately does not

Restores the step, behaviour unchanged, with two things added to its comment: the history, so the
next re-sync has a reason not to drop it, and a note against the tempting wrong fix —
`packages-dir` takes a directory, not a glob, so it cannot be narrowed to exclude the file.

**Not done:** the durable design, which is to stop staging provenance into `dist/` at all and
give it its own artifact, removing the coupling rather than working around it. That is the better
shape and a bigger change than a release that has already failed once should carry. Worth its own
issue.

## Recovery still needs a decision

Merging this does **not** republish v1.1.0. The workflow triggers on `push: tags` and
`workflow_call` only — no `workflow_dispatch` — and a tag-triggered run uses the workflow file
*at the tag*, which is `eb9cc79` and does not contain this fix. So the failed run cannot simply
be re-run.

Current state: tag `v1.1.0` pushed, GitHub release **draft** with 4 assets, PyPI at `1.0.0`.
