### PR TITLE
feat: run a repo-owned setup hook as part of install

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -209,6 +209,34 @@ JetBrains server refuses to serve gitignored directories and `_book` is one.
 |---|---|---|
 | `doctor` | — | check local prerequisites |
 | `clean` | — | remove build artifacts and stale local branches |
+| `setup` | — | run the repository's own environment setup hook |
+
+`setup` runs a repo-owned `local-setup.sh` at the repository root, and **every layer's
+`install` names it as a prerequisite** — so it reaches local `make test`, CI and a
+devcontainer through one insertion point rather than a step in each workflow.
+
+It is the seam for a native binary a project needs before its gates can run: graphviz for a
+docs plugin, `libpq` for psycopg, pandoc. rhiza's template owns every configuration file in a
+managed repository, so before this there was nowhere to put that step — and the workaround
+that was documented, shadowing `install` in `local.mk`, never ran. The Makefile shim forwards
+the *goal* to this CLI, so `install` resolves here rather than in make, and CI invokes the CLI
+directly without going through make at all.
+
+Deliberately **not** a `system-packages = [...]` setting. `graphviz` is spelled the same on
+apt and brew; `libgl1-mesa-glx` is not, and a list cannot express "download this tarball" —
+which is what rhiza itself does for tectonic. The hook is a script, so platform detection
+stays with the people who know which platforms they build on, and this package acquires no
+apt/brew/winget logic — the rule `lfs-install` states.
+
+A hook that exists but is not executable **fails**, with the `chmod` hint — a provisioning
+step someone wrote and believed was running is exactly what must not pass quietly.
+
+An absent hook, by contrast, **succeeds**; it does not skip. That is deliberate and is the
+one place in this package where "nothing happened" is not a `skipped`. `Skip` means work was
+asked for and did not happen, which is why `--strict` promotes it to a failure. Nothing is
+asked for by a repository that declares no hook — and since most declare none, skipping would
+fail every `--strict` invocation on the common case, `book --strict` included, five
+prerequisites down. The `[INFO] no local-setup.sh` line is what keeps that outcome legible.
 
 `doctor` is the second procedural escape — it compares semantic versions, which used to be
 an `awk` function inside a make recipe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,12 @@ quality = "rhiza_task.tasks.quality"
 extras = "rhiza_task.tasks.extras"
 book = "rhiza_task.tasks.book"
 doctor = "rhiza_task.tasks.doctor"
+# `setup` is bound here like any other module, but it is the one whose *absence* would be
+# invisible: an unresolvable prerequisite is skipped rather than an error (see runner.py),
+# so an unbound entry point would leave every `install` silently running no hook at all --
+# the failure this task exists to remove. rhiza's own test_bundle_cli_targets.py asserts the
+# pinned CLI still lists it.
+setup = "rhiza_task.tasks.setup"
 # The five bundle-owned fragments `.rhiza/make.d/` kept because nothing here answered for
 # their targets. One module per bundle, so which bundle owns a task stays as legible as it
 # was when each was a file the template synced.

--- a/src/rhiza_task/tasks/go.py
+++ b/src/rhiza_task/tasks/go.py
@@ -55,7 +55,7 @@ MANIFEST = Guard(file="go.mod", reason="no go.mod")
 """What every Go gate is guarded on: the module file, not a source folder."""
 
 
-@task("install", "install the toolchain and download dependencies", section="Go", layer="go")
+@task("install", "install the toolchain and download dependencies", section="Go", layer="go", needs=("setup",))
 def install(cfg: Config) -> None:
     """Download the module's dependencies and install the git hooks.
 

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -46,7 +46,10 @@ test failed.
 MAX_ATTEMPTS = 2
 
 
-@task("install", "create the venv and sync dependencies", section="Python", layer="python")
+# `setup` first, and in all three layers: a native library needed to *build* a wheel has to
+# be on the machine before `uv sync`, not after it. See tasks/setup.py for why the hook is
+# anchored on `install` rather than run by the workflows.
+@task("install", "create the venv and sync dependencies", section="Python", layer="python", needs=("setup",))
 def install(cfg: Config) -> None:
     """Create ``.venv`` if absent, sync from the lock file, install the git hooks.
 

--- a/src/rhiza_task/tasks/rust.py
+++ b/src/rhiza_task/tasks/rust.py
@@ -38,7 +38,7 @@ that renames it is still a crate. This is the flat analogue of python.mk's
 """
 
 
-@task("install", "install the toolchain and fetch dependencies", section="Rust", layer="rust")
+@task("install", "install the toolchain and fetch dependencies", section="Rust", layer="rust", needs=("setup",))
 def install(cfg: Config) -> None:
     """Materialise the pinned toolchain, fetch dependencies, install the git hooks.
 

