### PR TITLE
fix(ci): keep the workspace when pushing to the paper branch

### DIFF
--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -125,22 +125,59 @@ jobs:
 
       # An orphan `paper` branch holding only the current PDF, so the latest build has a
       # stable URL that outlives the 30-day artifact retention.
+      #
+      # Built with plumbing rather than by checking the branch out, and that is the whole
+      # point of the step's shape: **the workspace must survive it.** This used to run
+      # `git checkout -b paper origin/paper`, which replaces the checked-out tree with a
+      # branch holding one PDF -- and a *local* composite action's post phase re-reads its
+      # definition from the workspace. So the job pushed the PDF and then died on:
+      #
+      #     Can't find 'action.yml' ... under '.github/actions/setup-tectonic'.
+      #     Did you forget to run actions/checkout before running your local action?
+      #
+      # The cost was not only a red run: the post step that failed was the tectonic bundle
+      # cache *save*, so the cache never populated and every run paid the cold fetch. The
+      # PR build was green throughout, because this step is gated on `push` and a
+      # `pull_request` run therefore never swapped the tree out.
+      #
+      # `hash-object`, `mktree` and `commit-tree` write the blob, the tree and the commit
+      # straight into the object database and push the resulting SHA at the branch ref.
+      # Nothing is checked out, no index is touched, and the same three commands handle the
+      # branch existing and not existing -- the second case is just a commit with no parent,
+      # which is what "orphan" means. A worktree would also keep the workspace, but the
+      # orphan half of it needs `git worktree add --orphan`, i.e. git >= 2.42, and this
+      # needs no version floor at all.
       - name: Push the PDF to the paper branch
         if: ${{ steps.check_tex.outputs.tex_present == 'true' && github.event_name == 'push' }}
+        env:
+          PDF_PATH: ${{ steps.pdf.outputs.pdf_path }}
+          PDF_FILE: ${{ steps.pdf.outputs.pdf_file }}
+          # commit-tree reads the identity from the environment, so there is no `git config`
+          # here either -- that would be one more write to the checkout this step exists to
+          # leave alone.
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
-          pdf_file="${{ steps.pdf.outputs.pdf_file }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          cp "${{ steps.pdf.outputs.pdf_path }}" "/tmp/${pdf_file}"
-          git fetch origin paper 2>/dev/null || true
-          if git show-ref --verify --quiet refs/remotes/origin/paper; then
-            git checkout -b paper origin/paper
+          set -euo pipefail
+
+          blob=$(git hash-object -w "$PDF_PATH")
+          tree=$(printf '100644 blob %s\t%s\n' "$blob" "$PDF_FILE" | git mktree)
+
+          # Explicit refspec: `git fetch origin paper` alone relies on the remote's
+          # configured refspec to populate the tracking ref, and actions/checkout narrows
+          # that to the ref it checked out.
+          git fetch --quiet origin '+refs/heads/paper:refs/remotes/origin/paper' 2>/dev/null || true
+
+          if parent=$(git rev-parse --verify --quiet refs/remotes/origin/paper); then
+            if [ "$(git rev-parse "${parent}^{tree}")" = "$tree" ]; then
+              echo "paper branch already carries this PDF; nothing to push"
+              exit 0
+            fi
+            commit=$(git commit-tree "$tree" -p "$parent" -m "Update $PDF_FILE [skip ci]")
           else
-            git checkout --orphan paper
-            git rm -rf --quiet . || true
-            git reset
+            commit=$(git commit-tree "$tree" -m "Update $PDF_FILE [skip ci]")
           fi
-          cp "/tmp/${pdf_file}" "${pdf_file}"
-          git add "${pdf_file}"
-          git diff --staged --quiet || git commit -m "Update ${pdf_file} [skip ci]"
-          git push origin paper
+
+          git push origin "$commit:refs/heads/paper"


### PR DESCRIPTION
Fixes the `(RHIZA) PAPER` failure on `main` after v1.3.0 ([run 32657312512](https://github.com/Jebel-Quant/rhiza-task/actions/runs/32657312512)).

## What happened

`rhiza-task paper` compiled and the PDF reached the `paper` branch (`2f5c848..7ad414a`). Then the job died:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/rhiza-task/rhiza-task/.github/actions/setup-tectonic'.
Did you forget to run actions/checkout before running your local action?
```

Nothing was wrong with the checkout. The step immediately before ran `git checkout -b paper origin/paper` **in the workspace**, replacing the tree with a branch holding one PDF — and a *local* composite action's post phase re-reads its definition from that path. By then it was gone.

The failing step was `Post Set up tectonic`, i.e. the **cache save**.

## Why this cost more than a red run

The post step that failed is the one that writes `~/.cache/Tectonic`. So the cache introduced alongside the composite action **has never populated**, and every run since has paid the cold bundle fetch while appearing to be cached. This restores the behaviour the cache was added for.

## Why CI didn't catch it

The step is gated `github.event_name == 'push'`. A `pull_request` run skips it and never swaps the tree out, so #138's checks were green throughout — the failure was reachable only after merge, on the default branch.

## The fix

Plumbing instead of a checkout. `hash-object`, `mktree` and `commit-tree` write the blob, tree and commit straight to the object database, and the push sends that SHA at the branch ref:

- nothing is checked out and no index is touched, so the workspace survives for the post phase;
- the identity comes from `GIT_AUTHOR_*` / `GIT_COMMITTER_*` rather than a `git config` write to the checkout this step exists to leave alone;
- the same three commands cover the branch existing and not existing — the second case is a commit with no parent, which is what "orphan" meant;
- it now skips the push when the tree is unchanged, rather than relying on `git diff --staged --quiet`.

A worktree would also have preserved the workspace, but its orphan half needs `git worktree add --orphan` (git ≥ 2.42). This needs no version floor.

## Verification

Both paths were dry-run against the real `paper` branch before pushing — an identical PDF reports nothing to push; a changed one builds a commit whose parent is the current head (`7ad414a`) and whose tree holds only `paper.pdf` at mode `100644`.

The real proof is post-merge, since this path only runs on `push` to `main`: the `(RHIZA) PAPER` run should go green **and** report a cache save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
