### PR TITLE
Run the testing-extras vectors for real, and stop mutation leaving a partial report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,111 @@ jobs:
           uv run rhiza-task workflow-status
           uv run rhiza-task latest-release
 
+  # bundle-layer's argument, carried to the one family it stopped short of. Cross-referencing
+  # `rhiza-task list` against every `rhiza-task <task>` in .github/ showed the Testing extras
+  # bundle -- benchmark, stress, hypothesis-test, mutation -- was the remaining set with no
+  # real execution: `mutation` runs in weekly.yml, and the other three ran nowhere at all.
+  #
+  # They are the sharpest case for this kind of job rather than the mildest, because
+  # `benchmark` is the only vector in the package that pins the tools it provisions -- see its
+  # `withs=` tuple in src/rhiza_task/tasks/extras.py, which is deliberately not transcribed
+  # here: this comment sits beside the step and not beside the pin, so a copy would go stale
+  # on the next bump with nothing reading it back.
+  #
+  # Those pins exist in exactly one place -- the vector -- and are exact on purpose, since
+  # benchmark numbers only compare within a tool version. Nothing else installs them, so a
+  # yank or a release that stops importing on a newer Python is well-formed and *wrong*: it
+  # passes fmt, typecheck, test, complexity and the 100 floor, and breaks in the first
+  # consumer with a benchmarks folder. `--benchmark-histogram` is the flag that needs pygal,
+  # and this job is what asserts pygal alone is enough for it -- pytest-benchmark documents
+  # an extra that also pulls pygaljs, and the vector deliberately does not.
+  #
+  # A separate job rather than three more steps on python-layer, whose fixture comment says
+  # "anything more would be testing the fixture" and is right: these three need a benchmarks
+  # folder, a stress folder, marker registrations and a property test, which is four
+  # additions to a fixture whose point is that it has none.
+  #
+  # `mutation` is not here. mutmut re-runs the whole suite once per mutant, which is minutes
+  # on a real project and the reason weekly.yml runs it weekly and continue-on-error; a
+  # per-push copy would buy the same signal at the cost this repository already decided not
+  # to pay.
+  extras-layer:
+    name: testing-extras tasks against a real toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # Built to the shapes the three guards look for: benchmarks/*.py, stress/*.py and
+      # test_*.py under the tests folder. `coverage_fail_under = 0` for the reason
+      # python-layer gives -- the subject is the vector, not the fixture's coverage.
+      - name: Build a throwaway project
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/extras/src/demo" "$RUNNER_TEMP/extras/tests/benchmarks" \
+                   "$RUNNER_TEMP/extras/tests/stress"
+          cd "$RUNNER_TEMP/extras"
+          printf '"""A package for hatchling to build."""\n\n\ndef add(a, b):\n    """Add."""\n    return a + b\n' \
+            > src/demo/__init__.py
+          # hypothesis is declared as a project dependency and *not* left to the task's own
+          # `--with`, which is the one thing running these steps for real taught. `stress`
+          # provisions only pytest and pytest-html, and pytest imports every test module
+          # during collection -- before `-m stress` deselects any of them -- so a property
+          # test importing hypothesis breaks collection for a gate that never wanted to run
+          # it. A real project with property tests declares hypothesis; the fixture has to
+          # as well, or it tests the fixture's omission instead of the vector.
+          #
+          # The markers are registered for the same reason: unregistered `stress` and
+          # `property` are warnings today, and PytestUnknownMarkWarning is the kind of thing
+          # a future pytest promotes to an error.
+          cat > pyproject.toml <<'EOF'
+          [project]
+          name = "demo"
+          version = "0.1.0"
+          requires-python = ">=3.11"
+
+          [build-system]
+          requires = ["hatchling"]
+          build-backend = "hatchling.build"
+
+          [dependency-groups]
+          test = ["pytest", "hypothesis"]
+
+          [tool.rhiza-task]
+          coverage_fail_under = 0
+
+          [tool.pytest.ini_options]
+          markers = ["stress: load and soak tests", "property: property-based tests"]
+          EOF
+          # One real benchmark, using pytest-benchmark's own fixture: `--benchmark-only`
+          # deselects everything else, so a fixture without this collects nothing and pytest
+          # exits 5, which the task reports as a failure rather than the skip it looks like.
+          printf 'from demo import add\n\n\ndef test_add_benchmark(benchmark):\n    assert benchmark(add, 1, 2) == 3\n' \
+            > tests/benchmarks/test_bench.py
+          printf 'import pytest\n\nfrom demo import add\n\n\n@pytest.mark.stress\ndef test_add_under_load():\n    assert all(add(i, 0) == i for i in range(10000))\n' \
+            > tests/stress/test_load.py
+          # `@given` is what hypothesis's own plugin marks, which is what the task's
+          # `-m "hypothesis or property"` selects -- so this asserts the marker expression,
+          # not just that pytest starts.
+          printf 'from hypothesis import given\nfrom hypothesis import strategies as st\n\nfrom demo import add\n\n\n@given(st.integers(), st.integers())\ndef test_add_commutes(a, b):\n    assert add(a, b) == add(b, a)\n' \
+            > tests/test_props.py
+
+      # Each asserts a different half of its vector: benchmark the two pins and the histogram
+      # flag, stress the marker selection and the pytest-html provision, hypothesis-test the
+      # `--ignore` of the benchmarks folder and the statistics and seed flags. All three run
+      # `install` first, so `uv lock --check` and `uv sync` are exercised against the fixture.
+      - name: rhiza-task benchmark
+        run: uv run rhiza-task benchmark --root "$RUNNER_TEMP/extras"
+
+      - name: rhiza-task stress
+        run: uv run rhiza-task stress --root "$RUNNER_TEMP/extras"
+
+      - name: rhiza-task hypothesis-test
+        run: uv run rhiza-task hypothesis-test --root "$RUNNER_TEMP/extras"
+
   # The floors in pyproject.toml -- typer>=0.15, rich>=13.0, python-dotenv>=1.0 -- are a
   # claim, and `--frozen` everywhere else means nothing tests it: the lockfile resolves
   # typer 0.27.1 and rich 15.0.0, nine and two minor versions above what the manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,10 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
 
 ## Where the gates run
 
