### PR TITLE
fix(ci): pin tectonic's cache path instead of inferring it

### DIFF
--- a/.github/actions/setup-tectonic/action.yml
+++ b/.github/actions/setup-tectonic/action.yml
@@ -66,6 +66,17 @@ runs:
         "$RUNNER_TEMP/tectonic-bin/tectonic" --version
         echo "$RUNNER_TEMP/tectonic-bin" >> "$GITHUB_PATH"
 
+        # Pin where the bundle is cached instead of inferring it. tectonic resolves its cache
+        # through platform conventions -- ~/Library/Caches/Tectonic on macOS, an XDG path on
+        # Linux -- and caching a *guessed* path fails silently in the one direction that
+        # matters: actions/cache warns `Path Validation Error: Path(s) specified in the action
+        # for caching do(es) not exist` and saves nothing, while the job stays green and every
+        # run refetches the bundle. That is exactly what the first attempt at this did.
+        # TECTONIC_CACHE_DIR removes the inference; GITHUB_ENV so the compile step, which is
+        # in the calling workflow, sees it.
+        mkdir -p "$RUNNER_TEMP/tectonic-cache"
+        echo "TECTONIC_CACHE_DIR=$RUNNER_TEMP/tectonic-cache" >> "$GITHUB_ENV"
+
     # tectonic's whole model is fetching what the document cites out of a web bundle and
     # caching it, so the cache is where the trade against a provisioned distribution is
     # actually settled: warm, the compile is offline for everything it has seen before; cold,
@@ -74,12 +85,12 @@ runs:
     # fetched into a version's own cache layout. The prefix restore means editing the paper
     # reuses the previous run's files instead of refetching the preamble's packages.
     #
-    # ~/.cache/Tectonic is the XDG location tectonic uses on Linux; the macOS and Windows
-    # paths differ, which does not matter while the step above accepts only Linux.
+    # The path is the one the step above *told* tectonic to use, not one inferred from the
+    # platform -- see the comment there for why that distinction cost a release.
     - name: Cache the tectonic bundle
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ~/.cache/Tectonic
+        path: ${{ runner.temp }}/tectonic-cache
         key: tectonic-0.17.0-${{ runner.os }}-${{ hashFiles('docs/paper/**/*.tex') }}
         restore-keys: |
           tectonic-0.17.0-${{ runner.os }}-


### PR DESCRIPTION
Second half of the tectonic CI fix. With #141's workspace fix merged, the post step finally ran on `main` — and reported:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist,
hence no cache is being saved.
```

## The bug

`~/.cache/Tectonic` was my guess at the Linux convention, extrapolated from what the engine writes on macOS (`~/Library/Caches/Tectonic`). It's wrong — and wrong in the direction that hides: `actions/cache` warns, saves nothing, the job stays **green**, and every run refetches the bundle while the config reads as though it were cached.

## The fix

Stop inferring the path. `TECTONIC_CACHE_DIR` tells the engine where to put the cache, exported through `$GITHUB_ENV` because the compile step lives in the calling workflow rather than the action. The cache action is then given that same path via `${{ runner.temp }}/tectonic-cache`, so the two cannot disagree. The directory is created up front, so an empty cache is an empty directory rather than a validation error.

## Verification

Checked by running it, not by reading docs: a compile with `TECTONIC_CACHE_DIR` pointed at a scratch directory refetched from cold and left **45 MB** of `bundles/` and `formats/` there — the same layout the platform default holds. Exit 0.

## Both defects share a shape, which is worth recording

This is the second CI-only bug in this feature, and neither was reachable from a pull request:

- **#141** — the step that broke the workspace is gated `github.event_name == 'push'`, so PR runs skip it.
- **this one** — a cache that never saves is indistinguishable from a cache that has never hit, so a green run proves nothing about it.

The real check is post-merge: the next `(RHIZA) PAPER` run on `main` should report a cache **save**, and the one after that a **hit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
