### PR TITLE
fix(ci): run the paper workflow when its action changes

### DIFF
--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -30,16 +30,25 @@
 
 name: "(RHIZA) PAPER"
 
+# The paths list has to name the *action* as well as the workflow, and that is not
+# housekeeping: `.github/actions/setup-tectonic` is where the engine version, its checksum
+# and the bundle cache live, so a change there decides whether this workflow works -- and
+# without this entry, editing it triggers nothing. Two commits proved that in a row: the
+# fix that pinned the cache path merged and ran no paper build at all, so the thing it
+# fixed had to be checked by hand with `workflow_dispatch`. A path that can break a
+# workflow belongs in that workflow's filter.
 on:
   push:
     branches: [main]
     paths:
       - 'docs/paper/**'
       - '.github/workflows/rhiza_paper.yml'
+      - '.github/actions/setup-tectonic/**'
   pull_request:
     paths:
       - 'docs/paper/**'
       - '.github/workflows/rhiza_paper.yml'
+      - '.github/actions/setup-tectonic/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
`.github/actions/setup-tectonic` holds the engine version, its checksum and the bundle cache — everything that decides whether this workflow works — and the paths filter did not name it. So editing the action triggered nothing.

Not hypothetical: #142 (which pinned the cache path) merged and ran **no paper build at all**, so its fix had to be verified by hand with `workflow_dispatch`.

`rhiza_book.yml` needs no equivalent change — it triggers on pushes to every branch with no paths filter. That asymmetry is also why the cache works today: the book run on `main` **saved** the bundle, and the dispatched paper run **hit** it, across two workflows sharing one action.

## The tectonic cache is now confirmed working end to end

- book run on `main`: `Cache saved with key: tectonic-0.17.0-Linux-cc6b3f33…`
- paper run on `main`: `Cache hit for: tectonic-0.17.0-Linux-cc6b3f33…`, 10 MB restored, post step correctly declines to re-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
