### PR TITLE
docs: correct three stale figures in CLAUDE.md's House style section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,12 @@ file, because `adding_a_task.md`'s pair needs the first fence's `@task` before t
 `lookup`. There are **two** such blocks — that pair, and `layers.md`'s shadowing example,
 whose answers used to sit in trailing `# 'python:test'` comments until they were made a
 `result` block — so the gate's summary line reads `2 diffed`. That is every python fence in
-the tree that *produces output*; the remaining five define a task or bind a name and print
-nothing, so a `result` block on them would be ceremony rather than a check. One of them is
+the tree that *produces output*; the remaining **six** define a task, bind a name or quote a
+`Guard` fragment, and print nothing — so a `result` block on them would be ceremony rather
+than a check. Count them with `grep -rcE '^\s*```(python|py)\s*$' docs/*.md`, and note the
+leading `\s*`: two of the eight are **indented** inside a tabbed admonition
+(`adding_a_task.md:77` and `:86`), so a grep anchored at the line start misses them in
+silence. The gate's own `8 python` is the number to reconcile against. One of the six is
 also why a diffed block is not free: `adding_a_task.md`'s later fences sit *after* its
 `result` block, and moving one above would put a printing fence in the prelude — the
 assumption `_result_violations` documents and deliberately does not loosen.
@@ -364,8 +368,17 @@ rather than by a reader who remembers to — which is the whole reason
 `Config.__post_init__`'s note could say "roughly two more settings" and be held to it.
 `uvx radon cc src -a -s` remains how you read the figure by hand, and the gate reports the
 worst *block*, classes included — so the number to watch is now `_run_one`'s **12**, with
-`Config.load`'s B (9) behind it, no other C block anywhere, and no class above A (4). The
-tree average is A (3.23).
+`_report`'s B (10) in `tasks/fences.py` behind it, no other C block anywhere, and no class
+above `Guard`'s A (5). The tree average is A (3.23).
+
+**Every figure in this section is transcribed by hand and read back by nothing**, which is
+the one place this repository's "documentation should be falsifiable" argument does not
+hold: `docs-examples` diffs a `result` block and `test_doctests.py` evaluates a `>>>`, but a
+block score quoted in this file is discipline alone. It has already failed once — the edit
+that corrected the sum-vs-mean claim above simultaneously introduced three wrong figures
+here, all of them green on every gate. So re-run `uvx radon cc src -a -s` and reconcile
+before editing these numbers, and treat a disagreement between two statements in this file
+as the stronger signal: the `Guard` figure was wrong here while correct thirty lines above.
 
 When changing such code, update the comment with it. A stale comment is worse than none:
 `ci.yml` once asserted that `rhiza-task fmt` skipped for want of a pre-commit config, for


### PR DESCRIPTION
Found by a second `/rhiza:quality` pass over `main`. All three figures were introduced by
4f9c5ec — the commit whose *purpose* was correcting a different wrong claim in the same
section. Every gate stayed green through both.

## The corrections

| `CLAUDE.md` said | radon reports |
|---|---|
| "`Config.load`'s B (9) behind it" | **`_report` at B (10)**, `tasks/fences.py:747` — `Config.load` is third |
| "no class above A (4)" | **`Guard` at A (5)** |
| "the remaining five" python fences | **six** |

**The second mattered most.** This file already stated `Guard` was "at A (5)" some forty
lines earlier, so it contradicted itself — and the wrong half was the newer one. A file
that disagrees with itself is worse than one that is merely stale, because a reader has no
way to tell which statement to trust.

**The third had a specific, repeatable cause,** now recorded next to the count. The fences
were inventoried with a grep anchored at the line start, which silently misses the two
**indented** python fences inside `adding_a_task.md`'s tabbed admonition (`:77` and `:86`).
Eight, not six. `docs-examples` prints `8 python` on every run — the gate knew, and nothing
compared the two numbers. The comment now names the grep that works (`^\s*` matters) and
says the gate's count is the figure to reconcile against.

## The note this adds beyond the fix

Every figure in that section is transcribed by hand and **read back by nothing**. It is the
one place this repository's "documentation should be falsifiable" argument does not hold:
`docs-examples` diffs a `result` block, `test_doctests.py` evaluates a `>>>`, `complexity`
reads the ceiling back from a build — but a block score quoted in prose is discipline alone.

It has now failed once, visibly, in the worst possible place: three figures went stale in
the single edit that was fixing a fourth. So the section says so, and tells the next editor
of those numbers to re-run `uvx radon cc src -a -s` and to treat a disagreement between two
statements in the file as the stronger signal.

**Whether to gate it is deliberately left open.** The cheap version is narrow — parse the
`A (n)`/`B (n)`/`C (n)` figures and the fence counts out of this one file and compare
against `_tests/complexity.json`, which `complexity` already writes, plus the
`docs-examples` tally. Against it: a bespoke prose-parser for one file, and a new public
task name on a published CLI — the same cost that got a local `scorecard` task rejected.
Not proposed here; only the failure mode is written down.

## Verification

`uv run rhiza-task all` green (fmt, deps, test, docs-coverage, security, license,
typecheck, rhiza-test), plus `complexity` and `docs-examples`. markdownlint passes under
`fmt`.

Each corrected figure was re-checked against its source:

```
F 168:0 _run_one - C (12)      <- worst block
F 747:0 _report  - B (10)      <- second
M 479:4 Config.load - B (9)    <- third
C  89:0 Guard    - A (5)       <- worst class

$ grep -rcE '^\s*```(python|py)\s*$' docs/*.md
docs/adding_a_task.md:6
docs/layers.md:2               <- 8 total, 2 feeding result blocks, 6 remaining
```

Docs-only: no source, test or workflow file is touched, so nothing about this changes
behaviour for a consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
