### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-<!--
-The Unreleased section below holds an upgrade note written when the change landed, because
-git-cliff files a strictness increase wherever its commit type puts it and never writes one.
-At release time `git-cliff --prepend` inserts the new version's section *above* this heading:
-fold the note into that section, delete this heading and this comment, and restore the
-`# Changelog` title, which --prepend eats.
--->
-
-## [Unreleased]
+## [1.3.0] - 2026-08-23
 
 ### ⚠️ Upgrade note
 
@@ -49,6 +41,18 @@ make; this package has none, and nothing in the registry needs it. Every other b
 package reaches for — docker, gh, git-lfs, tectonic, marp — is a `Guard` on the task that wraps
 it and reports itself on that task's `skipped` line with an install URL, which is where an
 optional prerequisite belongs. `Tool.required` is gone from `rhiza_task.tasks.doctor` with it.
+
+### 🚀 Features
+
+- Compile the paper with tectonic, and stop probing for make
+
+### 🐛 Bug Fixes
+
+- *(ci)* Install tectonic from a pinned release, not from apt
+
+### 📚 Documentation
+
+- Add a total-downloads badge, and record what it counts
 
 ## [1.2.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The rhiza developer tasks as a **pinned CLI** rather than a synced make layer �
 of task names across Python, Rust and Go**.
 
 ```bash
-uvx rhiza-task@1.2.0 test
+uvx rhiza-task@1.3.0 test
 ```
 
 📖 **[Documentation](https://jebel-quant.github.io/rhiza-task/)** — the task catalogue,
@@ -63,9 +63,9 @@ v1.3.3 and hope nobody edited them."
 Nothing to install. `uvx` provisions it per invocation:
 
 ```bash
-uvx rhiza-task@1.2.0 list          # what is available
-uvx rhiza-task@1.2.0 all           # every gate, as CI runs them
-uvx rhiza-task@1.2.0 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.3.0 list          # what is available
+uvx rhiza-task@1.3.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.3.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 Task names are unchanged from the retired make layer, so a repo that wants `make test` to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,8 +87,8 @@ and wins when both are present.
 value a task will actually see:
 
 ```bash
-uvx rhiza-task@1.2.0 print coverage_fail_under
-uvx rhiza-task@1.2.0 print COVERAGE_FAIL_UNDER   # either spelling
+uvx rhiza-task@1.3.0 print coverage_fail_under
+uvx rhiza-task@1.3.0 print COVERAGE_FAIL_UNDER   # either spelling
 ```
 
 Field names are the lowercased make variables, so the mapping to what a consumer already
@@ -100,7 +100,7 @@ In the two string-valued layers, an empty value **leaves the layer below it alon
 than resolving to `""`:
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.2.0 ci-os-matrix   # still the default
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.3.0 ci-os-matrix   # still the default
 ```
 
 That is make's `$(or ...)` rule, and the reusable workflows depend on it: `rhiza_ci.yml`
@@ -228,7 +228,7 @@ layers = ["rust"]
 ```
 
 ```bash
-RHIZA_LAYERS=rust uvx rhiza-task@1.2.0 test
+RHIZA_LAYERS=rust uvx rhiza-task@1.3.0 test
 ```
 
 ## No `+=` successor, and none needed

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ language layers this repository does not have.
 
 You should. An unpinned task layer can change under a green pull request without a commit
 touching your repository — which is the failure mode the whole package exists to remove.
-`rhiza-task@1.2.0` makes a bump a deliberate commit that carries whatever fixes it wants.
+`rhiza-task@1.3.0` makes a bump a deliberate commit that carries whatever fixes it wants.
 
 ### A gate says `skipped`. Is that bad?
 
@@ -30,7 +30,7 @@ folder. The reason is printed next to it.
 It *is* bad when the subject was supposed to be there. That is what `--strict` is for:
 
 ```bash
-uvx rhiza-task@1.2.0 all --strict
+uvx rhiza-task@1.3.0 all --strict
 ```
 
 In a consumer repository `--strict` is usually the right setting, because a skip means a
@@ -68,7 +68,7 @@ Two likely causes:
 ### How do I run the gates for another repository?
 
 ```bash
-uvx rhiza-task@1.2.0 all --root ../other-repo
+uvx rhiza-task@1.3.0 all --root ../other-repo
 ```
 
 ## Configuration
@@ -78,7 +78,7 @@ uvx rhiza-task@1.2.0 all --root ../other-repo
 Check what actually resolved, rather than what you wrote:
 
 ```bash
-uvx rhiza-task@1.2.0 print coverage_fail_under
+uvx rhiza-task@1.3.0 print coverage_fail_under
 ```
 
 The usual causes, in order of likelihood:
@@ -101,7 +101,7 @@ Move anything CI depends on into `rhiza.toml` or `[tool.rhiza-task]`.
 ### Why is an empty value not empty?
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.2.0 ci-os-matrix   # still ["ubuntu-latest"]
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.3.0 ci-os-matrix   # still ["ubuntu-latest"]
 ```
 
 That is make's `$(or ...)` rule, kept because the reusable workflows depend on it:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,13 +10,13 @@ icon: material/rocket-launch
 project's dependencies:
 
 ```bash
-uvx rhiza-task@1.2.0 list          # what is available
-uvx rhiza-task@1.2.0 all           # every gate, as CI runs them
-uvx rhiza-task@1.2.0 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.3.0 list          # what is available
+uvx rhiza-task@1.3.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.3.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 !!! tip "Pin the version"
-    `rhiza-task@1.2.0` rather than `rhiza-task`. The pin is the whole point of the
+    `rhiza-task@1.3.0` rather than `rhiza-task`. The pin is the whole point of the
     package — an unpinned task layer is a layer that can change under a green pull
     request without a commit touching your repository. Bumping it is then a deliberate
     commit that carries whatever the new version wants.
@@ -30,7 +30,7 @@ it would have to provision the runtime that every task already runs under.
 Start by asking what this repository has:
 
 ```bash
-uvx rhiza-task@1.2.0 list
+uvx rhiza-task@1.3.0 list
 ```
 
 ```text
@@ -56,7 +56,7 @@ other layers call things.
 Then run the aggregate:
 
 ```bash
-uvx rhiza-task@1.2.0 all
+uvx rhiza-task@1.3.0 all
 ```
 
 ## `run`, and the bare shorthand
@@ -64,9 +64,9 @@ uvx rhiza-task@1.2.0 all
 `rhiza-task <task>` is shorthand for `rhiza-task run <task>`:
 
 ```bash
-uvx rhiza-task@1.2.0 test          # shorthand
-uvx rhiza-task@1.2.0 run test      # the same thing
-uvx rhiza-task@1.2.0 run fmt test  # several, in order, prerequisites deduplicated
+uvx rhiza-task@1.3.0 test          # shorthand
+uvx rhiza-task@1.3.0 run test      # the same thing
+uvx rhiza-task@1.3.0 run fmt test  # several, in order, prerequisites deduplicated
 ```
 
 This is a compatibility contract rather than sugar. The reusable workflows and a
@@ -98,7 +98,7 @@ different bundles installed. But a skip is also how a gate silently stops measur
 anything — so `--strict` turns every skip into a failure:
 
 ```bash
-uvx rhiza-task@1.2.0 all --strict
+uvx rhiza-task@1.3.0 all --strict
 ```
 
 !!! note "Which one belongs in your CI"
@@ -145,7 +145,7 @@ rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.2.0
+RHIZA_TASK := rhiza-task@1.3.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -167,11 +167,11 @@ same configuration the tasks read:
     enable-cache: true
 
 - name: Gates
-  run: uvx rhiza-task@1.2.0 all --strict
+  run: uvx rhiza-task@1.3.0 all --strict
 ```
 
 ```bash
-uvx rhiza-task@1.2.0 ci-os-matrix
+uvx rhiza-task@1.3.0 ci-os-matrix
 ```
 
 ```text

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ hide:
 ## 📋 Overview
 
 ```bash
-uvx rhiza-task@1.2.0 test
+uvx rhiza-task@1.3.0 test
 ```
 
 There is nothing to install and nothing to sync. One command runs a project's gates, and
@@ -66,7 +66,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Tasks, grouped by section, with prerequisites and a one-line description.
 
     ```bash
-    uvx rhiza-task@1.2.0 list
+    uvx rhiza-task@1.3.0 list
     ```
 
     [→ The task catalogue](tasks.md)
@@ -78,7 +78,7 @@ files at tag v1.3.3 and hope nobody edited them."
     The aggregate CI runs: format, deps, test, docs, security, licence, types.
 
     ```bash
-    uvx rhiza-task@1.2.0 all
+    uvx rhiza-task@1.3.0 all
     ```
 
     [→ Getting started](getting_started.md)
@@ -90,7 +90,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Six configuration layers, collapsed to the one value a task will actually see.
 
     ```bash
-    uvx rhiza-task@1.2.0 print coverage_fail_under
+    uvx rhiza-task@1.3.0 print coverage_fail_under
     ```
 
     [→ Configuration](configuration.md)

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -63,7 +63,7 @@ docs-examples` now runs the fence and compares.
 that did not win:
 
 ```bash
-uvx rhiza-task@1.2.0 rust:test
+uvx rhiza-task@1.3.0 rust:test
 ```
 
 Pinning the layer list does the same thing globally:
@@ -85,7 +85,7 @@ layer showed, having synced exactly one fragment.
 `--all` answers the question the make layer could not:
 
 ```bash
-uvx rhiza-task@1.2.0 list --all   # what the layers you do not have call things
+uvx rhiza-task@1.3.0 list --all   # what the layers you do not have call things
 ```
 
 ## A missing name is `None`, not an error

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,14 +26,14 @@ rewrite.
 Either invoke the CLI directly in CI and locally:
 
 ```bash
-uvx rhiza-task@1.2.0 all --strict
+uvx rhiza-task@1.3.0 all --strict
 ```
 
 …or keep `make test` working with a repo-owned `Makefile` that forwards — one rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.2.0
+RHIZA_TASK := rhiza-task@1.3.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -133,7 +133,7 @@ order.
 Add `--strict` in CI once the migration is quiet:
 
 ```bash
-uvx rhiza-task@1.2.0 all --strict
+uvx rhiza-task@1.3.0 all --strict
 ```
 
 A skip in a consumer repository means a gate lost its subject, and `--strict` is what turns

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -129,7 +129,7 @@ Windows. That probe is not incidental complexity; it is the price of the impleme
 language.
 
 Replacing the layer with a published package addresses both at once. A dependency
-\emph{is} a reference: \texttt{uvx rhiza-task@1.2.0 test} names a version, resolves it, and
+\emph{is} a reference: \texttt{uvx rhiza-task@1.3.0 test} names a version, resolves it, and
 leaves nothing in the working tree to drift or exclude. And a package is written in a
 language with data structures, so the retry loop becomes a \texttt{for} statement.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "1.2.0"
+version = "1.3.0"
 description = "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@1.2.0 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@1.3.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Bumps **v1.2.0 → v1.3.0**. Guarded as strictly increasing past every prior release: floor `v1.2.0`, highest existing tag `v1.2.0`.

## Why minor

Three unreleased commits — 1 `feat`, 1 `fix`, 1 `docs`, and **no breaking marker**. The `feat` is a strictness increase, which CLAUDE.md's own rule places here: *a change that makes a gate reject input it previously accepted is `feat:`, and needs at least a `minor`.*

## Files the bump touched

| file | what moved |
|---|---|
| `pyproject.toml` | `[project].version` |
| `src/rhiza_task/__init__.py` | `__version__` and the pin in its module docstring |
| `uv.lock` | this package's own locked version |
| `README.md`, `docs/*.md` (7 files), `docs/paper/paper.tex` | the `rhiza-task@<version>` usage pins |

No `current_version` was written into `[tool.bumpversion]` — this repo's config is deliberately tag-derived, and the bump was given `--current-version 1.2.0` explicitly rather than being allowed to guess. Verified afterwards that no `rhiza-task@1.2.0` pin survives anywhere in the tree.

## Changelog

The generated section was **prepended**, not regenerated, and the diff confirms no earlier section was touched — 13 insertions, 9 deletions, and every deletion is the scaffolding described below.

The hand-written `⚠️ Upgrade note` that has been sitting under `## [Unreleased]` since the tectonic change landed is now folded into `## [1.3.0]`, ahead of the generated categories, matching v1.2.0's layout. Its `## [Unreleased]` heading and the HTML comment that explained the fold are gone, having done their job.

That note is load-bearing for this release: the commit is `feat:` rather than `feat!:`, so `git-cliff` did **not** tag the entry `[**breaking**]`, and the note is therefore the only place a consumer is told that a machine with a TeX distribution and no tectonic now skips `paper` where it previously produced a PDF. It names the symptom, the install and `rhiza-task<1.3` as the pin to hold at.

`git-cliff --prepend` also ate the `# Changelog` title, as it did on both v1.1.0 prepends; it has been restored.

## Merging this does not publish the release

**No tag exists yet.** The tag is cut afterwards, from the merged commit, by a second `/rhiza:release` run — a tag created before the merge would name a SHA that a squash-merge never lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
