### PR TITLE
feat: let an empty pytest_rhiza run the checks from the project itself

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,6 +189,25 @@ $(CURDIR))` cannot be spelled as a dataclass default, and keeping it empty keeps
 | `ci_os_matrix` | `("ubuntu-latest",)` | feeds `ci-os-matrix` |
 | `pytest_rhiza` | pinned to a tag | the `rhiza-test` provider — a gate that moves under you is not a gate |
 
+**Empty means "omit `--with` entirely."** The pin is right for a consumer, and wrong for the
+one case that wants the opposite: trying an unreleased check against a real subject, which
+otherwise means publishing something first. Set it empty and `rhiza-test` and
+`test-pyproject` pass no `--with` at all, so `uv run` answers from the project environment —
+where an editable path source, say, actually tracks the working tree:
+
+```toml
+[tool.rhiza-task]
+pytest-rhiza = ""
+```
+
+TOML only, for the same reason as `mkdocs-extra-packages = []` above: `RHIZA_PYTEST_RHIZA=`
+reads as unset, and only TOML tells an empty string from an absent key.
+
+`pytest-rhiza = "."` looks like the shorthand and is a trap. `uv run --with .` resolves to a
+**cached built copy** that is not rebuilt on edit, so a broken check goes uncaught while the
+gate looks like it ran against your tree — worse than the pin, which at least declares what
+it is.
+
 ### Detected, not configured
 
 | setting | default | what |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -141,6 +141,10 @@ run is derived from the language layer, not configured: the neutral ones, plus
 `test_pyproject` and `test_docstrings` for Python, `test_cargo_toml` for Rust,
 `test_go_module` for Go.
 
+*Which* pytest-rhiza runs them is configured, by
+[`pytest_rhiza`](configuration.md#environment-and-ci) — a pinned release by default, and the
+project environment's own copy when the setting is empty.
+
 ## Testing extras
 
 | task | needs | does |

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -227,6 +227,14 @@ class Config:
     ci_os_matrix: tuple[str, ...] = DEFAULT_CI_OS_MATRIX
 
     # Pinned to a tag rather than a branch: a gate that moves under you is not a gate.
+    #
+    # Set it **empty** and `rhiza-test` passes no `--with` at all, resolving pytest-rhiza
+    # from the project environment instead -- the way to try an unreleased check against a
+    # real subject without publishing one first. Like `mkdocs_extra_packages` above, that is
+    # a manifest-only spelling: `_from_environ` and `_from_env_file` drop an empty value as
+    # unset, and only TOML tells an empty string from an absent key. See
+    # `tasks/quality.py`'s `_provider`, which also records why `"."` is not the shorthand it
+    # looks like.
     pytest_rhiza: str = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0"
 
     # Both are empty by default and filled in `_validate_layers`, because both depend on

--- a/src/rhiza_task/tasks/quality.py
+++ b/src/rhiza_task/tasks/quality.py
@@ -150,6 +150,9 @@ def rhiza_test(cfg: Config) -> None:
     the tag exists. It is a *local* improvement only: CI has no tags, so this check skips there
     regardless -- see that constant's own note.
 
+    The pin the checks are provisioned from is :func:`_provider`'s answer rather than the
+    setting itself, so a repository can spell "resolve them from my own environment".
+
     Args:
         cfg: The resolved config.
     """
@@ -172,7 +175,7 @@ def rhiza_test(cfg: Config) -> None:
         *cfg.rhiza_checks,
         *selection,
         cwd=cfg.root,
-        withs=(cfg.pytest_rhiza,),
+        withs=_provider(cfg),
         env={"RHIZA_DOCTEST_FOLDERS": cfg.source_folder},
     )
 
@@ -189,7 +192,8 @@ def test_pyproject(cfg: Config) -> None:
 
     A narrower, louder view of one module that ``rhiza-test`` also runs -- kept because it
     is what you want when that check is the thing you are fixing. The reporting flags are
-    python.mk's verbatim.
+    python.mk's verbatim, and the provider is :func:`_provider`'s, so the two gates agree on
+    where the checks come from.
 
     Args:
         cfg: The resolved config.
@@ -205,7 +209,7 @@ def test_pyproject(cfg: Config) -> None:
         "--durations=0",
         "--no-header",
         cwd=cfg.root,
-        withs=(cfg.pytest_rhiza,),
+        withs=_provider(cfg),
     )
 
 
@@ -312,6 +316,36 @@ def clean(cfg: Config) -> None:
         if ": gone]" in line and not line.startswith(("*", "+")):
             branch = line.strip().split()[0]
             _git(git, ["branch", "-D", branch], cfg.root)
+
+
+def _provider(cfg: Config) -> tuple[str, ...]:
+    """Return the ``--with`` arguments that provide pytest-rhiza, or nothing at all.
+
+    :attr:`~rhiza_task.config.Config.pytest_rhiza` is pinned by default, which is right for
+    a consumer: a gate should run the assertions of a known release rather than whatever the
+    checks repository's HEAD says today. **Empty means the opposite** -- omit ``--with``
+    entirely and let ``uv run`` resolve pytest-rhiza from the project environment, which is
+    how a repository tries an unreleased check against a real subject without publishing
+    something first. It is a real choice rather than an absent one, so it is honoured rather
+    than defaulted over.
+
+    Spelling it needs TOML, for the reason :func:`~rhiza_task.config._from_env_file` gives
+    about ``mkdocs-extra-packages``: only there does an empty value differ from an absent
+    key. ``pytest-rhiza = ""`` in ``[tool.rhiza-task]`` says it; ``RHIZA_PYTEST_RHIZA=``
+    cannot, and reads as unset.
+
+    ``pytest-rhiza = "."`` is the trap to avoid rather than the shorthand to reach for: uv
+    resolves it to a *cached built copy* which is not rebuilt on edit, so the checks pass
+    against a stale tree while looking like they ran against the working one. Empty leaves
+    the project environment to answer, which an editable install actually tracks.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The one-element pin, or an empty tuple when the setting is empty.
+    """
+    return (cfg.pytest_rhiza,) if cfg.pytest_rhiza.strip() else ()
 
 
 def _walk(root: Path) -> list[Path]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -493,6 +493,24 @@ def test_an_empty_toml_array_overrides_the_default_away(tmp_path: Path) -> None:
     assert Config.load(root=tmp_path).mkdocs_extra_packages == ()
 
 
+def test_an_empty_string_setting_survives_the_manifest(tmp_path: Path) -> None:
+    """``pytest-rhiza = ""`` must reach the config, not be defaulted back to the pin.
+
+    The scalar counterpart of the array case above, and the layer that makes the opt-out in
+    ``tasks/quality.py``'s ``_provider`` reachable at all: the empty string is how a
+    repository says "resolve the checks from my own environment", so a reader that dropped
+    it would leave that setting unspellable. The environment cannot say it -- that is the
+    empty-is-unset rule, pinned for ``mkdocs_extra_packages`` just below.
+
+    Args:
+        tmp_path: The repository root.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.0.0"\n\n[tool.rhiza-task]\npytest-rhiza = ""\n'
+    )
+    assert Config.load(root=tmp_path).pytest_rhiza == ""
+
+
 def test_an_empty_env_value_leaves_the_default_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """An empty environment value must not be read as "no packages".
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -372,6 +372,36 @@ class TestQuality:
         assert not [f for f in call.flags if "test_cargo_toml" in f or "test_go_module" in f]
         assert call.kwargs["withs"] == (cfg.pytest_rhiza,)
 
+    def test_rhiza_test_omits_the_with_when_the_provider_is_empty(self, cfg: Config, recorder: Recorder) -> None:
+        """An empty ``pytest_rhiza`` drops ``--with`` rather than passing an empty spec.
+
+        The pin is right for a consumer and wrong for anyone testing an unreleased check
+        against a real subject: ``--with`` overrides whatever the project environment
+        resolved, so there was no way to run the working tree's own copy. Empty says so, and
+        ``uv run`` then answers from the project environment. Passing ``("",)`` through would
+        be the other reading, and it is the broken one -- ``uv run --with ''``.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        quality.rhiza_test(replace(cfg, pytest_rhiza=""))
+        assert recorder.find("pytest").kwargs["withs"] == ()
+
+    def test_rhiza_test_reads_whitespace_as_empty(self, cfg: Config, recorder: Recorder) -> None:
+        """``pytest-rhiza = " "`` means the same thing as ``""``.
+
+        A TOML value cannot be stripped on the way in -- :func:`_coerce` only sees the
+        environment layer -- so the setting arrives as written, and a spec of pure whitespace
+        is not a spec.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        quality.rhiza_test(replace(cfg, pytest_rhiza="  "))
+        assert recorder.find("pytest").kwargs["withs"] == ()
+
     def test_rhiza_test_tells_the_docstring_check_where_to_look(self, cfg: Config, recorder: Recorder) -> None:
         """``RHIZA_DOCTEST_FOLDERS`` carries ``source_folder`` into the checks.
 
@@ -1194,6 +1224,19 @@ class TestPyprojectStructure:
         for loud in ("--tb=long", "--showlocals", "-rA", "--durations=0", "--no-header"):
             assert loud in call.flags
         assert call.kwargs["withs"] == (cfg.pytest_rhiza,)
+
+    def test_omits_the_with_when_the_provider_is_empty(self, cfg: Config, recorder: Recorder) -> None:
+        """The narrower gate honours the same opt-out as ``rhiza-test``.
+
+        Two gates disagreeing about where the checks come from would mean a repository
+        pointing at its own tree still got the pinned copy from one of them.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        quality.test_pyproject(replace(cfg, pytest_rhiza=""))
+        assert recorder.find("pytest").kwargs["withs"] == ()
 
 
 class TestComplexity:


### PR DESCRIPTION
Closes #133.

`rhiza-test` and `test-pyproject` passed `--with $pytest_rhiza` unconditionally. That is right for a consumer — a gate should run the assertions of a known release, not whatever the checks repo's HEAD says today — but there was no way to express the opposite, and the issue's remaining case wants it: trying an unreleased pytest-rhiza against a real subject, which otherwise means publishing something first.

## What changed

**Empty means "omit `--with` entirely."** `uv run` then resolves pytest-rhiza from the project environment, where an editable path source actually tracks the working tree. Both gates ask `_provider` in `tasks/quality.py`, so they cannot disagree about where the checks came from — two gates differing on that would mean a repo pointing at its own tree still got the pinned copy from one of them.

```toml
[tool.rhiza-task]
pytest-rhiza = ""
```

**Manifest-only**, and that is the existing rule rather than a new one: `_from_environ` and `_from_env_file` drop an empty value as unset to mirror make's `?=` — the thing `rhiza_ci.yml`'s empty matrix export relies on — and only TOML tells an empty string from an absent key. Exactly the `mkdocs-extra-packages = []` precedent, which `_from_env_file`'s docstring already argues; `RHIZA_PYTEST_RHIZA=` still reads as unset.

Worth being precise about the starting point: `""` **already reached the config** through the manifest layer. What it produced was `uv run --with '' pytest`, so the spelling existed and was broken rather than absent.

Whitespace reads as empty too. A TOML value is not passed through `_coerce`, so `pytest-rhiza = " "` arrives as written, and a spec of pure whitespace is not a spec.

## The trap, documented rather than left to be rediscovered

The issue asks for this explicitly. `pytest-rhiza = "."` looks like the shorthand and is not: `uv run --with .` resolves to a **cached built copy** that is not rebuilt on edit, so the checks pass against a stale tree while looking like they ran against the working one — worse than the honest pin. That reasoning is in `_provider`'s docstring and in `docs/configuration.md`, in both cases next to what to do instead.

## Why `feat:`

A new setting value with new behaviour. It is not the strictness case CLAUDE.md's rule is aimed at — no gate rejects input it accepted before — but it is not a `fix:` either, and a `minor` is what carries it.

## Verification

- `uv run rhiza-task all` — green, including `rhiza-test` still running against the pin.
- `uv run rhiza-task complexity` and `docs-examples` — green; the new `toml` fence in `docs/configuration.md` is parsed by the latter, and the fence counts moved with it.
- `uv run pytest -q` — 387 passed, coverage floor of 100 held.

Four tests, three of them behaviour pins rather than coverage: both gates omit `--with` when the setting is empty, whitespace counts as empty, and `pytest-rhiza = ""` survives `Config.load` — that last one is what makes the opt-out reachable from configuration at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)