### PR TITLE
refactor: decompose Config.__post_init__, and correct CLAUDE.md's radon class-scoring claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,15 @@ Two things a change to `docs/` should know. A ```` ```result ```` block is **exe
 diffed** against the `python` fences above it, so an example that goes stale fails a build
 rather than quietly outdating — and the prelude is every earlier `python` fence in that
 file, because `adding_a_task.md`'s pair needs the first fence's `@task` before the second's
-`lookup` — that page holds the one `result` block in the tree, which is why the gate's
-summary line reads `1 diffed`. And fences in a language it cannot check (`mermaid`,
+`lookup`. There are **two** such blocks — that pair, and `layers.md`'s shadowing example,
+whose answers used to sit in trailing `# 'python:test'` comments until they were made a
+`result` block — so the gate's summary line reads `2 diffed`. That is every python fence in
+the tree that *produces output*; the remaining five define a task or bind a name and print
+nothing, so a `result` block on them would be ceremony rather than a check. One of them is
+also why a diffed block is not free: `adding_a_task.md`'s later fences sit *after* its
+`result` block, and moving one above would put a printing fence in the prelude — the
+assumption `_result_violations` documents and deliberately does not loosen.
+And fences in a language it cannot check (`mermaid`,
 `makefile`, and those carrying no language) are **reported with a count** rather
 than passed over in silence, because a green line with no numbers reads as full coverage.
 
@@ -310,35 +317,55 @@ The comments here are unusually dense, and that is the convention rather than an
 The rule they follow: **say why, especially when the code looks wrong.** A flat
 `if ... raise` sequence that radon scores C, a `--partial-match` flag, a `# nosec`, a
 version pinned one patch above upstream — each carries the bug it prevents or the decision
-it records. Two blocks rank C on cyclomatic complexity and each states why the flat form
+it records. **One** block ranks C on cyclomatic complexity, and it states why the flat form
 is preferred over a decomposition that would satisfy the metric.
 
-One rule those two are held to: **if the branch count grows, the comment states a
-ceiling.** `_run_one` is bounded by a closed set — the size of `Status` — so its figure
-cannot drift far and "deliberate" is a complete answer. `Config.__post_init__` is one
-branch per validated setting, which is open-ended, so it names C (15) as the point where
-per-group helpers win. A growth rule without a limit is an open licence rather than a
-decision.
+The rule it is held to: **if the branch count grows, the comment states a ceiling.**
+`_run_one` is bounded by a closed set — the size of `Status` — so its figure cannot drift
+far and "deliberate" is a complete answer. A growth rule without a limit is an open licence
+rather than a decision.
 
-`Guard` and `Guard.check` used to be the other two, at C (14) and C (13). They are the
-worked example of a ceiling being *honoured* rather than restated: at one branch of
-headroom the comment stopped claiming "deliberate", named a tuple of
-`(predicate, message)` as the decomposition to reach for, and that decomposition is now
-`_clauses` — with the class at A (5). Two lessons kept from doing it. The helper is a
-module-level function because **radon scores a class as the sum of its methods**, so a
-second method would have relocated the 14 and reduced nothing. And it is a *generator*,
-because the property the flat form was really protecting was evaluation order — tool
-before file before folder before glob, each only reached if the last was satisfied — which
-a lazily-consumed `yield` keeps and an eagerly-built tuple of pairs would have lost.
+Two earlier cases were the other C blocks, and both are now worked examples of a ceiling
+being *honoured* rather than restated — which is the outcome this rule is for.
+
+`Guard` and `Guard.check`, at C (14) and C (13): at one branch of headroom the comment
+stopped claiming "deliberate", named a tuple of `(predicate, message)` as the
+decomposition to reach for, and that decomposition is now `_clauses` — with the class at
+A (5). The lesson kept from it is about the *generator*: the property the flat form was
+really protecting was evaluation order — tool before file before folder before glob, each
+only reached if the last was satisfied — which a lazily-consumed `yield` keeps and an
+eagerly-built tuple of pairs would have lost. That, and needing no `self`, is why the
+helper is module-level.
+
+`Config.__post_init__`, at C (13): one branch per validated setting, which is *open-ended*
+— every future setting adds one — so its comment named C (15), roughly two more settings,
+as the point where per-group helpers win. #124 took it there at two branches of headroom
+rather than waiting for the gate, and it is now A (1): a flat sequence of calls to
+`_coerce_sequence_fields`, `_validate_layers`, `_validate_typechecker`,
+`_validate_coverage` and `_validate_complexity_max`. The readable one-field-per-step order
+survived; each step is just bounded. **A new validated setting now adds a call here and its
+branches to its own helper**, which is what stops "one branch per validated setting" being
+a growth rule at all.
+
+**One correction that decomposition forced, and it matters because it is load-bearing
+advice.** This file used to say the `Guard` helper was module-level because *radon scores a
+class as the sum of its methods*, so a second method would relocate the figure and reduce
+nothing. **That is wrong.** radon scores a class as the **mean** of its methods, so a small
+method *lowers* the class score. The check is a two-method probe under `uvx radon cc -s`: a
+lone method of 5 scores its class 6, and adding a second of 1 scores it **4**, not 6. So
+`Config`'s five new helpers are *methods* — they need `self` — and the class went B (6) →
+A (4) rather than up. Prefer a module-level function when it needs no `self` or when
+laziness matters, as `_clauses` does; not to dodge a class score that works the other way.
 
 Unlike the layering invariant above, this one **is** gated: `rhiza-task complexity` fails on
 any block above `complexity_max`, which `pyproject.toml` leaves at the shipped 15, and
-`ci.yml`'s `gates` job names it. So the ceiling `Config.__post_init__`'s note commits to is
-read back by a build rather than by a reader who remembers to — which is the whole reason
-that note can say "roughly two more settings" and be held to it. `uvx radon cc src -a -s`
-remains how you read the figure by hand, and the gate reports the worst *block*, classes
-included — so the number to watch is currently `Config.__post_init__`'s 13, with
-`_run_one`'s 12 behind it and no class above either.
+`ci.yml`'s `gates` job names it. So a ceiling a comment commits to is read back by a build
+rather than by a reader who remembers to — which is the whole reason
+`Config.__post_init__`'s note could say "roughly two more settings" and be held to it.
+`uvx radon cc src -a -s` remains how you read the figure by hand, and the gate reports the
+worst *block*, classes included — so the number to watch is now `_run_one`'s **12**, with
+`Config.load`'s B (9) behind it, no other C block anywhere, and no class above A (4). The
+tree average is A (3.23).
 
 When changing such code, update the comment with it. A stale comment is worse than none:
 `ci.yml` once asserted that `rhiza-task fmt` skipped for want of a pre-commit config, for

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -45,9 +45,19 @@ so a crate with a Python binding package gets a single answer rather than an amb
 from rhiza_task.spec import lookup
 from rhiza_task.tasks import python, rust  # importing is what registers
 
-lookup("test", ["python", "rust"]).key  # 'python:test'
-lookup("test", ["rust", "python"]).key  # 'rust:test'
+print(lookup("test", ["python", "rust"]).key)
+print(lookup("test", ["rust", "python"]).key)
 ```
+
+```result
+python:test
+rust:test
+```
+
+Those two lines are **executed and diffed**, not annotated: the answers used to sit in
+trailing `# 'python:test'` comments, which is the shape that goes stale silently -- a change
+to layer precedence would have left them rendering perfectly and wrong. `rhiza-task
+docs-examples` now runs the fence and compares.
 
 `layer:name` addresses one layer explicitly, and is the **only** way to reach the layer
 that did not win:

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -229,9 +229,9 @@ class Config:
     # Pinned to a tag rather than a branch: a gate that moves under you is not a gate.
     pytest_rhiza: str = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0"
 
-    # Both are empty by default and filled in __post_init__, because both depend on the
-    # repository rather than on a constant: the layers come from the manifests present, and
-    # the check set follows from the layers. Setting either explicitly -- in
+    # Both are empty by default and filled in `_validate_layers`, because both depend on
+    # the repository rather than on a constant: the layers come from the manifests present,
+    # and the check set follows from the layers. Setting either explicitly -- in
     # pyproject.toml, or RHIZA_LAYERS=rust -- switches detection off for that field, which
     # is what a repository carrying two manifests and wanting one gate set needs.
     layers: tuple[str, ...] = ()
@@ -244,48 +244,63 @@ class Config:
 
     root: Path = field(default_factory=Path.cwd)
 
-    # radon scores this method C (13): one branch per field that needs normalising or
-    # checking -- str and list coercion, layer defaulting and membership, rhiza_checks
-    # defaulting, typechecker, coverage_fail_under, complexity_max. It is a flat sequence,
-    # one field per step, with no interaction between the steps; the count grows with the
-    # number of validated settings and not with the depth of anything. Deliberate.
+    # A flat sequence of calls, one per group of settings, and so A (1). It was C (13) --
+    # one branch per validated field -- carrying a comment that named **C (15)** as the
+    # point where the flat form stopped paying for itself, and per-group helpers as the
+    # answer. #124 honoured that ceiling at two branches of headroom instead of waiting for
+    # `rhiza-task complexity` to report it, and the shape below is the one that comment
+    # named: the readable one-field-per-step order survives, each step just bounded.
     #
-    # Unlike the other three C blocks here, that growth rule needs a stated ceiling, and
-    # the ceiling is **C (15)**. `_run_one` is bounded by the size of `Status` and
-    # `Guard.check` by the number of guard kinds -- closed sets, so their figures cannot
-    # drift far. "One branch per validated setting" is not a closed set: every future
-    # setting adds one, and a justification with no limit is an open licence rather than a
-    # decision. At 15 -- roughly two more settings -- the flat form stops paying for
-    # itself, and the answer is per-group helpers (`_validate_layers`,
-    # `_validate_typechecker`, `_validate_coverage`) called in sequence from here, which
-    # keeps the readable one-field-per-step order while bounding each block.
-    #
-    # 12 became 13 when `complexity_max` arrived -- the setting that configures the gate
-    # now watching this number, which is the point rather than an irony: `rhiza-task
-    # complexity` is what turns the paragraph above from discipline into a gate, so the
-    # next setting to cross 15 fails a build instead of going unnoticed. `uvx radon cc src
-    # -a -s` remains the way to read the figure by hand.
+    # The helpers are **methods**, which the `Guard`/`_clauses` precedent would have argued
+    # against -- on the grounds that radon scores a class as the *sum* of its methods, so a
+    # new method relocates the figure rather than reducing it. That premise is wrong: radon
+    # scores a class as the **mean** of its methods, so a small method *lowers* it. A
+    # two-method probe under `uvx radon cc -s` is the check -- a lone method of 5 scores its
+    # class 6, and adding a second of 1 scores it 4 -- and `Config` here went B (6) -> A (4)
+    # rather than up. What survives of that precedent is the *other* half, which was never
+    # about radon: `_clauses` is a module-level generator because it needs no `self` and
+    # because laziness preserves the guards' evaluation order. These five need `self` and
+    # have no order to protect, so they are methods.
     def __post_init__(self) -> None:
         """Normalise the list fields, then validate the enumerated and numeric ones.
 
-        :func:`_coerce` sees a string without knowing which field it is destined for, so
-        it can only recognise the two shapes that announce themselves -- a JSON array and
-        a ``;``-separated list. Everything else it leaves as a ``str``, and a ``str``
-        reaching a ``tuple[str, ...]`` field is splatted one *character* per argument at
-        the call site: ``UV_SYNC_ARGS="--group test"`` became ``uv sync - - g r o u p``.
-
-        The field's type is known here and nowhere lower, so this is where a string
-        becomes a tuple. Splitting on whitespace is the make layer's own format --
-        python.mk documented ``LICENSE_IGNORE_PACKAGES`` as space-separated and
-        ``RHIZA_CHECKS`` accumulated space-separated module names -- so a ``.rhiza/.env``
-        written for make keeps working, as does the ``UV_SYNC_ARGS`` that rhiza's synced
-        ``.devcontainer/bootstrap.sh`` exports.
+        Each step is a helper, so this method's own branch count is zero and the ceiling the
+        history above describes no longer applies to it. A new validated setting adds a call
+        here and its branches to its own helper -- which is what makes "one branch per
+        validated setting" stop being an open-ended growth rule.
 
         Raises:
             ValueError: When ``typechecker`` is not one of ty, mypy, both,
                 ``coverage_fail_under`` is outside 0-100, ``complexity_max`` is below 1,
                 ``layers`` names a layer that does not exist, :attr:`root` is not an
-                existing directory, or a ``*_folder`` escapes it.
+                existing directory, or a ``*_folder`` escapes it. Each helper below raises
+                for its own settings and documents the message it uses.
+        """
+        self._coerce_sequence_fields()
+        self._validate_layers()
+        self._validate_typechecker()
+        self._validate_coverage()
+        self._validate_complexity_max()
+        # Order matters, and only between these two: `_validate_folders` asks whether a
+        # setting escapes the root, which presupposes there is a root to escape.
+        self._validate_root()
+        self._validate_folders()
+
+    def _coerce_sequence_fields(self) -> None:
+        """Turn a ``str`` or ``list`` on a ``tuple[str, ...]`` field into a tuple.
+
+        :func:`_coerce` sees a string without knowing which field it is destined for, so it
+        can only recognise the two shapes that announce themselves -- a JSON array and a
+        ``;``-separated list. Everything else it leaves as a ``str``, and a ``str`` reaching
+        a ``tuple[str, ...]`` field is splatted one *character* per argument at the call
+        site: ``UV_SYNC_ARGS="--group test"`` became ``uv sync - - g r o u p``.
+
+        The field's type is known here and nowhere lower, so this is where a string becomes
+        a tuple. Splitting on whitespace is the make layer's own format -- python.mk
+        documented ``LICENSE_IGNORE_PACKAGES`` as space-separated and ``RHIZA_CHECKS``
+        accumulated space-separated module names -- so a ``.rhiza/.env`` written for make
+        keeps working, as does the ``UV_SYNC_ARGS`` that rhiza's synced
+        ``.devcontainer/bootstrap.sh`` exports.
         """
         for f in fields(self):
             if str(f.type).replace(" ", "") != "tuple[str,...]":
@@ -296,6 +311,17 @@ class Config:
             elif isinstance(value, list):
                 object.__setattr__(self, f.name, tuple(value))
 
+    def _validate_layers(self) -> None:
+        """Default :attr:`layers` and :attr:`rhiza_checks` from the repository, then check them.
+
+        Both are empty by default and filled here, because both depend on the repository
+        rather than on a constant. Setting either explicitly switches detection off for that
+        field, which is what a repository carrying two manifests and wanting one gate set
+        needs -- so the defaulting is conditional and the membership check is not.
+
+        Raises:
+            ValueError: When ``layers`` names a layer that does not exist.
+        """
         if not self.layers:
             object.__setattr__(self, "layers", detect_layers(self.root))
         unknown = [layer for layer in self.layers if layer not in LAYERS]
@@ -305,22 +331,38 @@ class Config:
         if not self.rhiza_checks:
             object.__setattr__(self, "rhiza_checks", rhiza_checks_for(self.layers))
 
+    def _validate_typechecker(self) -> None:
+        """Reject a :attr:`typechecker` outside the enumerated set.
+
+        Raises:
+            ValueError: When ``typechecker`` is not one of ty, mypy, both.
+        """
         if self.typechecker not in TYPECHECKERS:
             msg = f"typechecker must be one of {', '.join(TYPECHECKERS)} (got {self.typechecker!r})"
             raise ValueError(msg)
+
+    def _validate_coverage(self) -> None:
+        """Reject a :attr:`coverage_fail_under` that is not a percentage.
+
+        Raises:
+            ValueError: When ``coverage_fail_under`` is outside 0-100.
+        """
         if not 0 <= int(self.coverage_fail_under) <= 100:
             msg = f"coverage_fail_under must be a percentage (got {self.coverage_fail_under!r})"
             raise ValueError(msg)
+
+    def _validate_complexity_max(self) -> None:
+        """Reject a :attr:`complexity_max` below 1.
+
+        A ceiling of 0 would fail every block including the empty ones, which is a typo
+        rather than a very strict policy.
+
+        Raises:
+            ValueError: When ``complexity_max`` is below 1.
+        """
         if int(self.complexity_max) < 1:
             msg = f"complexity_max must be at least 1 (got {self.complexity_max!r})"
             raise ValueError(msg)
-
-        # Two calls rather than two more `if`s, and not only for tidiness: this method is
-        # the one whose branch count has a stated ceiling, so validation that needs its own
-        # branches goes in a helper where it costs nothing here. A call is not a decision
-        # point, so `__post_init__` stays at C (13) with both of these in front of it.
-        self._validate_root()
-        self._validate_folders()
 
     def _validate_root(self) -> None:
         """Reject a :attr:`root` that is not an existing directory.


### PR DESCRIPTION
Two findings from a `/rhiza:quality` pass, plus one correction the first of them forced.

## Decompose `Config.__post_init__` (`refactor`)

Closes #124

The block was **C (13)** against the ceiling of 15 that `rhiza-task complexity` gates.
Its own comment named **C (15)** — roughly two more settings — as the point where
per-group helpers win, and unlike `_run_one` (bounded by the size of `Status`) "one
branch per validated setting" is an *open-ended* growth rule. So the ceiling was going
to be reached by waiting rather than by deciding. This honours it at two branches of
headroom.

The shape is the one that comment named: `_coerce_sequence_fields`, `_validate_layers`,
`_validate_typechecker`, `_validate_coverage` and `_validate_complexity_max`, called in
sequence so the readable one-field-per-step order survives. **A new validated setting
now adds a call plus branches in its own helper**, which is what stops the growth rule
being one.

| | before | after |
|---|---|---|
| `Config.__post_init__` | C (13) | **A (1)** |
| `Config` (class) | B (6) | **A (4)** |
| worst block in `src/` | C (13) | C (12) — `_run_one` |
| tree average | A (3.31) | **A (3.23)** |

No behaviour change, and no new tests: the helpers are exercised through `Config(...)`
construction by the existing behaviour-level tests, and the 100% floor proves every
branch is reached.

## `CLAUDE.md` said the opposite of what radon does (`docs`)

The House style section explained `_clauses` being module-level by asserting that
**radon scores a class as the sum of its methods**, so a new method would relocate the
figure and reduce nothing. That premise is wrong, and it is load-bearing advice: radon
scores a class as the **mean** of its methods, so a small method *lowers* the class
score.

A two-method probe under `uvx radon cc -s` is the check — a lone method of 5 scores its
class **6**, and adding a second of 1 scores it **4**, not 6. Which is why the five
helpers above are *methods* and `Config` went B (6) → A (4) rather than up.

What survives of the `_clauses` precedent is the half that was never about radon: it
needs no `self`, and lazy evaluation preserves the guards' tool-before-file-before-
folder-before-glob ordering. The rule is now "prefer module-level when it needs no
`self` or when laziness matters", not "to dodge a class score".

The section's figures are updated with it: one C block rather than two, and `_run_one`'s
12 as the number to watch.

## Diff `layers.md`'s shadowing example (`docs`)

The example stated its answers in trailing `# 'python:test'` comments. `docs-examples`
parsed the fence but had nothing to compare against, so a change to layer precedence
would have left the claims rendering perfectly and wrong — the failure with the longest
half-life. They are now a `result` block: the gate reports **`2 diffed`** where it
reported 1.

Verified as load-bearing rather than merely passing, by corrupting the block:

```
docs/layers.md:52: result block is stale
           expected: 'python:test\nrust:WRONG'
           actual:   'python:test\nrust:test'
```

**Scoped smaller than the finding first claimed.** That is every python fence in the
tree which *produces output*. The other five define a task or bind a name and print
nothing, so a `result` block would be ceremony rather than a check — and one shows why a
diffed block is not free: `adding_a_task.md`'s later fences sit *after* its `result`
block, so promoting one would put a **printing** fence in the prelude, the assumption
`_result_violations` documents and deliberately declines to loosen. Recorded in
`CLAUDE.md` so `2 diffed` is not read as a gap.

### Release note: no minor bump owed

Flagging this explicitly against the rule in *Commit types are release evidence*, since
the finding was originally raised as a possible strictness increase. **It is not.**
`tasks/fences.py` is untouched, so a consumer running `docs-examples` over their own
docs sees no behavioural change; only this repository's own docs gained a checked block.
`refactor:` + `docs:` is the correct typing.

## Verification

`uv run rhiza-task all` green — fmt, deps, test, docs-coverage, security, license,
typecheck, rhiza-test — plus the two gates outside `all`, `complexity` and
`docs-examples`.

- **383 tests passed, coverage 100.00%** (1432 statements, up from 1422: the new `def`
  lines)
- `ty` and `mypy --strict` clean over 21 files
- `interrogate` 100% over `src/` **and** `tests/`
- no block above the ceiling of 15
- the layering invariant's two greps still return exactly the documented two lines, one
  of them the known `config.py` docstring false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