--- a/src/rhiza_task/tasks/setup.py
+++ b/src/rhiza_task/tasks/setup.py
@@ -57,6 +57,20 @@ can be used, and there is nothing a project could express by moving it. It sits 
 repository.
 """
 
+CHECKS_EXECUTABLE_BIT = os.name == "posix"
+"""Whether this platform has an execute bit worth asking about.
+
+Windows does not. ``os.access(path, os.X_OK)`` reports *every* existing file as executable
+there, so the check below would pass vacuously -- a guard that reads like protection while
+guaranteeing nothing, which is worse than not asking. What covers Windows instead is the
+``OSError`` handler: the OS refuses to start the script, and that is reported with its reason.
+
+Named rather than inlined as ``os.name == "posix"`` so the assumption is visible at module
+level, and so a test can reach *both* branches on either platform. Patching ``os.name`` to
+get there is not an option -- it is read by :mod:`pathlib` at import, and forcing it makes
+``Path`` unconstructible.
+"""
+
 
 @task("setup", "run the repository's own environment setup hook", section="Dev")
 def setup(cfg: Config) -> None:
@@ -87,11 +101,7 @@ def setup(cfg: Config) -> None:
     if not hook.is_file():
         print(f"[INFO] no {HOOK}; nothing to provision")
         return
-    # POSIX-only, because `os.access(X_OK)` cannot answer this on Windows: there is no
-    # execute bit, so it reports *every* existing file as executable and the check would
-    # pass vacuously. Asking anyway is worse than not asking -- it reads like a guard while
-    # guaranteeing nothing. What covers Windows is the OSError below.
-    if os.name == "posix" and not os.access(hook, os.X_OK):
+    if CHECKS_EXECUTABLE_BIT and not os.access(hook, os.X_OK):
         raise Failed(1, f"{HOOK} is not executable -- run `chmod +x {HOOK}`")
     try:
         tool(str(hook), cwd=cfg.root)

--- a/src/rhiza_task/tasks/setup.py
+++ b/src/rhiza_task/tasks/setup.py
@@ -31,8 +31,12 @@ to be spelled the same on apt and brew; ``libgl1-mesa-glx`` is not, and a list c
 would be a schema this package then had to keep honest across three package managers, for the
 subset of needs that happen to be a package name.
 
-The hook is POSIX shell by name and by nature. A Windows consumer needs their own mechanism;
-this task is not it.
+The hook is POSIX shell by name and by nature, and Windows is where that shows. The
+executable check is skipped there -- ``os.access(X_OK)`` reports every existing file as
+executable, so asking would be a guard that guarantees nothing -- and the OS refusing to run
+a ``.sh`` is reported as a failure with the reason attached rather than as a traceback. A
+project that must provision on Windows needs its own arrangement; this task will tell you
+clearly that it could not.
 """
 
 from __future__ import annotations
@@ -83,6 +87,17 @@ def setup(cfg: Config) -> None:
     if not hook.is_file():
         print(f"[INFO] no {HOOK}; nothing to provision")
         return
-    if not os.access(hook, os.X_OK):
+    # POSIX-only, because `os.access(X_OK)` cannot answer this on Windows: there is no
+    # execute bit, so it reports *every* existing file as executable and the check would
+    # pass vacuously. Asking anyway is worse than not asking -- it reads like a guard while
+    # guaranteeing nothing. What covers Windows is the OSError below.
+    if os.name == "posix" and not os.access(hook, os.X_OK):
         raise Failed(1, f"{HOOK} is not executable -- run `chmod +x {HOOK}`")
-    tool(str(hook), cwd=cfg.root)
+    try:
+        tool(str(hook), cwd=cfg.root)
+    except OSError as exc:
+        # Not a Windows special case, though it is how Windows arrives: the OS refuses to
+        # execute the file at all. A malformed shebang on POSIX raises ENOEXEC through the
+        # same path. Either way an unhandled OSError would surface as a traceback, which is
+        # a poor way to learn that a provisioning script cannot start.
+        raise Failed(1, f"could not run {HOOK}: {exc}") from exc