-`ci.yml` has nine jobs, and its comments explain each in detail. In short:
+`ci.yml`'s jobs are the ones below, and its comments explain each in detail. The count is
+deliberately not written here: the list *is* the enumeration, so a reader can count it, and
+an integer in this sentence would be one more measured figure with nothing reading it back
+(see the rule further down). In short:
 
 - **`test`** — a 12-cell `pytest` matrix (3 OS × Python 3.11–3.14). **Windows is
   deliberate**, as the assertion that the shell dependency is gone, and the job carries a
@@ -305,6 +308,19 @@ retire — a new `# pragma: no cover` should be argued for rather than added.
   download a browser per run, and its vector differs from `presentation`'s by one flag the
   suite already asserts. `lfs-pull` needs a remote holding LFS objects, and the fixture has
   no remote.
+- **`extras-layer`** — the same argument again, and the family it had stopped short of. The
+  Testing extras bundle was the last set with no real execution: `mutation` runs in
+  `weekly.yml`, and `benchmark`, `stress` and `hypothesis-test` ran **nowhere**. It is the
+  sharpest case rather than the mildest, because `benchmark` is the only vector in the
+  package that *pins* what it provisions — exactly, because benchmark numbers only compare
+  within a tool version — and those pins exist in one place, the vector itself, with nothing
+  else installing them. `grep -n withs= src/rhiza_task/tasks/extras.py` is where to read
+  them; they are not copied here, for the reason the rule below gives. A separate job rather than
+  three steps on `python-layer`, whose fixture comment says anything more would be testing
+  the fixture and is right: these three need a benchmarks folder, a stress folder, marker
+  registrations and a property test. **`mutation` is deliberately absent**, and for a cost
+  reason rather than a structural one: mutmut re-runs the whole suite once per mutant, which
+  is why `weekly.yml` runs it weekly and `continue-on-error`.
 - **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
   are real.
 

--- a/src/rhiza_task/tasks/extras.py
+++ b/src/rhiza_task/tasks/extras.py
@@ -160,8 +160,21 @@ def mutation(cfg: Config) -> None:
     uv_run("mutmut", "html", cwd=cfg.root, withs=("mutmut",))
     generated = cfg.root / "html"
     if generated.is_dir():
-        shutil.rmtree(out / "html", ignore_errors=True)
-        shutil.move(str(generated), str(out / "html"))
+        destination = out / "html"
+        shutil.rmtree(destination, ignore_errors=True)
+        # `shutil.move` is a rename within one filesystem and a recursive copy across two,
+        # and `_tests` can legitimately be a mount or a symlink -- so the copy path is
+        # reachable rather than theoretical. A copy that fails part-way leaves a partial
+        # destination *and* the source, and the next run's `is_dir()` check above would then
+        # relocate that leftover source as if it were its own report. Removing the partial
+        # destination is what keeps the outcomes to the two this task should have: the report
+        # moved, or nothing moved. The source is left alone deliberately -- `copytree` does
+        # not touch it on failure, and leaving it is what lets the next run try again.
+        try:
+            shutil.move(str(generated), str(destination))
+        except OSError:
+            shutil.rmtree(destination, ignore_errors=True)
+            raise
     uv_run("mutmut", "results", cwd=cfg.root, withs=("mutmut",))
 
     if run_status:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -640,6 +640,50 @@ class TestMutation:
         assert not (moved / "stale.html").exists()
         assert not generated.exists()
 
