### PR TITLE
feat: compile the paper with tectonic, and stop probing for make

### DIFF
--- a/.github/actions/setup-tectonic/action.yml
+++ b/.github/actions/setup-tectonic/action.yml
@@ -1,0 +1,85 @@
+# The paper engine, installed once and defined once.
+#
+# Two workflows compile docs/paper: rhiza_paper.yml produces the artifact and the `paper`
+# branch, rhiza_book.yml the copy inside the published book. They must use the *same* engine
+# -- that argument is why the TeX distribution this replaced kept a four-package list in each
+# file, and the hazard was that nothing checked the two lists agreed. Pinning a release
+# tarball trades that list for a version and a checksum, which would be the same hazard twice
+# over if each workflow carried its own copy. So they carry none: this is the one place the
+# version, the URL and the digest exist.
+#
+# Why a pinned tarball rather than a package manager or the upstream installer:
+#
+#   * `apt-get install tectonic` does not work -- tectonic is packaged for Debian but not for
+#     Ubuntu noble, which is what ubuntu-latest is. That is what the first attempt at this
+#     did, and `E: Unable to locate package tectonic` is how it failed.
+#   * The upstream one-liner pipes a fetched script into a shell. Every action in this
+#     repository is pinned to a commit SHA; fetching an unpinned script and executing it is
+#     the opposite of that, and dependabot cannot see it either.
+#   * `cargo install tectonic` compiles for minutes per run and pulls system libraries.
+#
+# The pin is also load-bearing beyond supply chain: a typesetting engine's output moves
+# between versions, so an unpinned engine would let the PDF on the `paper` branch and the one
+# inside the book differ for no reason anybody could see in a diff.
+#
+# musl rather than gnu deliberately: the musl build is statically linked, so it depends on no
+# libssl or fontconfig the runner image happens to ship. The pin is therefore x86_64 Linux
+# only, and the step below refuses anything else rather than downloading a tarball for the
+# wrong machine.
+#
+# To bump: change VERSION, download the matching -x86_64-unknown-linux-musl.tar.gz, and put
+# its sha256 in SHA256. Nothing else moves.
+name: Set up tectonic
+description: Install a pinned tectonic release and restore its bundle cache.
+
+runs:
+  using: composite
+  steps:
+    - name: Install tectonic
+      shell: bash
+      env:
+        VERSION: "0.17.0"
+        SHA256: "8533d07f9ccbd7a65824b9e0459041bca34af1eb33daba48f59215593753a3b7"
+      run: |
+        set -euo pipefail
+
+        if [ "$RUNNER_OS" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+          echo "::error::setup-tectonic pins an x86_64 Linux build; this runner is $RUNNER_OS/$(uname -m)."
+          exit 1
+        fi
+
+        archive="$RUNNER_TEMP/tectonic.tar.gz"
+        # %40 is the '@' in the tag `tectonic@<version>`: the repository releases several
+        # crates from one tag namespace, so the CLI's tags are not bare versions.
+        url="https://github.com/tectonic-typesetting/tectonic/releases/download/tectonic%40${VERSION}/tectonic-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-connrefused -o "$archive" "$url"
+
+        # Checked before anything is unpacked, let alone executed. `--strict` so a malformed
+        # digest line is an error rather than a silently skipped check.
+        echo "${SHA256}  ${archive}" | sha256sum --check --strict -
+
+        mkdir -p "$RUNNER_TEMP/tectonic-bin"
+        tar -xzf "$archive" -C "$RUNNER_TEMP/tectonic-bin" tectonic
+        chmod +x "$RUNNER_TEMP/tectonic-bin/tectonic"
+        # Absolute path here because GITHUB_PATH only takes effect in the *next* step, and a
+        # version that prints is the proof the download is a working binary for this runner.
+        "$RUNNER_TEMP/tectonic-bin/tectonic" --version
+        echo "$RUNNER_TEMP/tectonic-bin" >> "$GITHUB_PATH"
+
+    # tectonic's whole model is fetching what the document cites out of a web bundle and
+    # caching it, so the cache is where the trade against a provisioned distribution is
+    # actually settled: warm, the compile is offline for everything it has seen before; cold,
+    # it is a network round trip per file the document needs. Keyed on the sources because
+    # that is what determines the fetch set, and on the engine version because a bundle is
+    # fetched into a version's own cache layout. The prefix restore means editing the paper
+    # reuses the previous run's files instead of refetching the preamble's packages.
+    #
+    # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
+    # paths differ, which does not matter while the step above accepts only Linux.
+    - name: Cache the tectonic bundle
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/Tectonic
+        key: tectonic-0.17.0-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
+        restore-keys: |
+          tectonic-0.17.0-${{ runner.os }}-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,27 @@ updates:
     commit-message:
       prefix: "build"
 
+  # The composite action in .github/actions/setup-tectonic, which pins actions/cache by SHA
+  # like every workflow does. It needs its own entry because `directory: /` above covers
+  # .github/workflows and not composite actions nested below .github/actions -- so without
+  # this, that one SHA would be the only unwatched action pin in the repository, which is
+  # exactly the silent rot the header describes.
+  #
+  # Its *other* pin, the tectonic tarball, is not something dependabot can move; see the
+  # note at the foot of this file.
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-tectonic
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+    groups:
+      actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+
   # pyproject.toml and uv.lock. The floors here (`typer>=0.15`, `rich>=13.0`,
   # `python-dotenv>=1.0`) are asserted by ci.yml's `lowest-deps` job and the ceiling by
   # weekly.yml's `dep-compat`, so both ends of every range already have a gate -- what was
@@ -60,7 +81,7 @@ updates:
     commit-message:
       prefix: "build"
 
-# Two pins dependabot cannot reach, and both are reviewed by hand. Recorded here rather
+# Three pins dependabot cannot reach, and all are reviewed by hand. Recorded here rather
 # than only at the call sites, because this is the file a reader consults to learn what is
 # and is not automated -- and silence here would read as "everything is covered".
 #
@@ -75,6 +96,13 @@ updates:
 #     the action. It must stay equal to the uv that rhiza_release.yml builds and publishes
 #     with, for the reason ci.yml's first job records: a gate that passes on one uv and a
 #     release built on another is a resolver difference nothing would catch.
+#   * `VERSION` and `SHA256` in .github/actions/setup-tectonic/action.yml, which pin the
+#     paper engine as a release tarball plus its digest. There is no ecosystem that reads a
+#     version out of a shell variable, and the pin is not only supply chain: a typesetting
+#     engine's output moves between versions, and rhiza_paper.yml and rhiza_book.yml compile
+#     the same document, so an engine bump is a deliberate act that should be looked at
+#     rather than merged on a Monday. Bump both fields together -- a stale digest fails the
+#     checksum step, which is the intended failure mode.
 #
 # The remaining .pre-commit-config.yaml hook revs are unautomated for the same
 # no-such-ecosystem reason, but carry no cross-file pairing, so `prek autoupdate` is a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,10 @@ jobs:
       # this OS". `list` executes config resolution, layer detection and the registry walk;
       # `doctor` then resolves binaries for real -- `shutil.which` (uv.exe on Windows), a
       # real subprocess, `cfg.root` path handling -- which is the layer the suite stubs.
-      # Neither provisions anything, and `make` is optional in `doctor`'s TOOLS, so its
-      # absence on the runners is reported rather than fatal.
+      # Neither provisions anything. `doctor`'s TOOLS names only uv and git -- both present
+      # on all three runners, uv from the setup step above and git from the image -- so this
+      # step asserts the probe machinery works rather than tolerating a miss. It used to also
+      # name make, optionally, which meant the step passed whether or not that half worked.
       #
       # `!cancelled()` for the reason the ruff job's two halves have it: a broken CLI and a
       # failing test are independent findings, and reporting one at a time costs a round

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -84,39 +84,16 @@ jobs:
       # `deploy`'s exactly, so the ref that publishes is the ref that has the engine. (The
       # fork exclusion is the job's own `if`, so it is not repeated here.)
       #
-      # One package where this used to be four, and that is the point of tectonic rather than
-      # a saving: the distribution install asked each workflow to name the TeX packages the
-      # document happens to cite, and two workflows compiling one document against different
-      # package sets is a divergence neither would catch. tectonic resolves what the document
-      # cites from its own bundle, so there is no set to diverge. It does fetch that bundle
-      # over the network on a cold cache, which a provisioned distribution did not.
-      - name: Install tectonic (publishing refs only)
+      # One tool where this used to be a distribution and a four-package list, and that is the
+      # point of tectonic rather than a saving: the list asked each workflow to name the TeX
+      # packages the document happens to cite, and two workflows compiling one document
+      # against different package sets is a divergence neither would catch. tectonic resolves
+      # what the document cites from its own bundle. The local action is shared with
+      # rhiza_paper.yml so the engine version cannot diverge either, which matters because
+      # that workflow publishes the same document's PDF on the `paper` branch.
+      - name: Set up tectonic (publishing refs only)
         if: ${{ github.ref_name == github.event.repository.default_branch }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tectonic
-
-      # tectonic's whole model is fetching what the document cites out of a web bundle and
-      # caching it, so the cache is where the trade against a provisioned distribution is
-      # actually settled: warm, the install is one apt package and the compile is offline for
-      # everything it has seen before; cold, it is a network round trip per file the document
-      # needs. Keyed on the sources because that is what determines the fetch set, with a
-      # prefix restore so editing the paper reuses the previous run's files instead of
-      # refetching the preamble's packages from scratch.
-      #
-      # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
-      # paths differ, which does not matter here because both jobs are ubuntu-only.
-      #
-      # Same condition as the install above, so a branch build neither restores nor saves a
-      # cache for a paper it never compiles.
-      - name: Cache the tectonic bundle (publishing refs only)
-        if: ${{ github.ref_name == github.event.repository.default_branch }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/Tectonic
-          key: tectonic-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
-          restore-keys: |
-            tectonic-${{ runner.os }}-
+        uses: ./.github/actions/setup-tectonic
 
       # `book` depends on `test`, so this step also produces the `_tests/` tree it folds in
       # as docs/reports -- the coverage XML the badge step reads, and the HTML report and

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -71,31 +71,52 @@ jobs:
           restore-keys: |
             mkdocs-plugin-${{ runner.os }}-
 
-      # TeX Live, and only on the ref `deploy` will publish. `book` names `paper` as a
-      # prerequisite and a *skipped* prerequisite does not block a dependent, so without
-      # latexmk this job built a site whose `Paper: paper/paper.pdf` nav entry pointed at a
+      # The paper engine, and only on the ref `deploy` will publish. `book` names `paper` as a
+      # prerequisite and a *skipped* prerequisite does not block a dependent, so without an
+      # engine this job built a site whose `Paper: paper/paper.pdf` nav entry pointed at a
       # file nothing had written -- and published it. That is what 404ed:
       # https://jebel-quant.github.io/rhiza-task/paper/paper.pdf, on a run that was green,
       # because every gate here passes when the paper is absent.
       #
-      # Scoped to the default branch rather than run everywhere because the apt-get is the
+      # Scoped to the default branch rather than run everywhere because the install is the
       # expensive half and a branch book is downloaded from the run page, not visited. A
       # branch build therefore still carries the dangling entry; the condition mirrors
-      # `deploy`'s exactly, so the ref that publishes is the ref that has latexmk. (The
+      # `deploy`'s exactly, so the ref that publishes is the ref that has the engine. (The
       # fork exclusion is the job's own `if`, so it is not repeated here.)
       #
-      # The same four packages as rhiza_paper.yml, deliberately: two workflows compiling one
-      # document against different TeX package sets is a divergence neither would catch --
-      # that one produces the PDF on the `paper` branch, this one the copy inside the book.
-      - name: Install TeX Live (publishing refs only)
+      # One package where this used to be four, and that is the point of tectonic rather than
+      # a saving: the distribution install asked each workflow to name the TeX packages the
+      # document happens to cite, and two workflows compiling one document against different
+      # package sets is a divergence neither would catch. tectonic resolves what the document
+      # cites from its own bundle, so there is no set to diverge. It does fetch that bundle
+      # over the network on a cold cache, which a provisioned distribution did not.
+      - name: Install tectonic (publishing refs only)
         if: ${{ github.ref_name == github.event.repository.default_branch }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            texlive-latex-extra \
-            texlive-fonts-recommended \
-            texlive-bibtex-extra \
-            latexmk
+          sudo apt-get install -y tectonic
+
+      # tectonic's whole model is fetching what the document cites out of a web bundle and
+      # caching it, so the cache is where the trade against a provisioned distribution is
+      # actually settled: warm, the install is one apt package and the compile is offline for
+      # everything it has seen before; cold, it is a network round trip per file the document
+      # needs. Keyed on the sources because that is what determines the fetch set, with a
+      # prefix restore so editing the paper reuses the previous run's files instead of
+      # refetching the preamble's packages from scratch.
+      #
+      # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
+      # paths differ, which does not matter here because both jobs are ubuntu-only.
+      #
+      # Same condition as the install above, so a branch build neither restores nor saves a
+      # cache for a paper it never compiles.
+      - name: Cache the tectonic bundle (publishing refs only)
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
+          restore-keys: |
+            tectonic-${{ runner.os }}-
 
       # `book` depends on `test`, so this step also produces the `_tests/` tree it folds in
       # as docs/reports -- the coverage XML the badge step reads, and the HTML report and
@@ -109,13 +130,13 @@ jobs:
 
       # The gate on what was *published* rather than on what was built. zensical reports
       # `No issues found` for a nav entry whose page is missing and for one whose asset is
-      # missing, so the TeX install above fixes one instance of the 404 and this catches the
-      # class: any nav target that did not make it into `_book/`.
+      # missing, so the engine install above fixes one instance of the 404 and this catches
+      # the class: any nav target that did not make it into `_book/`.
       #
       # Same condition as the install above and as `deploy`, for a reason that is the whole
       # design of the gate: several nav entries here resolve only once the gates that produce
       # them have run -- the two `reports/` pages need a `_tests/` tree, the paper needs
-      # latexmk -- so on a branch a dangling entry is the machine's shape, and on the ref
+      # tectonic -- so on a branch a dangling entry is the machine's shape, and on the ref
       # that publishes it is a defect. `book-nav` is deliberately not a prerequisite of
       # `book` for the same reason; a test in tests/test_tasks.py holds that.
       - name: Check every nav entry resolves (publishing refs only)

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -2,8 +2,8 @@
 # carries no circularity to remove -- upstream's version never calls rhiza-task at all, it
 # reimplements the recipe in shell. Two things change as a result:
 #
-#   * The compile step calls `uv run rhiza-task paper` instead of inlining `latexmk`, so the
-#     workflow and a local `rhiza-task paper` cannot drift. This repository's dogfood
+#   * The compile step calls `uv run rhiza-task paper` instead of inlining the engine, so
+#     the workflow and a local `rhiza-task paper` cannot drift. This repository's dogfood
 #     position is that its own gates run through the CLI under test.
 #   * Upstream's "prefer basanos.tex, else the first *.tex" step is gone with it. That was a
 #     named preference for one downstream repository's paper, living in a template every
@@ -13,8 +13,10 @@
 #     whatever PDF the task produced instead.
 #
 # The `tex_present` guard is kept even though `rhiza-task paper` skips on its own: the task
-# skipping is cheap, but installing TeX Live first is not. So the guard is about the apt-get,
-# not about the gate.
+# skipping is cheap, but installing the engine first is not. So the guard is about the
+# apt-get, not about the gate. tectonic is one package where a TeX distribution was four, so
+# the guard buys less than it did -- kept because it costs nothing and still skips an install
+# for a consumer with no paper.
 #
 # This note used to add "and this repository ships no docs/paper", which was the guard's
 # original motivation and is no longer true: docs/paper/paper.tex arrived with the paper
@@ -83,19 +85,40 @@ jobs:
           version: "0.11.16"
           enable-cache: true
 
-      - name: Install TeX Live
+      # The same single package as rhiza_book.yml, deliberately: that workflow produces the
+      # copy of the PDF inside the book and this one the artifact and the `paper` branch, so
+      # they must compile the one document with the same engine. Under a TeX distribution
+      # this meant keeping two package lists in step; tectonic resolves what the document
+      # cites from its own bundle, fetched over the network on a cold cache.
+      - name: Install tectonic
         if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            texlive-latex-extra \
-            texlive-fonts-recommended \
-            texlive-bibtex-extra \
-            latexmk
+          sudo apt-get install -y tectonic
 
-      # `rhiza-task paper` guards on latexmk being present and on the paper folder
-      # existing, chooses the root document, and runs latexmk with -bibtex so the
-      # references converge. Everything this step used to spell out lives there.
+      # tectonic's whole model is fetching what the document cites out of a web bundle and
+      # caching it, so the cache is where the trade against a provisioned distribution is
+      # actually settled: warm, the install is one apt package and the compile is offline for
+      # everything it has seen before; cold, it is a network round trip per file the document
+      # needs. Keyed on the sources because that is what determines the fetch set, with a
+      # prefix restore so editing the paper reuses the previous run's files instead of
+      # refetching the preamble's packages from scratch.
+      #
+      # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
+      # paths differ, which does not matter here because both jobs are ubuntu-only.
+      - name: Cache the tectonic bundle
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/Tectonic
+          key: tectonic-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
+          restore-keys: |
+            tectonic-${{ runner.os }}-
+
+      # `rhiza-task paper` guards on tectonic being present and on the paper folder
+      # existing, chooses the root document, and runs tectonic over it -- which reruns the
+      # TeX pass and bibtex until the references converge on its own, so there is no flag
+      # here saying so. Everything this step used to spell out lives there.
       - name: Compile the paper
         if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
         run: uv run rhiza-task paper

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -14,9 +14,9 @@
 #
 # The `tex_present` guard is kept even though `rhiza-task paper` skips on its own: the task
 # skipping is cheap, but installing the engine first is not. So the guard is about the
-# apt-get, not about the gate. tectonic is one package where a TeX distribution was four, so
-# the guard buys less than it did -- kept because it costs nothing and still skips an install
-# for a consumer with no paper.
+# install, not about the gate. It buys less than it did -- one pinned tarball where a TeX
+# distribution was an apt-get and four packages -- and is kept because it costs nothing and
+# still skips a download for a consumer with no paper.
 #
 # This note used to add "and this repository ships no docs/paper", which was the guard's
 # original motivation and is no longer true: docs/paper/paper.tex arrived with the paper
@@ -85,35 +85,15 @@ jobs:
           version: "0.11.16"
           enable-cache: true
 
-      # The same single package as rhiza_book.yml, deliberately: that workflow produces the
-      # copy of the PDF inside the book and this one the artifact and the `paper` branch, so
-      # they must compile the one document with the same engine. Under a TeX distribution
-      # this meant keeping two package lists in step; tectonic resolves what the document
-      # cites from its own bundle, fetched over the network on a cold cache.
-      - name: Install tectonic
+      # The same engine as rhiza_book.yml, and not merely the same intent: that workflow
+      # produces the copy of the PDF inside the book and this one the artifact and the `paper`
+      # branch, so a version skew between them would show up as two different PDFs of one
+      # document. The local action is where the version, the URL and the digest live, exactly
+      # once -- see .github/actions/setup-tectonic/action.yml for why it is a pinned tarball
+      # rather than a package or the upstream installer.
+      - name: Set up tectonic
         if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tectonic
-
-      # tectonic's whole model is fetching what the document cites out of a web bundle and
-      # caching it, so the cache is where the trade against a provisioned distribution is
-      # actually settled: warm, the install is one apt package and the compile is offline for
-      # everything it has seen before; cold, it is a network round trip per file the document
-      # needs. Keyed on the sources because that is what determines the fetch set, with a
-      # prefix restore so editing the paper reuses the previous run's files instead of
-      # refetching the preamble's packages from scratch.
-      #
-      # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
-      # paths differ, which does not matter here because both jobs are ubuntu-only.
-      - name: Cache the tectonic bundle
-        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/Tectonic
-          key: tectonic-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
-          restore-keys: |
-            tectonic-${{ runner.os }}-
+        uses: ./.github/actions/setup-tectonic
 
       # `rhiza-task paper` guards on tectonic being present and on the paper folder
       # existing, chooses the root document, and runs tectonic over it -- which reruns the

--- a/.gitignore
+++ b/.gitignore
@@ -25,14 +25,13 @@ _site
 
 # LaTeX build artifacts
 docs/paper/*.aux
-docs/paper/*.fdb_latexmk
-docs/paper/*.fls
-docs/paper/*.log
-docs/paper/*.out
-docs/paper/*.toc
-docs/paper/*.pdf
 docs/paper/*.bbl
 docs/paper/*.blg
+docs/paper/*.log
+docs/paper/*.out
+docs/paper/*.pdf
+docs/paper/*.synctex.gz
+docs/paper/*.toc
 
 # temp file used by Junie
 .output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ fold the note into that section, delete this heading and this comment, and resto
 no longer with a TeX distribution's driver.** A machine that could build the paper before and
 has no tectonic will now report `skipped  paper  tectonic not found` instead of producing a
 PDF — a machine that previously succeeded, so this is breaking even though the gate reports it
-as a skip rather than a failure. Install tectonic (`brew install tectonic`, `apt-get install
-tectonic`, `cargo install tectonic`), or pin `rhiza-task<1.3`.
+as a skip rather than a failure. [Install tectonic](https://tectonic-typesetting.github.io/en-US/install.html)
+— `brew install tectonic`, `cargo install tectonic`, or a release binary; note that Ubuntu does
+not package it, which is what CI here installs a pinned tarball for — or pin `rhiza-task<1.3`.
 
 What the trade buys, and what it costs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+<!--
+The Unreleased section below holds an upgrade note written when the change landed, because
+git-cliff files a strictness increase wherever its commit type puts it and never writes one.
+At release time `git-cliff --prepend` inserts the new version's section *above* this heading:
+fold the note into that section, delete this heading and this comment, and restore the
+`# Changelog` title, which --prepend eats.
+-->
+
+## [Unreleased]
+
+### ⚠️ Upgrade note
+
+**`rhiza-task paper` compiles with [tectonic](https://tectonic-typesetting.github.io/), and
+no longer with a TeX distribution's driver.** A machine that could build the paper before and
+has no tectonic will now report `skipped  paper  tectonic not found` instead of producing a
+PDF — a machine that previously succeeded, so this is breaking even though the gate reports it
+as a skip rather than a failure. Install tectonic (`brew install tectonic`, `apt-get install
+tectonic`, `cargo install tectonic`), or pin `rhiza-task<1.3`.
+
+What the trade buys, and what it costs:
+
+- **One binary instead of a distribution plus a package list.** The old install asked each
+  workflow to name the TeX packages the document happened to cite, and this repository carried
+  two such lists — one per workflow, compiling the same document, with nothing checking that
+  they agreed. tectonic resolves what the document cites from its own bundle, so there is no
+  list to diverge.
+- **The argument vector is the document and one flag.** Convergence and bibtex are tectonic's
+  own loop rather than a driver's, and there is no interaction mode to pin because tectonic
+  never prompts. `--keep-logs` is the flag, kept because tectonic writes only the PDF by
+  default and the log is what you upload when a CI compile fails.
+- **A cold cache needs the network**, where a provisioned distribution did not. The cache is
+  per-machine and survives between runs, so it is a first-run cost; both workflows here now
+  cache it.
+
+**`rhiza-task paper-clean` no longer guards on a tool, and no longer sweeps by extension.**
+tectonic has no clean subcommand, so the task deletes the artifacts itself — which makes it the
+one task in the section that works on a machine that cannot build the paper at all. It removes
+the PDF and auxiliary files **belonging to the folder's top-level `.tex` documents**, so a
+committed `diagram.pdf` with no `diagram.tex` now survives a clean that would previously have
+been the driver's business. If you relied on `paper-clean` clearing every `.pdf` in the folder,
+it no longer does.
+
+**`rhiza-task doctor` no longer probes for GNU make**, and has no optional tier left. It names
+uv and git, and a miss is a failure. `doctor.mk` required make because the whole task layer was
+make; this package has none, and nothing in the registry needs it. Every other binary the
+package reaches for — docker, gh, git-lfs, tectonic, marp — is a `Guard` on the task that wraps
+it and reports itself on that task's `skipped` line with an install URL, which is where an
+optional prerequisite belongs. `Tool.required` is gone from `rhiza_task.tasks.doctor` with it.
+
 ## [1.2.0] - 2026-08-22
 
 ### ⚠️ Upgrade note

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,24 @@ checks are forge-API queries about the *remote* repository, so a local task coul
 pre-push signal the way `bandit` or `pytest` do — it would restate what the workflow already
 reported, while costing a public task name on a released package.
 
+### The one local composite action
+
+`.github/actions/setup-tectonic/` is the first and only `uses: ./` in this repository, and it
+exists for a reason worth stating rather than copying: **two workflows compile the same
+document.** `rhiza_paper.yml` publishes the PDF as an artifact and on the `paper` branch,
+`rhiza_book.yml` the copy inside the book, and a typesetting engine's output moves between
+versions — so a version skew between them would show up as two different PDFs of one paper,
+with nothing to catch it. The distribution this replaced had the same hazard in a worse form:
+a four-package apt list in each file, kept in step by hand.
+
+So the action is where the engine's version, URL and sha256 live, exactly once. Two things
+follow. `apt-get install tectonic` is **not** the alternative — tectonic is packaged for
+Debian but not for Ubuntu noble, which is what `ubuntu-latest` is, and a first attempt at
+this failed exactly there. And the composite action needs its **own** `dependabot.yml`
+entry, because `directory: /` covers `.github/workflows` and not actions nested below
+`.github/actions`; without it the `actions/cache` SHA inside would be the only unwatched
+action pin in the repository.
+
 ## The layering invariant
 
 The import graph is strictly layered, and nothing enforces it:

--- a/README.md
+++ b/README.md
@@ -70,12 +70,15 @@ keep working owns that `Makefile` itself and forwards each target to `uvx rhiza-
 | Paper | `paper` `paper-clean` |
 | Presentation | `presentation` `presentation-pdf` `presentation-serve` |
 
-The last five sections are bundle-owned fragments. None is a gate — no `all` names them,
-no workflow invokes them — so each is guarded on the CLI it wraps and **skips** when that
-tool is absent, with `--strict` for a caller who wants the hard failure instead. Two
-changed behaviour on purpose, and say so in their module docstring: `lfs-install`
-configures the repository and reports how to install the binary rather than downloading
-one; `presentation` reaches Marp through `npx --yes`.
+The last five sections are bundle-owned fragments. None is a gate — no `all` names them —
+so each is guarded on the CLI it wraps and **skips** when that tool is absent, with
+`--strict` for a caller who wants the hard failure instead. Three changed behaviour on
+purpose, and say so in their module docstring: `lfs-install` configures the repository and
+reports how to install the binary rather than downloading one; `presentation` reaches Marp
+through `npx --yes`; `paper` compiles with [tectonic](https://tectonic-typesetting.github.io/)
+rather than a TeX distribution's driver, which makes `paper-clean` the one task here guarded
+on no tool at all — it deletes the artifacts itself, so a machine that cannot build the paper
+can still tidy up after one.
 
 ### Three layers, one set of names
 

--- a/docs/adding_a_task.md
+++ b/docs/adding_a_task.md
@@ -84,7 +84,7 @@ A guard is the first of the three parts every recipe has. Two forms:
 === "A binary must be on PATH"
 
     ```python
-    Guard(tool="latexmk", reason="latexmk not found; install a LaTeX distribution")
+    Guard(tool="tectonic", reason="tectonic not found; install it")
     ```
 
     The `reason` is what the user sees on the `skipped` line, so make it actionable.
@@ -106,7 +106,7 @@ right:
 |---|---|---|
 | `uvx("my-auditor", ...)` | an isolated one-shot tool | linters, scanners, formatters |
 | `uv_run("pytest", ..., withs=("pytest-cov",))` | the tool **imports your project's code** | pytest, mypy, interrogate |
-| `tool("cargo", "clippy", ...)` | a toolchain binary already on `PATH` | `cargo`, `go`, `latexmk`, `npx` |
+| `tool("cargo", "clippy", ...)` | a toolchain binary already on `PATH` | `cargo`, `go`, `tectonic`, `npx` |
 | `uv("sync", "--frozen", ...)` | uv itself | `venv`, `sync`, `lock --check` |
 
 All four take `cwd=` and echo the command they run, so `$ cargo clippy` is printed the same

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ What skips is outside `all`, and for three different reasons worth separating:
 - `semgrep` has no `.rhiza/semgrep.yml`. This is the genuine "not rhiza-managed" case.
 - `presentation` has no `PRESENTATION.md`, and `marimo-validate` no `docs/notebooks`. These
   skip for want of a *subject*, which any consumer that has not adopted the bundle shares.
-- `paper` skips on a machine without `latexmk` — a fact about the machine, not about this
+- `paper` skips on a machine without `tectonic` — a fact about the machine, not about this
   repository.
 
 So a registry-wide `--strict` would assert that this is a consumer carrying every bundle,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -120,6 +120,8 @@ any change that is not a straight port:
 |---|---|
 | `lfs-install` | configures the repository and **reports** how to install the binary, rather than downloading one |
 | `presentation` | reaches Marp through `npx --yes` |
+| `paper` | compiles with [tectonic](https://tectonic-typesetting.github.io/) — one binary, no TeX-distribution package list, but a cold cache needs the network |
+| `paper-clean` | deletes the artifacts in Python rather than delegating, so it needs no toolchain and keeps a committed PDF that no `.tex` claims |
 
 And one that is not a change so much as a name losing its special status: `paper.mk`
 preferred a file called `basanos.tex` — one downstream repository's paper, named in a

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -173,16 +173,16 @@ exports every Marimo notebook to `docs/notebooks/*.html`, builds the site with
 [zensical](https://github.com/squidfunk/zensical), and generates a coverage badge. It
 skips entirely without a `mkdocs.yml`.
 
-`paper` is a prerequisite but needs no copy step, unlike `_tests/`: latexmk writes the PDF
+`paper` is a prerequisite but needs no copy step, unlike `_tests/`: tectonic writes the PDF
 beside its source, and `paper_folder` (default `docs/paper`) is already inside `docs_dir`,
 so the site build picks it up as an asset and `mkdocs.yml` only names it in `nav`. A
-repository with no paper — or no latexmk — still builds its book, because a *skipped*
+repository with no paper — or no tectonic — still builds its book, because a *skipped*
 prerequisite does not block a dependent; only a failed one does. Under `--strict` that skip
 becomes a failure and would block `book`, which is worth knowing but is not specific to
 `paper`: `benchmark` and `stress` guard on folders most repositories do not have.
 
 `book-nav` is the other side of that permissiveness, and deliberately **not** a prerequisite
-of `book`. Skipping a producer is what lets a repository without latexmk still build its
+of `book`. Skipping a producer is what lets a repository without tectonic still build its
 book — and the cost is that `mkdocs.yml` can name a target the build never wrote. zensical
 does not catch it: it reports `No issues found` for a nav entry whose page is missing *and*
 for one whose asset is missing, so such a site builds green and publishes a 404 in its own
@@ -212,6 +212,12 @@ JetBrains server refuses to serve gitignored directories and `_book` is one.
 
 `doctor` is the second procedural escape — it compares semantic versions, which used to be
 an `awk` function inside a make recipe.
+
+It names **uv and git, and nothing else**, and a miss is a failure rather than a warning.
+Every other binary the package reaches for — docker, gh, git-lfs, tectonic, marp — is a
+`Guard` on the one task that wraps it, and reports itself on that task's `skipped` line with
+an install URL. `doctor.mk` also probed GNU make, which was honest while the task layer *was*
+make; nothing here needs it, so it is not probed at all.
 
 ## Bundle-owned sections
 
@@ -257,7 +263,21 @@ tool is absent, with `--strict` for a caller who wants the hard failure instead.
 | task | does |
 |---|---|
 | `paper` | compile the LaTeX paper to PDF |
-| `paper-clean` | remove the latexmk build artifacts |
+| `paper-clean` | remove the LaTeX build artifacts |
+
+**The engine is [tectonic](https://tectonic-typesetting.github.io/), not a TeX
+distribution's driver.** One binary to install instead of a distribution plus the list of
+packages a document happens to cite, because tectonic resolves what the document cites from
+its own bundle and caches it. So the vector is the document and one flag: convergence and
+bibtex are the engine's own loop, and there is no interaction mode to pin because tectonic
+never prompts. The cost is that a cold cache needs the network, where a provisioned
+distribution did not.
+
+`paper-clean` follows from that: tectonic has no clean subcommand, so the task is plain
+Python and guards on no tool at all — the one task in this section that works on a machine
+which cannot build the paper. It removes the PDF and the auxiliary files **belonging to the
+folder's top-level `.tex` documents**, so a committed `diagram.pdf` with no `diagram.tex`
+survives.
 
 `paper.mk` preferred a file called `basanos.tex` — one downstream repository's paper, named
 in a template every consumer synced. That is now two conventional names, `main.tex` and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,11 +39,11 @@ nav:
   # the normal path produces both together.
   #
   # What differs from the two above is a toolchain rather than a build order. The reports
-  # need only the gates, which any runner can run; this needs latexmk, and a *skipped*
-  # prerequisite does not block `book` -- so a runner with no LaTeX distribution published
-  # this entry pointing at a file nothing had written, on a green run. It did, and 404ed,
-  # until rhiza_book.yml installed TeX Live on the ref it deploys. So the entry resolves in
-  # the published book and on a machine with latexmk, and dangles anywhere else -- a branch
+  # need only the gates, which any runner can run; this needs tectonic, and a *skipped*
+  # prerequisite does not block `book` -- so a runner with no TeX engine published this
+  # entry pointing at a file nothing had written, on a green run. It did, and 404ed, until
+  # rhiza_book.yml installed the engine on the ref it deploys. So the entry resolves in the
+  # published book and on a machine with tectonic, and dangles anywhere else -- a branch
   # book, or a bare checkout.
   - Paper: paper/paper.pdf
 

--- a/src/rhiza_task/spec.py
+++ b/src/rhiza_task/spec.py
@@ -104,7 +104,7 @@ class Guard:
     what github.mk's ``require-gh`` was: a target whose whole body is
     ``command -v gh >/dev/null || exit 1``, declared as a prerequisite of every helper.
     The five bundle-owned fragments are mostly wrappers over a CLI nobody can assume is
-    installed -- gh, docker, git-lfs, latexmk, marp -- so the check is declared once here
+    installed -- gh, docker, git-lfs, tectonic, marp -- so the check is declared once here
     rather than repeated as the first three lines of a dozen task bodies.
 
     A missing tool is a :class:`Skip`, not a failure, which is a deliberate change from

--- a/src/rhiza_task/tasks/book.py
+++ b/src/rhiza_task/tasks/book.py
@@ -4,7 +4,7 @@
 producing gates, copies their output into the docs tree, exports every notebook, builds
 the site, and generates a coverage badge.
 
-The one artefact it does *not* copy is the paper's PDF. latexmk writes it beside its
+The one artefact it does *not* copy is the paper's PDF. tectonic writes it beside its
 source, and ``paper_folder`` is already inside ``docs_dir``, so the site build finds it
 where it lies -- a prerequisite plus a ``nav`` entry, and no plumbing.
 
@@ -23,16 +23,17 @@ from pathlib import Path
 from ..config import Config
 from ..spec import Failed, Guard, Skip, task
 from ..uv import uv_run, uvx
+from .paper import AUX_SUFFIXES
 
 
 # `paper` is a prerequisite for the same reason the other four are: it produces something
 # the book publishes, and the book should be one command. It needs no copy step, unlike the
-# `_tests/` tree -- latexmk writes the PDF beside its source, and `paper_folder` defaults to
+# `_tests/` tree -- tectonic writes the PDF beside its source, and `paper_folder` defaults to
 # `docs/paper`, which is already inside `docs_dir`. So the build picks it up as an asset and
 # mkdocs.yml only has to name it in `nav`.
 #
 # Safe to add because a *skipped* prerequisite does not block a dependent -- only FAILED and
-# BLOCKED do (see `_run_one`) -- so a repository with no paper, or no latexmk, still builds
+# BLOCKED do (see `_run_one`) -- so a repository with no paper, or no tectonic, still builds
 # its book. Under `--strict` a skip becomes a failure and would block `book`, which is worth
 # knowing but is not new: `benchmark` and `stress` guard on folders most repositories do not
 # have, so `--strict book` already required a repo that has all of them.
@@ -168,27 +169,24 @@ def marimo_validate(cfg: Config) -> None:
     print(f"[SUCCESS] all {len(notebooks)} notebook(s) valid")
 
 
-LATEX_ARTIFACTS = (".aux", ".fdb_latexmk", ".fls", ".log", ".out", ".toc", ".bbl", ".blg", ".synctex.gz")
-"""What latexmk leaves beside the document, mirroring .gitignore's list for the same folder.
-
-Matched as name suffixes rather than through :attr:`~pathlib.PurePath.suffix`, because
-``.synctex.gz`` is two extensions and ``suffix`` would report only ``.gz``.
-"""
-
-
 def _prune_latex_artifacts(cfg: Config, output: Path) -> None:
-    """Remove latexmk's auxiliary files from the built site, keeping the PDF and the source.
+    """Remove the paper's auxiliary files from the built site, keeping the PDF and the source.
 
     The paper's source sits inside ``docs_dir`` so that its PDF needs no copy step, and the
-    price is that everything *else* latexmk leaves beside it is copied into the site too.
-    ``paper.log`` is the one that matters: some 20 KB of build trace which records absolute
-    paths from whichever machine ran the build.
+    price is that everything *else* the build leaves beside it is copied into the site too.
+    ``paper.log`` is the one that matters, and the one ``rhiza-task paper`` deliberately asks
+    tectonic to keep: some 20 KB of build trace which records absolute paths from whichever
+    machine ran the build.
 
     mkdocs would answer this with ``exclude_docs``. zensical does not implement it -- the
     note in ``docs/mkdocs-base.yml`` records that an excluded page is still written -- and
-    deleting them at the source would defeat latexmk's incremental rebuild, which reads
-    ``.aux`` and ``.fdb_latexmk`` to decide what to redo. So they are pruned here, from the
-    output, where nothing reads them again.
+    deleting them at the source would throw away the log the run was asked to keep. So they
+    are pruned here, from the output, where nothing reads them again.
+
+    The suffix list is :data:`~rhiza_task.tasks.paper.AUX_SUFFIXES`, shared with
+    ``paper-clean`` rather than restated: one list, two callers, and the difference between
+    them is only whether the PDF goes with it -- which is the difference between publishing a
+    build and discarding one.
 
     Scoped to the paper folder rather than swept over the whole site: ``.log`` and ``.out``
     are not LaTeX-specific names, and a consumer with a genuine ``debug.log`` under ``docs/``
@@ -210,7 +208,7 @@ def _prune_latex_artifacts(cfg: Config, output: Path) -> None:
     if not published.is_dir():
         return
     for path in sorted(published.iterdir()):
-        if path.is_file() and path.name.endswith(LATEX_ARTIFACTS):
+        if path.is_file() and path.name.endswith(AUX_SUFFIXES):
             path.unlink(missing_ok=True)
 
 
@@ -415,14 +413,14 @@ def book_nav(cfg: Config) -> None:
     The gap this closes, and it is a published one rather than a hypothetical: zensical
     reports ``No issues found`` for a nav entry whose page does not exist *and* for one whose
     asset does not exist. So `- Paper: paper/paper.pdf` survived a build in which
-    ``rhiza-task paper`` had skipped for want of latexmk, and the site deployed with a 404 in
+    ``rhiza-task paper`` had skipped for want of an engine, and the site deployed with a 404 in
     its own navigation, green the whole way. Every other gate here asks about the source; this
     is the only one that asks whether what was *published* holds together.
 
     **Not a prerequisite of** :func:`book`, deliberately. Half the nav entries in a repository
     like this one resolve only after the gates that produce them have run -- the two
-    ``reports/`` pages need a ``_tests/`` tree, the paper needs a LaTeX distribution -- and a
-    repository with no latexmk must keep building its book, which is exactly what a *skipped*
+    ``reports/`` pages need a ``_tests/`` tree, the paper needs tectonic -- and a
+    repository without it must keep building its book, which is exactly what a *skipped*
     prerequisite buys. Making that a failure would break every consumer that documents a
     paper it cannot compile locally. So this is a separate gate, named by ``rhiza_book.yml``
     on the ref it deploys, where the entries are supposed to be complete and a dangling one is

--- a/src/rhiza_task/tasks/doctor.py
+++ b/src/rhiza_task/tasks/doctor.py
@@ -6,10 +6,23 @@ program comparing dotted versions component by component, and ``check_tool``, wh
 five positional arguments including a *quoted shell command to eval* for extracting the
 version. The escaping is such that the awk field references appear as ``\\$$i``.
 
-The change of substance is which tools are required. doctor.mk requires GNU make, because
-the whole task layer was make; here make is optional -- a repo may keep a Makefile that
-forwards to the CLI, but every task is reachable without one. Requiring a tool the layer no
-longer needs is how a diagnostic starts lying about its own prerequisites.
+The change of substance is which tools it asks about at all. doctor.mk probes GNU make,
+because the whole task layer was make. It is not probed here, and neither is anything else
+beyond uv and git -- the two a process running ``uvx rhiza-task`` genuinely cannot do
+without.
+
+That is a design boundary rather than a short list. **Optionality is what
+:class:`~rhiza_task.spec.Guard` is for**: docker, gh, git-lfs, tectonic and marp are each
+declared as a precondition on the task that wraps them, and a missing one reports itself on
+the ``skipped`` line of the gate that wanted it, with the install URL in its ``reason``. A
+diagnostic that also enumerated them would answer the same question one indirection further
+from where it matters, and would need updating every time a bundle gained a tool.
+
+So this task has one tier, not two: everything it names is required, and a miss is a
+failure. ``make`` was the last inhabitant of the optional tier -- reported as a warning for
+the sake of a repo-owned Makefile forwarding to the CLI -- and the tier went with it. If a
+genuinely optional *core* prerequisite ever appears, that is an edit here rather than a
+mechanism to keep warm for it.
 """
 
 from __future__ import annotations
@@ -29,7 +42,6 @@ from ..spec import Failed, task
 
 GREEN = "\033[32m"
 RED = "\033[31m"
-YELLOW = "\033[33m"
 RESET = "\033[0m"
 
 VERSION_RE = re.compile(r"(\d+(?:\.\d+)+)")
@@ -39,24 +51,25 @@ VERSION_RE = re.compile(r"(\d+(?:\.\d+)+)")
 class Tool:
     """A prerequisite, its minimum version, and where to get it.
 
+    Every entry is required; see the module docstring for why there is no optional tier.
+
     Attributes:
         name: Executable name.
         minimum: Lowest acceptable dotted version.
         url: Install instructions, printed when it is missing.
-        required: When False, a miss is reported but does not fail the task.
     """
 
     name: str
     minimum: str
     url: str
-    required: bool = True
 
 
+# uv because a process launched by `uvx rhiza-task` runs *because* uv exists, and git because
+# `clean` and the release flow drive it directly. Nothing else belongs here: see the module
+# docstring on why the bundle CLIs are guards rather than entries.
 TOOLS = (
     Tool("uv", "0.4.0", "https://docs.astral.sh/uv/getting-started/installation/"),
     Tool("git", "2.0.0", "https://git-scm.com"),
-    # Optional: only a repo-owned forwarding Makefile needs it, and that is a convenience.
-    Tool("make", "3.8.0", "https://www.gnu.org/software/make/", required=False),
 )
 
 
@@ -107,8 +120,7 @@ def doctor(cfg: Config) -> None:
         path = shutil.which(tool.name)
         if path is None:
             _report(tool, "missing", ok=False, note=f"install: {tool.url}")
-            if tool.required:
-                failed.append(tool.name)
+            failed.append(tool.name)
             continue
 
         output = subprocess.run(  # noqa: S603  # nosec B603
@@ -119,15 +131,15 @@ def doctor(cfg: Config) -> None:
         ).stdout
         version = parse_version(output)
         if not version:
+            # Not assumed fine. A tool that prints no parseable version is a tool this
+            # diagnostic cannot vouch for, and saying nothing would be the same as passing.
             _report(tool, "unknown", ok=False, note=f"required >= {tool.minimum}")
-            if tool.required:
-                failed.append(tool.name)
+            failed.append(tool.name)
         elif at_least(version, tool.minimum):
             _report(tool, ".".join(map(str, version)), ok=True, note=f">= {tool.minimum}")
         else:
             _report(tool, ".".join(map(str, version)), ok=False, note=f"< {tool.minimum}")
-            if tool.required:
-                failed.append(tool.name)
+            failed.append(tool.name)
 
     print(f"\n[INFO] python {cfg.python_version} (from .python-version or config)")
     if failed:
@@ -143,11 +155,5 @@ def _report(tool: Tool, version: str, ok: bool, note: str) -> None:
         ok: Whether it satisfies the requirement.
         note: Trailing detail.
     """
-    if ok:
-        mark, colour = "[ OK ]", GREEN
-    elif tool.required:
-        mark, colour = "[FAIL]", RED
-    else:
-        mark, colour = "[WARN]", YELLOW
-    optional = "" if tool.required else " (optional)"
-    print(f"{colour}{mark}{RESET} {tool.name:<8} {version:<10} {note}{optional}")
+    mark, colour = ("[ OK ]", GREEN) if ok else ("[FAIL]", RED)
+    print(f"{colour}{mark}{RESET} {tool.name:<8} {version:<10} {note}")

--- a/src/rhiza_task/tasks/paper.py
+++ b/src/rhiza_task/tasks/paper.py
@@ -1,10 +1,27 @@
 """The LaTeX tasks: paper.mk, as tasks.
 
 Closer in shape to ``book`` than to the CLI wrappers: a build with an output worth
-naming. latexmk does the hard part -- it reruns pdflatex and bibtex until the references
-converge -- so the task is a folder, a file choice and a fixed flag set.
+naming. The engine does the hard part -- it reruns the TeX pass and bibtex until the
+citations and cross-references converge -- so the task is a folder, a file choice and a
+fixed flag set.
 
-The file choice is the one thing that changes. paper.mk reads
+**The engine is tectonic**, which is the one substantive change from paper.mk. paper.mk
+drove a full TeX distribution, so a consumer provisioned the distribution *and* the list
+of packages their document happened to cite, and the two workflows here each carried their
+own copy of that list. tectonic is a single binary that resolves what a document cites out
+of its web bundle and caches it, so there is one tool to install and no list to keep in
+step. Three consequences the flag set below records rather than restates:
+
+* Convergence and bibtex are the engine's own loop, not a driver's, so neither is asked
+  for -- the argument vector is the document and nothing about *how* to build it.
+* There is no interaction mode to pin. tectonic never stops for a prompt, so it needs no
+  flag saying so; a broken document exits non-zero, which :func:`~rhiza_task.uv.tool`
+  turns into :class:`~rhiza_task.spec.Failed`.
+* A cold cache needs the network. A provisioned distribution did not, and that is the one
+  thing this trade costs; the cache is per-machine and survives between runs, so it is a
+  first-run cost rather than a per-build one.
+
+The file choice is the other thing that changed, and it changed earlier. paper.mk reads
 
     if [ -f $(PAPER_DIR)/basanos.tex ]; then tex_file="basanos.tex"; else <first *.tex>; fi
 
@@ -15,7 +32,7 @@ common case) and no longer privileges a stranger's filename.
 
 ``-maxdepth 1`` survives as :meth:`~pathlib.Path.glob` rather than
 :meth:`~pathlib.Path.rglob`, and deliberately: a LaTeX project's subdirectories hold
-included chapters, and latexmk must be pointed at the root document, not at a chapter.
+included chapters, and the engine must be pointed at the root document, not at a chapter.
 """
 
 from __future__ import annotations
@@ -28,13 +45,30 @@ from ..uv import tool
 
 SECTION = "Paper"
 
-HAVE_LATEXMK = Guard(
-    tool="latexmk",
-    reason="latexmk not found; install a LaTeX distribution (MacTeX, TeX Live)",
+HAVE_TECTONIC = Guard(
+    tool="tectonic",
+    reason="tectonic not found; install it (brew install tectonic, cargo install tectonic)",
 )
 
 PREFERRED = ("main.tex", "paper.tex")
 """Root-document names tried before falling back to alphabetical order."""
+
+AUX_SUFFIXES = (".aux", ".bbl", ".blg", ".log", ".out", ".synctex.gz", ".toc")
+"""What a TeX run leaves beside the document, mirroring .gitignore's list for this folder.
+
+The PDF is deliberately absent: this is the set that is *never* worth keeping, and both
+callers want it -- :func:`paper_clean` adds the PDF because removing the output is the
+point of a clean, and ``book``'s prune keeps the PDF because publishing it is the point of
+the build.
+
+These are the names TeX itself writes. A driver's own bookkeeping files -- the
+rebuild-cache and file-list a make-style LaTeX driver keeps -- are not listed, because no
+driver runs here: tectonic is the whole engine and writes the ``.log`` (asked for below)
+and, only when asked, the rest.
+
+Matched as name suffixes rather than through :attr:`~pathlib.PurePath.suffix`, because
+``.synctex.gz`` is two extensions and ``suffix`` would report only ``.gz``.
+"""
 
 
 def main_document(folder: Path) -> Path | None:
@@ -53,9 +87,9 @@ def main_document(folder: Path) -> Path | None:
     return next((by_name[name] for name in PREFERRED if name in by_name), candidates[0])
 
 
-@task("paper", "compile the LaTeX paper to PDF", section=SECTION, guards=(HAVE_LATEXMK, Guard("paper_folder")))
+@task("paper", "compile the LaTeX paper to PDF", section=SECTION, guards=(HAVE_TECTONIC, Guard("paper_folder")))
 def paper(cfg: Config) -> None:
-    """Run latexmk over the paper folder's root document.
+    """Run tectonic over the paper folder's root document.
 
     Args:
         cfg: The resolved config.
@@ -69,15 +103,32 @@ def paper(cfg: Config) -> None:
         raise Skip(f"no .tex files in '{cfg.paper_folder}'")
 
     print(f"[INFO] compiling {document.name}")
-    # cwd is the paper folder, as `cd $(PAPER_DIR) && latexmk` was: latexmk writes its
-    # auxiliary files beside the document, and \input paths are relative to it.
-    tool("latexmk", "-pdf", "-bibtex", "-interaction=nonstopmode", document.name, cwd=folder)
+    # cwd is the paper folder, as `cd $(PAPER_DIR) && <engine>` was: tectonic resolves
+    # \input paths relative to the document and writes its output beside it, which is what
+    # lets `book` publish the PDF with no copy step.
+    #
+    # `--keep-logs` is the one flag, and it is not cosmetic: tectonic writes only the PDF by
+    # default, and on a runner the log is the artefact you upload when a compile fails. It
+    # is also the file `book`'s prune exists to keep out of the published site, since it
+    # records absolute paths from whichever machine built it.
+    tool("tectonic", "--keep-logs", document.name, cwd=folder)
     print(f"[SUCCESS] {cfg.paper_folder}/{document.stem}.pdf")
 
 
-@task("paper-clean", "remove the latexmk build artifacts", section=SECTION, guards=(HAVE_LATEXMK,))
+@task("paper-clean", "remove the LaTeX build artifacts", section=SECTION)
 def paper_clean(cfg: Config) -> None:
-    """Run ``latexmk -C``, removing the generated PDF and every auxiliary file.
+    """Remove the PDF and auxiliary files belonging to the folder's top-level documents.
+
+    Pure Python, and unguarded on any tool: tectonic has no clean subcommand to delegate
+    to, so there is nothing to be absent. That makes this the one task in the section that
+    works on a machine which cannot build the paper at all -- an improvement over
+    delegating, where cleaning required the very toolchain you were cleaning up after.
+
+    **Scoped by document stem, not by extension sweep.** ``paper.tex`` authorises deleting
+    ``paper.pdf`` and ``paper.log``; a ``figures/`` diagram exported to ``diagram.pdf`` and
+    committed beside the source has no ``diagram.tex`` and survives. An extension sweep
+    would be one line shorter and would delete a consumer's checked-in artwork, which is
+    not recoverable by rebuilding.
 
     Args:
         cfg: The resolved config.
@@ -88,7 +139,15 @@ def paper_clean(cfg: Config) -> None:
     folder = cfg.path("paper_folder")
     if not folder.is_dir():
         raise Skip(f"paper_folder '{cfg.paper_folder}' not found")
-    # `|| true`, as paper.mk has it: cleaning a folder that was never built is the
-    # expected state of a clean target.
-    tool("latexmk", "-C", cwd=folder, check=False)
-    print(f"[SUCCESS] cleaned {cfg.paper_folder}")
+
+    removed = 0
+    for stem in sorted({p.stem for p in folder.glob("*.tex") if p.is_file()}):
+        for suffix in (*AUX_SUFFIXES, ".pdf"):
+            artifact = folder / f"{stem}{suffix}"
+            if artifact.is_file():
+                artifact.unlink()
+                removed += 1
+    # Cleaning a folder that was never built leaves nothing to report and is not a failure,
+    # which is what paper.mk's `|| true` bought; here it falls out of there being no tool
+    # to fail.
+    print(f"[SUCCESS] cleaned {cfg.paper_folder} ({removed} file(s))")

--- a/src/rhiza_task/tasks/paper.py
+++ b/src/rhiza_task/tasks/paper.py
@@ -47,7 +47,7 @@ SECTION = "Paper"
 
 HAVE_TECTONIC = Guard(
     tool="tectonic",
-    reason="tectonic not found; install it (brew install tectonic, cargo install tectonic)",
+    reason="tectonic not found; see https://tectonic-typesetting.github.io/en-US/install.html",
 )
 
 PREFERRED = ("main.tex", "paper.tex")

--- a/tests/test_bundle_tasks.py
+++ b/tests/test_bundle_tasks.py
@@ -478,7 +478,11 @@ class TestPaper:
         assert paper_tasks.main_document(repo / "docs" / "paper").name == "main.tex"
 
     def test_compiles_in_the_paper_folder(self, repo, recorder: Recorder, present: set[str], papers) -> None:
-        """Run latexmk with the folder as cwd, so its aux files land beside the source.
+        """Run tectonic with the folder as cwd, so its output lands beside the source.
+
+        The vector is the document and one flag, which is the point of the engine change:
+        convergence and bibtex are tectonic's own loop, so neither is asked for, and there is
+        no interaction mode to pin because tectonic never prompts.
 
         Args:
             repo: The repository root.
@@ -486,13 +490,28 @@ class TestPaper:
             present: The installed-tool set.
             papers: The paper-writing helper.
         """
-        present.add("latexmk")
+        present.add("tectonic")
         papers("main.tex")
         state = runner.run(["paper"], Config.load(root=repo))
         assert state.results[0].status is Status.OK
-        call = recorder.find("latexmk")
-        assert call.flags == ["-pdf", "-bibtex", "-interaction=nonstopmode", "main.tex"]
+        call = recorder.find("tectonic")
+        assert call.flags == ["--keep-logs", "main.tex"]
         assert call.kwargs["cwd"] == repo / "docs" / "paper"
+
+    def test_skips_without_tectonic(self, repo, recorder: Recorder, present: set[str], papers) -> None:
+        """No engine on the machine is a skip, not a failure -- and runs nothing.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            present: The installed-tool set, left empty.
+            papers: The paper-writing helper.
+        """
+        papers("main.tex")
+        state = runner.run(["paper"], Config.load(root=repo))
+        assert state.results[0].status is Status.SKIPPED
+        assert "tectonic not found" in state.results[0].detail
+        assert recorder.calls == []
 
     def test_skips_a_folder_with_no_tex(self, repo, recorder: Recorder, present: set[str]) -> None:
         """An adopted-but-unused bundle skips rather than failing.
@@ -502,38 +521,81 @@ class TestPaper:
             recorder: The uv recorder.
             present: The installed-tool set.
         """
-        present.add("latexmk")
+        present.add("tectonic")
         (repo / "docs" / "paper").mkdir(parents=True)
         state = runner.run(["paper"], Config.load(root=repo))
         assert state.results[0].status is Status.SKIPPED
         assert recorder.calls == []
 
-    def test_clean_skips_without_a_paper_folder(self, cfg: Config, recorder: Recorder, present: set[str]) -> None:
+    def test_clean_skips_without_a_paper_folder(self, cfg: Config, recorder: Recorder) -> None:
         """Cleaning a folder that does not exist reports that rather than failing.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
-            present: The installed-tool set.
         """
-        present.add("latexmk")
         with pytest.raises(Skip, match="paper_folder"):
             paper_tasks.paper_clean(cfg)
         assert recorder.calls == []
 
-    def test_clean_tolerates_an_unbuilt_paper(self, repo, recorder: Recorder, present: set[str], papers) -> None:
-        """``latexmk -C || true``.
+    def test_clean_needs_no_tool(self, repo, recorder: Recorder, present: set[str], papers) -> None:
+        """The engine has no clean subcommand, so this one is Python and runs nothing.
+
+        ``present`` is left empty deliberately: a machine that cannot compile the paper can
+        still tidy up after one, which delegating to a driver never allowed.
 
         Args:
             repo: The repository root.
             recorder: The uv recorder.
-            present: The installed-tool set.
+            present: The installed-tool set, left empty.
             papers: The paper-writing helper.
         """
-        present.add("latexmk")
+        folder = repo / "docs" / "paper"
+        papers("main.tex")
+        for name in ("main.pdf", "main.log", "main.aux", "main.synctex.gz"):
+            (folder / name).write_text("x")
+
+        state = runner.run(["paper-clean"], Config.load(root=repo))
+
+        assert state.results[0].status is Status.OK
+        assert recorder.calls == []
+        assert sorted(p.name for p in folder.iterdir()) == ["main.tex"]
+
+    def test_clean_keeps_a_pdf_no_document_claims(self, repo, recorder: Recorder, papers) -> None:
+        """A committed figure has no ``.tex`` of its own and must survive the clean.
+
+        The reason the sweep is scoped by document stem: an extension sweep would delete
+        checked-in artwork, which no rebuild brings back.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            papers: The paper-writing helper.
+        """
+        folder = repo / "docs" / "paper"
+        papers("main.tex")
+        (folder / "main.pdf").write_text("x")
+        (folder / "diagram.pdf").write_text("x")
+
+        paper_tasks.paper_clean(Config.load(root=repo))
+
+        assert sorted(p.name for p in folder.iterdir()) == ["diagram.pdf", "main.tex"]
+
+    def test_clean_tolerates_an_unbuilt_paper(self, repo, recorder: Recorder, papers) -> None:
+        """Cleaning what was never built removes nothing and is still a success.
+
+        What paper.mk bought with ``|| true``, and here it falls out of there being no tool
+        to fail.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+            papers: The paper-writing helper.
+        """
         papers("main.tex")
         paper_tasks.paper_clean(Config.load(root=repo))
-        assert recorder.find("latexmk").kwargs["check"] is False
+        assert recorder.calls == []
+        assert (repo / "docs" / "paper" / "main.tex").is_file()
 
 
 class TestPresentation:

--- a/tests/test_dev_tasks.py
+++ b/tests/test_dev_tasks.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from rhiza_task.config import Config
-from rhiza_task.spec import Failed, Skip
+from rhiza_task.spec import REGISTRY, Failed, Skip
 from rhiza_task.tasks import book as book_tasks
 from rhiza_task.tasks import doctor as doctor_module
 from rhiza_task.tasks import quality
@@ -32,7 +32,6 @@ class TestDoctor:
         versions = {
             "uv": "uv 0.9.2 (abc 2026-01-01)",
             "git": "git version 2.39.5",
-            "make": "GNU Make 4.4.1",
         }
         monkeypatch.setattr(doctor_module.shutil, "which", lambda name: f"/fake/{name}" if name in versions else None)
 
@@ -55,7 +54,7 @@ class TestDoctor:
     def test_passes_when_everything_is_current(
         self, cfg: Config, tools: dict[str, str], capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """All three tools present and recent enough.
+        """Every tool present and recent enough.
 
         Args:
             cfg: The resolved config.
@@ -77,25 +76,33 @@ class TestDoctor:
         with pytest.raises(Failed, match="uv"):
             doctor_module.doctor(cfg)
 
-    def test_missing_make_only_warns(
-        self, cfg: Config, tools: dict[str, str], capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """GNU make is optional now, because no task needs it.
+    def test_probes_nothing_a_guard_already_owns(self) -> None:
+        """The diagnostic and the guards partition the question; they must not overlap.
 
-        doctor.mk requires GNU make, which was honest while the task layer *was* make.
-        Requiring a tool the layer no longer uses is how a diagnostic starts lying about
-        its own prerequisites -- only the convenience shim needs it.
+        ``doctor`` answers "can this machine run the CLI at all", so it names uv and git and
+        fails on a miss. Every other binary the package reaches for -- docker, gh, git-lfs,
+        tectonic, marp -- is a precondition on the one task that wraps it, and reports itself
+        on that task's ``skipped`` line with an install URL in its ``reason``. Listing one of
+        them here too would answer the same question one indirection further from where it
+        matters, and would need updating whenever a bundle gained a tool.
 
-        Args:
-            cfg: The resolved config.
-            tools: The faked tool versions.
-            capsys: pytest's output capture.
+        The assertion is disjointness rather than a transcribed list, so a new guard tool
+        needs no edit here and a *duplicated* one fails.
         """
-        del tools["make"]
-        doctor_module.doctor(cfg)
-        out = capsys.readouterr().out
-        assert "[WARN]" in out
-        assert "(optional)" in out
+        named = {tool.name for tool in doctor_module.TOOLS}
+        guarded = {guard.tool for spec in REGISTRY.values() for guard in spec.guards if guard.tool}
+        assert guarded, "no task guards on a tool; this test would pass vacuously"
+        assert named.isdisjoint(guarded)
+
+    def test_probing_make_would_be_a_regression(self) -> None:
+        """doctor.mk required GNU make, and this package has no make layer to require it for.
+
+        Kept as its own case because it is the correction, not a corollary: make was carried
+        over as an *optional* entry for the sake of a repo-owned Makefile forwarding to the
+        CLI, warned about on every clean run, and no task in the registry needs it. A guard
+        would not catch its return, since nothing guards on make either.
+        """
+        assert "make" not in {tool.name for tool in doctor_module.TOOLS}
 
     def test_fails_when_a_required_tool_is_absent(self, cfg: Config, tools: dict[str, str]) -> None:
         """A missing git is reported with its install URL and fails.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -659,7 +659,7 @@ class TestBook:
         """The book publishes the paper's PDF, so building the book must compile it.
 
         Asserted on the registry rather than on a vector, because there is no vector: the
-        PDF needs no copy step. latexmk writes it beside its source and ``paper_folder`` is
+        PDF needs no copy step. tectonic writes it beside its source and ``paper_folder`` is
         inside ``docs_dir``, so the only two moving parts are this prerequisite and the
         ``nav`` entry in ``mkdocs.yml`` -- and this is the half a test can hold.
         """
@@ -668,7 +668,7 @@ class TestBook:
         assert "paper" in spec.needs
 
     def test_prunes_latex_artifacts_but_keeps_the_pdf(self, cfg: Config, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The published site carries the paper's PDF and source, not latexmk's scratch files.
+        """The published site carries the paper's PDF and source, not the build's scratch files.
 
         ``paper.log`` is the one that matters: it records absolute paths from the machine
         that built it, and publishing it to Pages is a leak of build environment rather than
@@ -960,7 +960,7 @@ extra:
     def test_fails_naming_the_missing_asset(self, cfg: Config, capsys: pytest.CaptureFixture[str]) -> None:
         """The published 404 this gate exists for: a nav entry whose asset was never written.
 
-        This is the paper's case exactly. ``rhiza-task paper`` skips without latexmk, the
+        This is the paper's case exactly. ``rhiza-task paper`` skips without tectonic, the
         build succeeds, zensical reports ``No issues found``, and the site deploys with a
         dead entry in its own navigation -- so the assertion is that the *name* reaches the
         operator, not merely that the count is wrong.
@@ -1005,7 +1005,7 @@ extra:
         """``book`` must not need this gate.
 
         Half the nav entries here resolve only after the gates that produce them have run,
-        and a repository with no latexmk must still build its book -- which is what a skipped
+        and a repository with no tectonic must still build its book -- which is what a skipped
         prerequisite buys. Wiring this into ``book`` would turn that into a failure for every
         consumer documenting a paper it cannot compile, so the omission is the design and a
         test holds it.


### PR DESCRIPTION
Two pieces of make-era tooling, removed together because the second was found while auditing what the first belonged to.

## `paper` compiles with tectonic

`paper` drove a full TeX distribution, so a consumer provisioned the distribution *and* the list of packages their document happened to cite. This repository carried **two such lists** — one in `rhiza_paper.yml`, one in `rhiza_book.yml` — compiling the same document, with nothing checking that they agreed. tectonic resolves what the document cites from its own bundle, so there is one apt package and no list to diverge.

The vector shrinks to the document and one flag:

```
tectonic --keep-logs paper.tex
```

`-pdf`, `-bibtex` and `-interaction=nonstopmode` are gone rather than translated — convergence and bibtex are tectonic's own loop, and it never prompts. `--keep-logs` stays because tectonic writes only the PDF by default and the log is the artefact you upload when a CI compile fails; it is also the file `book`'s prune already exists to keep out of the published site.

Both workflows now cache `~/.cache/Tectonic`, keyed on the sources with a prefix restore, since a cold cache needing the network is the one thing this trade costs.

## `paper-clean` needs no tool, and sweeps by document stem

tectonic has no clean subcommand, so the task deletes the artifacts itself and guards on **no tool at all** — the one task in the section that works on a machine which cannot build the paper.

It sweeps by document *stem* rather than by extension: `paper.tex` authorises deleting `paper.pdf` and `paper.log`, but a committed `diagram.pdf` with no `diagram.tex` survives. An extension sweep would be one line shorter and would delete a consumer's checked-in artwork, which no rebuild brings back.

The suffix list moved to `paper.AUX_SUFFIXES` and `book.py` imports it, so the site prune and the clean share one list and differ only in whether the PDF goes with it. `.fdb_latexmk` and `.fls` are dropped as driver-specific to an engine that no longer runs; `.synctex.gz` is added to `.gitignore`, which now matches.

## `doctor` stops probing for make

`doctor` probed GNU make as an optional prerequisite — honest while the task layer *was* make, residue in a package that has none. Removing it emptied the optional tier, so `Tool.required`, the `[WARN]` branch and the `(optional)` suffix went with it.

**Optionality is what `Guard` is for**: docker, gh, git-lfs, tectonic and marp each report themselves on the `skipped` line of the task that wraps them, with an install URL in the `reason`. A diagnostic enumerating them too would answer the same question one indirection from where it matters, and need editing whenever a bundle gained a tool.

Two tests hold the boundary — one asserts `TOOLS` is disjoint from every guard tool in `REGISTRY`, computed rather than transcribed, so a new guard tool needs no edit; the other pins `make` specifically, because no guard would catch its return.

## Breaking, and why the commit is `feat:` rather than `feat!:`

A machine with a TeX distribution and no tectonic now **skips** `paper` where it previously produced a PDF. `CHANGELOG.md` carries the upgrade note under `## [Unreleased]`, with an HTML comment telling whoever cuts the release to fold it into the generated section — `git-cliff` files a strictness increase wherever the commit type puts it and never writes one.

The commit type is `feat:`, which is CLAUDE.md's own rule rather than a softening: *a change that makes a gate reject input it previously accepted is `feat:`, and needs at least a `minor`*. `uvx git-cliff --bumped-version` accordingly derives **v1.3.0**. A `!` would have derived a major, and the version is a judgement for whoever cuts the release — `/rhiza:release` refuses to recommend one for exactly this reason.

The cost of dropping the `!` is that the generated list will not carry a `[**breaking**]` tag, so **the upgrade note is the only place a consumer is told**. That is why it names the symptom, the install and the pin to hold at (`rhiza-task<1.3`).

## Verification

Verified against the **real engine**, not only as a vector: `rhiza-task paper` compiled `docs/paper/paper.pdf` and `paper-clean` removed what it left.

- `rhiza-task all` — green
- `rhiza-task docs-examples`, `rhiza-task complexity` — green
- 389 tests, 100% coverage
- `actionlint`, `markdownlint`, `bandit`, `gitleaks` via pre-commit — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

