### PR TITLE
docs: stop giving a total for uv.py's entry points, and name capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ race, never on 1/2/4), `mutation` (run/html/move/results, reporting the *first* 
 |---|---|
 | `spec.py` | `Task`, `Guard`, `Skip`/`Failed`, the `@task` registry, layer resolution |
 | `config.py` | six-layer resolution, replacing `?=` and `+=` |
-| `uv.py` | the four ways rhiza reaches a tool: `uv`, `uvx`, `uv run --with`, and `tool` for a cargo/go binary already on PATH |
+| `uv.py` | the ways rhiza reaches a tool: `uv`, `uvx`, `uv run --with`, `tool` for a cargo/go binary already on PATH, and `capture` for the one recipe that needs stdout back |
 | `runner.py` | prerequisite dedup, guards, outcome bookkeeping |
 | `cli.py` | Typer app, generated from the registry |
 | `tasks/*.py` | the gates themselves, loaded by entry point |

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ the reasoning for each design decision lives.
 | module | reach for it when |
 |---|---|
 | [`spec`](#spec) | writing a task: `@task`, `Guard`, `Skip`, `Failed` |
-| [`uv`](#uv) | writing a task body: the four ways to reach a tool |
+| [`uv`](#uv) | writing a task body: the ways to reach a tool |
 | [`config`](#config) | reading a resolved setting, or adding one |
 | [`runner`](#runner) | understanding prerequisite order and outcomes |
 | [`cli`](#cli) | understanding how the registry becomes commands |

--- a/docs/design.md
+++ b/docs/design.md
@@ -46,7 +46,7 @@ naming them so the exception stays bounded:
 |---|---|
 | `spec.py` | `Task`, `Guard`, `Skip`/`Failed`, the `@task` registry, layer resolution |
 | `config.py` | six-layer resolution, replacing `?=` and `+=` |
-| `uv.py` | the three ways rhiza reaches a tool |
+| `uv.py` | the ways rhiza reaches a tool |
 | `runner.py` | prerequisite dedup, guards, outcome bookkeeping |
 | `cli.py` | Typer app, generated from the registry |
 | `tasks/*.py` | the gates themselves, loaded by entry point |
@@ -59,7 +59,7 @@ flowchart TD
     REG --> RUN["runner.py<br/><small>dedup · guards · outcomes</small>"]
     CLI --> RUN
     RUN --> UV["uv.py"]
-    UV --> A["uv · uvx · uv run --with · tool"]
+    UV --> A["uv · uvx · uv run --with · tool · capture"]
 ```
 
 ## How a tool gets reached
@@ -73,10 +73,17 @@ distinction is preserved rather than unified, because the make layer already got
 | `uvx <tool>` | an isolated one-shot tool run | prek, deptry, bandit, semgrep, zensical, genbadge |
 | `uv run --with a --with b <tool>` | a tool run **against the project environment**, because it imports the project's own code | pytest, interrogate, mutmut, `ty`, mypy |
 
-Rust and Go add a fourth, and only a fourth: a toolchain binary already on `PATH`, because
-uv provisions neither `cargo` nor `go` and nothing here pretends otherwise. It shares the
-module's environment handling and echoing rather than being a bare `subprocess.call` in
-each language module — so `$ cargo clippy` is printed the same way `$ uvx bandit` is.
+Rust and Go add a fourth: a toolchain binary already on `PATH`, because uv provisions
+neither `cargo` nor `go` and nothing here pretends otherwise. It shares the module's
+environment handling and echoing rather than being a bare `subprocess.call` in each
+language module — so `$ cargo clippy` is printed the same way `$ uvx bandit` is.
+
+Go contributes one more — `capture`, which returns **stdout** rather than an exit status,
+for the one recipe that needs a value back rather than a verdict: the licence gate, which
+interpolates `go list -m` into its own arguments. It is the form that gets missed when
+these are counted, being the only one whose caller reads the result and not just the
+status. That is why neither this page nor the module docstring states a total any more;
+`uv.py`'s public functions are the authority. See #131.
 
 !!! note "No shell, anywhere"
     Commands are argument vectors, never shell strings. `rhiza.mk` carried a 40-line probe

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -13,7 +13,7 @@ Layout:
 * :mod:`rhiza_task.spec` -- the task model: ``Task``, ``Guard``, ``Skip``/``Failed``, and
   the registry that replaces make's double-colon rules.
 * :mod:`rhiza_task.config` -- six-layer settings resolution, replacing ``?=`` and ``+=``.
-* :mod:`rhiza_task.uv` -- the three ways rhiza reaches a tool.
+* :mod:`rhiza_task.uv` -- the ways rhiza reaches a tool.
 * :mod:`rhiza_task.runner` -- prerequisite dedup, guard evaluation, outcome bookkeeping.
 * :mod:`rhiza_task.cli` -- the Typer app, generated from the registry.
 * :mod:`rhiza_task.tasks` -- the task modules themselves, loaded by entry point.

--- a/src/rhiza_task/uv.py
+++ b/src/rhiza_task/uv.py
@@ -11,11 +11,20 @@ Every recipe in the retired *Python* make layer used one of exactly three forms:
 The second and third are a real distinction that the make layer already gets right, so it
 is preserved here rather than unified.
 
-rust.mk and go.mk add a fourth, and only a fourth: ``$(CARGO) nextest run``, ``$(GO) test``
--- a toolchain binary that is already on PATH, because uv does not provision cargo or go
-and nothing here pretends otherwise. :func:`tool` is that form. It shares this module's
-environment handling and echoing rather than being a bare ``subprocess.call`` in each
-language module, so ``$ cargo clippy`` is printed the same way ``$ uvx bandit`` is.
+rust.mk and go.mk add a fourth: ``$(CARGO) nextest run``, ``$(GO) test`` -- a toolchain
+binary that is already on PATH, because uv does not provision cargo or go and nothing here
+pretends otherwise. :func:`tool` is that form. It shares this module's environment handling
+and echoing rather than being a bare ``subprocess.call`` in each language module, so
+``$ cargo clippy`` is printed the same way ``$ uvx bandit`` is.
+
+go.mk contributes one more, and it is the one that gets missed when these are counted:
+:func:`capture`, which returns *stdout* rather than an exit status, for the recipe that
+needs a value back rather than a verdict -- the licence gate, which has to interpolate
+``go list -m`` into its own arguments. It is easy to overlook precisely because it is the
+only form whose caller reads the result instead of just its status, and #131 is what that
+cost: every prose total for this module disagreed with the code, and with the others. So no
+sentence here gives one -- the public functions below are the authority, and a total in
+prose goes stale the moment a form is added.
 
 Two things disappear:
 


### PR DESCRIPTION
Closes #131.

`uv.py` exports five public entry points — `uv`, `uvx`, `uv_run`, `tool`, `capture` — and **seven** places described that set wrongly. `tests/conftest.py` was the only one right.

| File | Was | Now |
|---|---|---|
| `src/rhiza_task/__init__.py:16` | "the **three** ways" | "the ways" |
| `src/rhiza_task/uv.py:14` | "a fourth, and **only** a fourth" | "a fourth" + a paragraph naming `capture` |
| `README.md:118` | "the **four** ways: `uv`, `uvx`, `uv run --with`, `tool`" | no total; `capture` enumerated |
| `docs/api.md:14` | "the **four** ways to reach a tool" | "the ways to reach a tool" |
| `docs/design.md:49` | "the **three** ways" | "the ways" |
| `docs/design.md:62` (mermaid) | `uv · uvx · uv run --with · tool` | `… · tool · capture` |
| `docs/design.md:78` | "a fourth, and **only** a fourth" | "a fourth" + a `capture` paragraph |

## The defect was not the integer three

`uv.py:3` and `design.md:67` say the retired *Python* make layer used exactly three forms. That is **scoped to that layer's history and accurate**, so both are left alone — `CLAUDE.md`'s rule permits historical figures precisely because they cannot drift.

What was false is **`and only a fourth`**. `go.mk` contributed `capture` as well: the licence gate has to interpolate `go list -m` into its own arguments, so it needs stdout rather than an exit status. It is the form that gets missed when these are counted, being the only one whose caller reads the result instead of just the status.

## Why no total, rather than five everywhere

Resetting each site to "five" would reset the failure surface rather than remove it. This follows the rule the bug argues for:

- no prose gives a total;
- the enumerations that genuinely help a reader are completed with `capture`;
- both new paragraphs state that `uv.py`'s public functions are the authority.

A total in prose is read back by nothing — `docs-examples` diffs fences, the doctests evaluate `>>>`, `interrogate` asks whether a docstring *exists*. That is how five files disagreed with the code while every gate stayed green. `test_uv.py:315` does assert all five entry points are patched, but that is hermeticity, not the count.

## Commit type

`docs:`, not `feat:`. No gate accepts less than it did before, so `CLAUDE.md`'s "a stricter gate is `feat:` and needs a minor" rule does not apply here.

## Verification

- `uv run rhiza-task all` → **ok** (fmt, deps, test, docs-coverage, security, license, typecheck, rhiza-test)
- `uv run rhiza-task complexity` → **ok**
- `uv run rhiza-task docs-examples` → **ok**, with fence tallies **byte-identical** to before (63 fences, 45 checked, 8 python, 2 diffed, 5 mermaid) — confirming prose changed and fence structure did not
- 384 tests pass, coverage 100%, docstring coverage 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
