### PR TITLE
docs: add a total-downloads badge, and record what it counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
 # rhiza-task
 
 [![PyPI](https://img.shields.io/pypi/v/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
+[![Downloads](https://static.pepy.tech/personalized-badge/rhiza-task?period=total&units=international_system&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/project/rhiza-task)
 [![Python](https://img.shields.io/pypi/pyversions/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
 [![CI](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml/badge.svg)](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Docs](https://img.shields.io/badge/docs-jebel--quant.github.io-blue)](https://jebel-quant.github.io/rhiza-task/)
+
+<!--
+The downloads badge counts `uvx rhiza-task` runs, and that is the point of having it rather
+than an aside: this package is invoked far more often than it is installed into a project, so
+a counter that missed uv would report a small fraction of its use. It does not miss it --
+`uv` is by a wide margin the dominant installer here, and pip is a rounding error. Check it
+rather than believing this comment:
+
+  curl -sS 'https://sql-clickhouse.clickhouse.com/?user=demo&default_format=TabSeparatedWithNames' \
+    --data-binary "SELECT installer, sum(count) FROM pypi.pypi_downloads_per_day_by_version_by_installer_by_type \
+                   WHERE project='rhiza-task' GROUP BY installer ORDER BY 2 DESC"
+
+Two things about the choice of service. It is pepy rather than shields because shields has no
+PyPI *total* endpoint -- `img.shields.io/pypi/dt/...` 404s, and only `dm`/`dw`/`dd` exist -- so
+a total means one more third-party service than the badge row already depends on. And what
+either service counts is *file downloads*, which for a CI-invoked CLI is closer to a count of
+pipeline runs than of people; mirror traffic is excluded, but a re-run is not.
+-->
 
 The rhiza developer tasks as a **pinned CLI** rather than a synced make layer — **one set
 of task names across Python, Rust and Go**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ hide:
 **The rhiza developer tasks, as a pinned CLI** — not a synced make layer.
 
 [![PyPI](https://img.shields.io/pypi/v/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
+[![Downloads](https://static.pepy.tech/personalized-badge/rhiza-task?period=total&units=international_system&left_color=grey&right_color=blue&left_text=downloads)](https://pepy.tech/project/rhiza-task)
 [![Python](https://img.shields.io/pypi/pyversions/rhiza-task.svg)](https://pypi.org/project/rhiza-task/)
 [![CI](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml/badge.svg)](https://github.com/Jebel-Quant/rhiza-task/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Jebel-Quant/rhiza-task/blob/main/LICENSE)


### PR DESCRIPTION
Adds a PyPI downloads badge to `README.md` and `docs/index.md`.

## It counts `uvx`, and that was the thing to check first

The condition on the request was that the count include `uvx`. It does — the installer breakdown for this project is **uv first by a wide margin**, with `pip` a rounding error behind `Browser` and `bandersnatch`.

That matters more here than it would for most packages: `rhiza-task` is *invoked* far more often than it is installed into a project, so a counter that missed uv would report a small fraction of its use — which is exactly the failure the condition was guarding against.

The README carries the query rather than the figures, so the claim stays checkable and cannot go stale:

```bash
curl -sS 'https://sql-clickhouse.clickhouse.com/?user=demo&default_format=TabSeparatedWithNames' \
  --data-binary "SELECT installer, sum(count) FROM pypi.pypi_downloads_per_day_by_version_by_installer_by_type \
                 WHERE project='rhiza-task' GROUP BY installer ORDER BY 2 DESC"
```

## pepy rather than shields, and not by preference

shields has **no PyPI total endpoint** — `img.shields.io/pypi/dt/<pkg>` 404s, and only `dm`/`dw`/`dd` exist. So a *total* costs one more third-party service than the badge row already depends on.

If that trade isn't worth it, `https://img.shields.io/pypi/dm/rhiza-task.svg` renders `downloads | 34k/month` on shields alone, and swapping is a one-line change.

## What the number is not

The comment beside the badge says so: file downloads for a CI-invoked CLI are closer to a count of pipeline runs than of people. Mirror traffic is excluded; a re-run is not.

## Note on how this branch came about

The commit was originally pushed to `feat/compile-the-paper-with-tectonic` moments after #138 merged and that branch was deleted, which silently recreated it. It has been cherry-picked onto a fresh branch off `main` and the recreated branch removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