--- a/src/rhiza_task/tasks/setup.py
+++ b/src/rhiza_task/tasks/setup.py
@@ -1,0 +1,88 @@
+"""The repository's own environment hook: the seam a template cannot ship.
+
+A rhiza-managed project may need a **native binary** in place before any gate can run --
+graphviz for a docs plugin, ``libpq`` for psycopg, pandoc, an ODBC driver. The template
+owns every configuration file in such a repository, so there was nowhere to put that step,
+and the answer rhiza documented did not work.
+
+That answer was to shadow ``install`` in ``local.mk``. It never ran. The Makefile is a shim
+whose ``%:`` catch-all forwards the *goal* to this CLI, and ``install`` is a prerequisite
+**here** rather than at make level -- so ``make test`` resolves it in :mod:`rhiza_task.runner`
+and never consults a make rule of that name. CI is worse: every reusable workflow invokes
+``uvx rhiza-task <gate>`` directly and never runs make at all. The recipe fired only if
+someone typed ``make install`` by hand, which is exactly when a consumer would test it and
+conclude it worked.
+
+So the hook belongs where ``install`` is, and this is it. ``install`` is the prerequisite of
+essentially every gate, in all three language layers, which is what makes one insertion point
+enough: local ``make test``, GitHub Actions, GitLab CI and the devcontainer's ``make install``
+all arrive here without a workflow edit between them.
+
+**This is not the package growing a package manager**, which :mod:`rhiza_task.tasks.lfs`
+rules out: a runner provisioned by ``uvx`` should not shell out to ``sudo apt-get`` as a
+side effect of a target someone typed. That rule is about *this* package owning
+apt/brew/winget logic and its liability. Running a script the repository committed inverts
+it -- the CLI decides *when*, the repository decides *what*, and the platform detection
+stays with the people who know which platforms they build on.
+
+It is also why there is no ``system-packages = [...]`` setting instead. ``graphviz`` happens
+to be spelled the same on apt and brew; ``libgl1-mesa-glx`` is not, and a list cannot express
+"download this tarball" -- which is precisely what rhiza itself does for tectonic. A list
+would be a schema this package then had to keep honest across three package managers, for the
+subset of needs that happen to be a package name.
+
+The hook is POSIX shell by name and by nature. A Windows consumer needs their own mechanism;
+this task is not it.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..config import Config
+from ..spec import Failed, task
+from ..uv import tool
+
+HOOK = "local-setup.sh"
+"""The repo-owned hook, at the repository root.
+
+A fixed name rather than a setting, for the same reason the Makefile hard-codes
+``-include local.mk``: a seam whose *location* is configurable has to be discovered before it
+can be used, and there is nothing a project could express by moving it. It sits beside
+``local.mk`` and is committed for the same reason -- anything CI invokes has to be in the
+repository.
+"""
+
+
+@task("setup", "run the repository's own environment setup hook", section="Dev")
+def setup(cfg: Config) -> None:
+    """Run ``local-setup.sh`` if the repository has one.
+
+    The asymmetry between the two failure modes is the whole design. A repository with no
+    hook is a genuine no-op, so it skips. A hook that exists but is not executable is a
+    mistake someone made while expecting it to run, so it fails rather than passing quietly
+    -- that is the case a skip would turn into the silent-green outcome this hook exists to
+    remove.
+
+    **An absent hook succeeds rather than skipping**, and that is not the usual call in this
+    package. :class:`~rhiza_task.spec.Skip` means work was asked for and did not happen,
+    which is why ``--strict`` promotes it to a failure: CI can then assert that a gate
+    measured something. Nothing was asked for here. Most repositories need no native
+    provisioning at all, so skipping would make every ``--strict`` invocation fail on the
+    common case -- ``book --strict`` reaches this through five prerequisites -- and a switch
+    that cannot be used is worth less than the line it prints. The INFO line is what keeps
+    the outcome legible.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Failed: When the hook is not executable, or exits non-zero.
+    """
+    hook = cfg.root / HOOK
+    if not hook.is_file():
+        print(f"[INFO] no {HOOK}; nothing to provision")
+        return
+    if not os.access(hook, os.X_OK):
+        raise Failed(1, f"{HOOK} is not executable -- run `chmod +x {HOOK}`")
+    tool(str(hook), cwd=cfg.root)

--- a/tests/test_dev_tasks.py
+++ b/tests/test_dev_tasks.py
@@ -487,16 +487,18 @@ class TestSetupHook:
         Skipping here would recreate the silent-green failure the hook exists to remove --
         the author wrote provisioning, believed it ran, and nothing said otherwise.
 
-        ``os.name`` is pinned rather than assumed: the suite runs on Windows too, where
-        ``chmod`` cannot clear an execute bit that does not exist, so the unpinned version of
-        this test passed on POSIX and failed on all four Windows cells.
+        Both the platform flag and ``os.access`` are pinned rather than assumed, because the
+        suite runs on Windows too and neither holds there: ``chmod`` cannot clear an execute
+        bit that does not exist, and ``os.access`` answers True regardless. Relying on the
+        filesystem passed on POSIX and failed on all four Windows cells.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
             monkeypatch: pytest's patcher.
         """