+    def test_a_failed_relocation_leaves_no_partial_report(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A move that fails part-way must not leave a half-written report behind.
+
+        ``shutil.move`` copies rather than renames when source and destination are on
+        different filesystems, and ``_tests`` can be a mount or a symlink. The failure that
+        matters is not the raise -- it is what the *next* run would then find: a partial
+        destination plus an untouched source, whose ``is_dir()`` check would relocate that
+        stale source as if it were a fresh report. So the partial destination goes, and the
+        source stays for the next run to retry.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+        """
+        generated = cfg.root / "html"
+        generated.mkdir()
+        (generated / "index.html").write_text("<html></html>")
+
+        def half_copied(source: str, destination: str) -> None:
+            """Create the destination, then fail -- what an interrupted copy leaves.
+
+            Args:
+                source: The generated report, which a real failure would not touch.
+                destination: The partial tree the cleanup has to remove.
+
+            Raises:
+                OSError: Always, standing in for a cross-device copy that dies part-way.
+            """
+            Path(destination).mkdir(parents=True)
+            (Path(destination) / "partial.html").write_text("half")
+            msg = "no space left on device"
+            raise OSError(msg)
+
+        monkeypatch.setattr(shutil, "move", half_copied)
+
+        with pytest.raises(OSError, match="no space left"):
+            extras.mutation(cfg)
+
+        assert not (cfg.root / "_tests" / "mutation" / "html").exists()
+        assert (generated / "index.html").is_file()
+
 
 class TestHypothesis:
     """test.mk's ``hypothesis-test``."""


### PR DESCRIPTION
Fixes the two findings from a `/rhiza:quality` run. They are independent, and each has its
own commit.

## `ci:` run the testing-extras vectors against a real toolchain

`bundle-layer`'s argument, carried to the one family it stopped short of. Cross-referencing
`rhiza-task list` against every `rhiza-task <task>` in `.github/` showed the Testing extras
bundle was the last set with no real execution: `mutation` runs in `weekly.yml`, and
`benchmark`, `stress` and `hypothesis-test` ran **nowhere**.

They are the sharpest case for this kind of job rather than the mildest, because `benchmark`
is the only vector in the package that *pins* the tools it provisions. Those pins live in one
place — the vector — with nothing else installing them, so a yank or a release that stops
importing on a newer Python is well-formed and *wrong*: it passes `fmt`, `typecheck`, `test`,
`complexity` and the 100 floor, and breaks in the first consumer with a benchmarks folder.

A separate job rather than three more steps on `python-layer`, whose fixture comment says
anything more would be testing the fixture and is right: these three need a benchmarks
folder, a stress folder, marker registrations and a property test.

`mutation` is deliberately absent, for a cost reason rather than a structural one: mutmut
re-runs the whole suite once per mutant, which is why `weekly.yml` runs it weekly and
`continue-on-error`.

### What running it for real taught

Two things the fixture comments now record, both found by executing the steps rather than by
reasoning about them:

- **hypothesis is a declared project dependency, not left to the task's `--with`.** `stress`
  provisions only `pytest` and `pytest-html`, and pytest imports every test module during
  collection — *before* `-m stress` deselects any of them. A property test importing
  hypothesis otherwise breaks collection for a gate that never wanted to run it. This is the
  same class of lesson as `bundle-layer` learning it needed `src/demo` for `uv sync` to build.
- **`--benchmark-histogram` needs `pygal` alone.** pytest-benchmark documents an extra that
  also pulls `pygaljs`; the vector deliberately does not, and the histogram is generated
  regardless. That is now asserted rather than assumed.

All three vectors were run locally against the exact fixture this job builds — the shell block
was extracted from the committed YAML and executed verbatim, not retyped — and all three pass.

## `fix:` leave no partial report when mutation's relocation fails

`shutil.move` is a rename within one filesystem and a recursive copy across two, and `_tests`
can legitimately be a mount or a symlink, so the copy path is reachable rather than
theoretical. A copy that failed part-way left a partial destination **and** the source — and
the next run's `is_dir()` check would then relocate that leftover source as if it were its own
report, carrying a transient failure forward into a later run's output.

The partial destination is now removed before the error propagates. The source is deliberately
left alone: `copytree` does not touch it on failure, and leaving it is what lets the next run
retry.

**Not a strictness increase**, so `fix:` is the right type under the commit-types rule in
`CLAUDE.md`: the success path is unchanged and the failure path raises the same `OSError` it
always did. No gate rejects input it previously accepted, and no consumer's green run goes red.

## `CLAUDE.md`

Drops the `nine jobs` count. It was current measured state, it had just drifted, and the
bullet list immediately below *is* the enumeration — which is exactly what that file's own
"quote a figure only when it cannot drift" rule says to replace with a claim. The two version
pins are likewise named by `grep` rather than transcribed, in both `CLAUDE.md` and the new
workflow comment, since neither sits beside the pin it would be copying.

## Gates

`uv run rhiza-task all` green, plus the two outside it. 384 tests (one new), coverage still
100%. `_run_one` remains the only block ranking C; `mutation` is A (4). Both layering greps
unchanged — 2 lines for rule 3, nothing for rule 4 over `src/` **and** `tests/`.

Closes #128
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