-        monkeypatch.setattr(setup_tasks.os, "name", "posix")
+        monkeypatch.setattr(setup_tasks, "CHECKS_EXECUTABLE_BIT", True)
+        monkeypatch.setattr(setup_tasks.os, "access", lambda *_a, **_k: False)
         self._write(cfg, executable=False)
         with pytest.raises(Failed, match="chmod"):
             setup_tasks.setup(cfg)
@@ -517,7 +519,7 @@ class TestSetupHook:
             recorder: The uv recorder.
             monkeypatch: pytest's patcher.
         """
-        monkeypatch.setattr(setup_tasks.os, "name", "nt")
+        monkeypatch.setattr(setup_tasks, "CHECKS_EXECUTABLE_BIT", False)
         hook = self._write(cfg, executable=False)
         setup_tasks.setup(cfg)
         assert recorder.find(str(hook)).kind == "tool"

--- a/tests/test_dev_tasks.py
+++ b/tests/test_dev_tasks.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import pytest
 
 from rhiza_task.config import Config
+from rhiza_task.runner import Status, run
 from rhiza_task.spec import REGISTRY, Failed, Skip
 from rhiza_task.tasks import book as book_tasks
 from rhiza_task.tasks import doctor as doctor_module
 from rhiza_task.tasks import quality
+from rhiza_task.tasks import setup as setup_tasks
 
 from .conftest import Recorder
 
@@ -421,3 +423,111 @@ class TestHookInstall:
         quality.install_hooks(cfg)
         assert recorder.find("prek").flags == ["install", "-c", ".pre-commit-config.yaml"]
         assert recorder.find("prek").kwargs["check"] is False
+
+
+class TestSetupHook:
+    """The repo-owned environment hook, and the reason it hangs off ``install``."""
+
+    def _write(self, cfg: Config, *, executable: bool) -> Path:
+        """Write a hook into the throwaway repository.
+
+        Args:
+            cfg: The resolved config.
+            executable: Whether to set the execute bit.
+
+        Returns:
+            The hook's path.
+        """
+        hook = cfg.root / setup_tasks.HOOK
+        hook.write_text("#!/usr/bin/env bash\napt-get install -y graphviz\n")
+        hook.chmod(0o755 if executable else 0o644)
+        return hook
+
+    def test_no_hook_succeeds_rather_than_skipping(
+        self, cfg: Config, recorder: Recorder, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An absent hook is the absence of a request, so it is not a skip.
+
+        Deliberately not ``Skip``: ``--strict`` promotes a skip to a failure so CI can assert
+        a gate measured something, and most repositories need no native provisioning -- so
+        skipping here would fail every ``--strict`` run on the common case. See
+        ``test_strict_does_not_fail_a_repository_that_needs_no_provisioning``.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            capsys: pytest's output capture.
+        """
+        setup_tasks.setup(cfg)
+        assert recorder.calls == []
+        assert "nothing to provision" in capsys.readouterr().out
+
+    def test_strict_does_not_fail_a_repository_that_needs_no_provisioning(
+        self, cfg: Config, recorder: Recorder
+    ) -> None:
+        """The regression this asymmetry exists to prevent, asserted through the runner.
+
+        ``--strict`` is what CI uses to demand that a gate did its work. If an absent hook
+        skipped, every ``--strict`` invocation would fail on a repository that simply has no
+        native dependencies -- and ``install`` would be reported ``blocked`` behind it.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        state = run(["install"], Config.load(root=cfg.root, strict=True))
+        assert [(r.name, r.status) for r in state.results] == [("setup", Status.OK), ("install", Status.OK)]
+        assert not state.failed
+
+    def test_a_hook_that_cannot_run_fails_rather_than_skipping(self, cfg: Config, recorder: Recorder) -> None:
+        """The asymmetry that is the whole point: a forgotten ``chmod`` must not pass quietly.
+
+        Skipping here would recreate the silent-green failure the hook exists to remove --
+        the author wrote provisioning, believed it ran, and nothing said otherwise.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        self._write(cfg, executable=False)
+        with pytest.raises(Failed, match="chmod"):
+            setup_tasks.setup(cfg)
+        assert recorder.calls == []
+
+    def test_runs_the_hook_from_the_repository_root(self, cfg: Config, recorder: Recorder) -> None:
+        """An absolute path, so it runs whatever the caller's working directory was.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        hook = self._write(cfg, executable=True)
+        setup_tasks.setup(cfg)
+        call = recorder.find(str(hook))
+        assert call.kind == "tool"
+        assert call.kwargs["cwd"] == cfg.root
+
+    @pytest.mark.parametrize("layer", ["python", "rust", "go"])
+    def test_every_layers_install_names_it(self, layer: str) -> None:
+        """The wiring, per layer -- one insertion point is only enough if all three have it.
+
+        Asserted on the registry rather than on a run, because the failure this guards
+        against is a layer added later without the prerequisite: an unresolvable one is
+        skipped rather than an error, so it would go unnoticed at runtime.
+
+        Args:
+            layer: The language layer.
+        """
+        assert "setup" in REGISTRY[f"{layer}:install"].needs
+
+    def test_the_hook_precedes_the_dependency_sync(self, cfg: Config, recorder: Recorder) -> None:
+        """A native library needed to *build* a wheel has to be there before ``uv sync``.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        self._write(cfg, executable=True)
+        run(["install"], cfg)
+        tools = recorder.tools()
+        assert tools.index(str(cfg.root / setup_tasks.HOOK)) < tools.index("sync")

--- a/tests/test_dev_tasks.py
+++ b/tests/test_dev_tasks.py
@@ -479,20 +479,80 @@ class TestSetupHook:
         assert [(r.name, r.status) for r in state.results] == [("setup", Status.OK), ("install", Status.OK)]
         assert not state.failed
 
-    def test_a_hook_that_cannot_run_fails_rather_than_skipping(self, cfg: Config, recorder: Recorder) -> None:
+    def test_a_hook_that_cannot_run_fails_rather_than_skipping(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The asymmetry that is the whole point: a forgotten ``chmod`` must not pass quietly.
 
         Skipping here would recreate the silent-green failure the hook exists to remove --
         the author wrote provisioning, believed it ran, and nothing said otherwise.
 
+        ``os.name`` is pinned rather than assumed: the suite runs on Windows too, where
+        ``chmod`` cannot clear an execute bit that does not exist, so the unpinned version of
+        this test passed on POSIX and failed on all four Windows cells.
+
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
         """
+        monkeypatch.setattr(setup_tasks.os, "name", "posix")
         self._write(cfg, executable=False)
         with pytest.raises(Failed, match="chmod"):
             setup_tasks.setup(cfg)
         assert recorder.calls == []
+
+    def test_the_executable_check_is_not_asked_on_windows(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows has no execute bit, so the check would pass vacuously; it is not made.
+
+        ``os.access(X_OK)`` reports *every* existing file as executable there, which is why
+        this cannot be one code path with a platform-independent check: a guard that always
+        passes reads like protection while providing none. The hook is attempted instead, and
+        the OS's refusal is what reports it.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(setup_tasks.os, "name", "nt")
+        hook = self._write(cfg, executable=False)
+        setup_tasks.setup(cfg)
+        assert recorder.find(str(hook)).kind == "tool"
+
+    def test_a_hook_the_os_refuses_to_start_fails_with_the_reason(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OSError is reported as a failure, not raised as a traceback.
+
+        How Windows arrives at a `.sh`, and how POSIX arrives at a malformed shebang
+        (ENOEXEC). Either way the script cannot start, and a traceback is a poor way to learn
+        that a provisioning step never began.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+        """
+        self._write(cfg, executable=True)
+
+        def refuse(*_args: str, **_kwargs: object) -> int:
+            """Stand in for an OS that will not execute the file.
+
+            Args:
+                *_args: Ignored.
+                **_kwargs: Ignored.
+
+            Raises:
+                OSError: Always.
+            """
+            raise OSError("Exec format error")
+
+        monkeypatch.setattr(setup_tasks, "tool", refuse)
+        with pytest.raises(Failed, match=r"could not run local-setup\.sh: Exec format error"):
+            setup_tasks.setup(cfg)
 
     def test_runs_the_hook_from_the_repository_root(self, cfg: Config, recorder: Recorder) -> None:
         """An absolute path, so it runs whatever the caller's working directory was.

--- a/tests/test_language_layers.py
+++ b/tests/test_language_layers.py
@@ -182,7 +182,10 @@ class TestResolution:
         """
         monkeypatch.setattr(rust_tasks, "have", lambda _: True)
         state = runner.run(["rust:test", "test"], Config.load(root=crate))
-        assert [r.name for r in state.results] == ["install", "cargo-tools", "test"]
+        # `setup` leads because every layer's `install` names it -- the repo-owned
+        # environment hook, which skips here since the crate ships none. Spelled out rather
+        # than sliced off, so that a prerequisite silently disappearing still fails this.
+        assert [r.name for r in state.results] == ["setup", "install", "cargo-tools", "test"]
         # One `test`, not two: `install` and `cargo-tools` ran once each, and the two
         # spellings of the gate itself resolved to the same registry key.
         assert [c.flags[0] for c in recorder.calls if c.tool == "cargo"] == ["fetch", "nextest", "test"]


### PR DESCRIPTION
## The problem

A rhiza-managed project may need a **native binary** before any gate can run — graphviz for a docs plugin, `libpq` for psycopg, pandoc. The template owns every configuration file in such a repository, so there was nowhere to put that step, and **the workaround rhiza documented never ran.**

That workaround (`docs/guides/CUSTOMIZATION.md`, using graphviz as its literal worked example) was to shadow `install` in `local.mk`. It fires in neither place that matters:

- **Locally**, the Makefile shim's `%:` catch-all forwards the *goal* to this CLI, and `install` is a prerequisite **here** rather than at make level — so `make test` resolves it in `runner.py` and never consults a make rule of that name.
- **In CI**, worse: all sixteen gate invocations across rhiza's reusable workflows are `uvx "$RHIZA_TASK" <task>`. make is never used for a gate at all.

The recipe fired only if someone typed `make install` by hand — which is exactly when a consumer would test it and conclude it worked.

## The change

A `setup` task runs a repo-owned `local-setup.sh`, and **all three language layers name it as a prerequisite of `install`**. That is what makes one insertion point enough: `install` is the prerequisite of essentially every gate, so local `make test`, GitHub Actions, GitLab CI and the devcontainer's `make install` all arrive here with no workflow edit between them. It runs before `uv sync` / `cargo fetch` / `go mod download`, because a native library needed to *build* a wheel has to be there first.

**This is not the package growing a package manager**, which `lfs.py` rules out. That rule is about owning apt/brew/winget logic and its liability; running a script the repository committed inverts it — the CLI decides *when*, the repository decides *what*. It is also why there is no `system-packages = [...]` setting: `graphviz` is spelled the same on apt and brew, `libgl1-mesa-glx` is not, and a list cannot express "download this tarball" — which is what rhiza itself does for tectonic.

## Outcomes, and the one that is not obvious

| case | outcome |
|---|---|
| hook present, executable | runs it; its exit code propagates unflattened |
| present, **not executable** | **fails**, with the `chmod +x` hint |
| absent | **succeeds** (`[INFO] no local-setup.sh`) |

The last row is the one place in this package where "nothing happened" is not a `skipped`, and it is deliberate. `Skip` means work was asked for and did not happen, which is why `--strict` promotes it to a failure. Nothing is asked for by a repository that declares no hook — and since most declare none, skipping would fail **every** `--strict` invocation on the common case, `book --strict` included, five prerequisites down, with `install` reported `blocked` behind it.

That was a real regression in the first draft of this branch, caught before commit and now pinned by `test_strict_does_not_fail_a_repository_that_needs_no_provisioning`, which asserts it through the runner rather than the task body.

The non-executable case fails rather than skipping for the mirror-image reason: a provisioning step someone wrote and believed was running is exactly what must not pass quietly.

## Verification

- **398 tests pass**, 100% coverage floor held (`setup.py` 16/16).
- `typecheck`, `complexity`, `docs-coverage`, `deps`, `security`, `rhiza-test`, `docs-examples`, `fmt` all green.
- **Exercised for real**, since the suite deliberately never runs a subprocess: hook runs and writes a sentinel; a hook exiting 7 gives exit **7**; non-executable gives exit 1; absent gives exit 0; `install --strict` with no hook gives exit 0.

## Notes for the release

Cut as **v1.4.0** (`minor`). A suggested `⚠️ Upgrade note` is worth considering: `local-setup.sh` is now an *executed* filename, so a repository that already has one for another purpose would start running it on every gate.

rhiza's side is a separate PR — the docs there already replace the dead recipe; the pin bump and its guard tests follow this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)