### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.4.0] - 2026-08-25
+
+### 🚀 Features
+
+- Run a repo-owned setup hook as part of install
+
+### 🐛 Bug Fixes
+
+- Do not ask an executable question Windows cannot answer
+- Reach both executable-check branches without patching os.name
+
 ## [1.3.1] - 2026-08-23
 
 ### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The rhiza developer tasks as a **pinned CLI** rather than a synced make layer �
 of task names across Python, Rust and Go**.
 
 ```bash
-uvx rhiza-task@1.3.1 test
+uvx rhiza-task@1.4.0 test
 ```
 
 📖 **[Documentation](https://jebel-quant.github.io/rhiza-task/)** — the task catalogue,
@@ -63,9 +63,9 @@ v1.3.3 and hope nobody edited them."
 Nothing to install. `uvx` provisions it per invocation:
 
 ```bash
-uvx rhiza-task@1.3.1 list          # what is available
-uvx rhiza-task@1.3.1 all           # every gate, as CI runs them
-uvx rhiza-task@1.3.1 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.4.0 list          # what is available
+uvx rhiza-task@1.4.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.4.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 Task names are unchanged from the retired make layer, so a repo that wants `make test` to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,8 +87,8 @@ and wins when both are present.
 value a task will actually see:
 
 ```bash
-uvx rhiza-task@1.3.1 print coverage_fail_under
-uvx rhiza-task@1.3.1 print COVERAGE_FAIL_UNDER   # either spelling
+uvx rhiza-task@1.4.0 print coverage_fail_under
+uvx rhiza-task@1.4.0 print COVERAGE_FAIL_UNDER   # either spelling
 ```
 
 Field names are the lowercased make variables, so the mapping to what a consumer already
@@ -100,7 +100,7 @@ In the two string-valued layers, an empty value **leaves the layer below it alon
 than resolving to `""`:
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.3.1 ci-os-matrix   # still the default
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.4.0 ci-os-matrix   # still the default
 ```
 
 That is make's `$(or ...)` rule, and the reusable workflows depend on it: `rhiza_ci.yml`
@@ -228,7 +228,7 @@ layers = ["rust"]
 ```
 
 ```bash
-RHIZA_LAYERS=rust uvx rhiza-task@1.3.1 test
+RHIZA_LAYERS=rust uvx rhiza-task@1.4.0 test
 ```
 
 ## No `+=` successor, and none needed

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ language layers this repository does not have.
 
 You should. An unpinned task layer can change under a green pull request without a commit
 touching your repository — which is the failure mode the whole package exists to remove.
-`rhiza-task@1.3.1` makes a bump a deliberate commit that carries whatever fixes it wants.
+`rhiza-task@1.4.0` makes a bump a deliberate commit that carries whatever fixes it wants.
 
 ### A gate says `skipped`. Is that bad?
 
@@ -30,7 +30,7 @@ folder. The reason is printed next to it.
 It *is* bad when the subject was supposed to be there. That is what `--strict` is for:
 
 ```bash
-uvx rhiza-task@1.3.1 all --strict
+uvx rhiza-task@1.4.0 all --strict
 ```
 
 In a consumer repository `--strict` is usually the right setting, because a skip means a
@@ -68,7 +68,7 @@ Two likely causes:
 ### How do I run the gates for another repository?
 
 ```bash
-uvx rhiza-task@1.3.1 all --root ../other-repo
+uvx rhiza-task@1.4.0 all --root ../other-repo
 ```
 
 ## Configuration
@@ -78,7 +78,7 @@ uvx rhiza-task@1.3.1 all --root ../other-repo
 Check what actually resolved, rather than what you wrote:
 
 ```bash
-uvx rhiza-task@1.3.1 print coverage_fail_under
+uvx rhiza-task@1.4.0 print coverage_fail_under
 ```
 
 The usual causes, in order of likelihood:
@@ -101,7 +101,7 @@ Move anything CI depends on into `rhiza.toml` or `[tool.rhiza-task]`.
 ### Why is an empty value not empty?
 
 ```bash
-RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.3.1 ci-os-matrix   # still ["ubuntu-latest"]
+RHIZA_CI_OS_MATRIX= uvx rhiza-task@1.4.0 ci-os-matrix   # still ["ubuntu-latest"]
 ```
 
 That is make's `$(or ...)` rule, kept because the reusable workflows depend on it:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,13 +10,13 @@ icon: material/rocket-launch
 project's dependencies:
 
 ```bash
-uvx rhiza-task@1.3.1 list          # what is available
-uvx rhiza-task@1.3.1 all           # every gate, as CI runs them
-uvx rhiza-task@1.3.1 test --strict # fail rather than skip when a gate measures nothing
+uvx rhiza-task@1.4.0 list          # what is available
+uvx rhiza-task@1.4.0 all           # every gate, as CI runs them
+uvx rhiza-task@1.4.0 test --strict # fail rather than skip when a gate measures nothing
 ```
 
 !!! tip "Pin the version"
-    `rhiza-task@1.3.1` rather than `rhiza-task`. The pin is the whole point of the
+    `rhiza-task@1.4.0` rather than `rhiza-task`. The pin is the whole point of the
     package — an unpinned task layer is a layer that can change under a green pull
     request without a commit touching your repository. Bumping it is then a deliberate
     commit that carries whatever the new version wants.
@@ -30,7 +30,7 @@ it would have to provision the runtime that every task already runs under.
 Start by asking what this repository has:
 
 ```bash
-uvx rhiza-task@1.3.1 list
+uvx rhiza-task@1.4.0 list
 ```
 
 ```text
@@ -56,7 +56,7 @@ other layers call things.
 Then run the aggregate:
 
 ```bash
-uvx rhiza-task@1.3.1 all
+uvx rhiza-task@1.4.0 all
 ```
 
 ## `run`, and the bare shorthand
@@ -64,9 +64,9 @@ uvx rhiza-task@1.3.1 all
 `rhiza-task <task>` is shorthand for `rhiza-task run <task>`:
 
 ```bash
-uvx rhiza-task@1.3.1 test          # shorthand
-uvx rhiza-task@1.3.1 run test      # the same thing
-uvx rhiza-task@1.3.1 run fmt test  # several, in order, prerequisites deduplicated
+uvx rhiza-task@1.4.0 test          # shorthand
+uvx rhiza-task@1.4.0 run test      # the same thing
+uvx rhiza-task@1.4.0 run fmt test  # several, in order, prerequisites deduplicated
 ```
 
 This is a compatibility contract rather than sugar. The reusable workflows and a
@@ -98,7 +98,7 @@ different bundles installed. But a skip is also how a gate silently stops measur
 anything — so `--strict` turns every skip into a failure:
 
 ```bash
-uvx rhiza-task@1.3.1 all --strict
+uvx rhiza-task@1.4.0 all --strict
 ```
 
 !!! note "Which one belongs in your CI"
@@ -145,7 +145,7 @@ rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.3.1
+RHIZA_TASK := rhiza-task@1.4.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -167,11 +167,11 @@ same configuration the tasks read:
     enable-cache: true
 
 - name: Gates
-  run: uvx rhiza-task@1.3.1 all --strict
+  run: uvx rhiza-task@1.4.0 all --strict
 ```
 
 ```bash
-uvx rhiza-task@1.3.1 ci-os-matrix
+uvx rhiza-task@1.4.0 ci-os-matrix
 ```
 
 ```text

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ hide:
 ## 📋 Overview
 
 ```bash
-uvx rhiza-task@1.3.1 test
+uvx rhiza-task@1.4.0 test
 ```
 
 There is nothing to install and nothing to sync. One command runs a project's gates, and
@@ -66,7 +66,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Tasks, grouped by section, with prerequisites and a one-line description.
 
     ```bash
-    uvx rhiza-task@1.3.1 list
+    uvx rhiza-task@1.4.0 list
     ```
 
     [→ The task catalogue](tasks.md)
@@ -78,7 +78,7 @@ files at tag v1.3.3 and hope nobody edited them."
     The aggregate CI runs: format, deps, test, docs, security, licence, types.
 
     ```bash
-    uvx rhiza-task@1.3.1 all
+    uvx rhiza-task@1.4.0 all
     ```
 
     [→ Getting started](getting_started.md)
@@ -90,7 +90,7 @@ files at tag v1.3.3 and hope nobody edited them."
     Six configuration layers, collapsed to the one value a task will actually see.
 
     ```bash
-    uvx rhiza-task@1.3.1 print coverage_fail_under
+    uvx rhiza-task@1.4.0 print coverage_fail_under
     ```
 
     [→ Configuration](configuration.md)

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -63,7 +63,7 @@ docs-examples` now runs the fence and compares.
 that did not win:
 
 ```bash
-uvx rhiza-task@1.3.1 rust:test
+uvx rhiza-task@1.4.0 rust:test
 ```
 
 Pinning the layer list does the same thing globally:
@@ -85,7 +85,7 @@ layer showed, having synced exactly one fragment.
 `--all` answers the question the make layer could not:
 
 ```bash
-uvx rhiza-task@1.3.1 list --all   # what the layers you do not have call things
+uvx rhiza-task@1.4.0 list --all   # what the layers you do not have call things
 ```
 
 ## A missing name is `None`, not an error

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,14 +26,14 @@ rewrite.
 Either invoke the CLI directly in CI and locally:
 
 ```bash
-uvx rhiza-task@1.3.1 all --strict
+uvx rhiza-task@1.4.0 all --strict
 ```
 
 …or keep `make test` working with a repo-owned `Makefile` that forwards — one rule:
 
 ```makefile
 # Repo-owned. Nothing syncs this file, and nothing overwrites it.
-RHIZA_TASK := rhiza-task@1.3.1
+RHIZA_TASK := rhiza-task@1.4.0
 
 .PHONY: test fmt typecheck all
 test fmt typecheck all:
@@ -133,7 +133,7 @@ order.
 Add `--strict` in CI once the migration is quiet:
 
 ```bash
-uvx rhiza-task@1.3.1 all --strict
+uvx rhiza-task@1.4.0 all --strict
 ```
 
 A skip in a consumer repository means a gate lost its subject, and `--strict` is what turns

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -129,7 +129,7 @@ Windows. That probe is not incidental complexity; it is the price of the impleme
 language.
 
 Replacing the layer with a published package addresses both at once. A dependency
-\emph{is} a reference: \texttt{uvx rhiza-task@1.3.1 test} names a version, resolves it, and
+\emph{is} a reference: \texttt{uvx rhiza-task@1.4.0 test} names a version, resolves it, and
 leaves nothing in the working tree to drift or exclude. And a package is written in a
 language with data structures, so the retry loop becomes a \texttt{for} statement.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "1.3.1"
+version = "1.4.0"
 description = "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -3,7 +3,7 @@
 What this replaces, per consumer repository: ``.rhiza/rhiza.mk`` (200 lines) and the ten
 fragments in ``.rhiza/make.d/`` (823 lines), synced at a template tag and excluded,
 shadowed or patched wherever a project disagreed with them. Here they are a dependency
-pin -- ``uvx rhiza-task@1.3.1 test`` -- so there is nothing to copy, nothing to exclude in
+pin -- ``uvx rhiza-task@1.4.0 test`` -- so there is nothing to copy, nothing to exclude in
 ``template.yml``, and nothing to drift.
 
 Sibling to ``pytest-rhiza``, which did the same for ``.rhiza/tests``.
@@ -23,4 +23,4 @@ __all__ = ["__version__"]
 
 # Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
 # for this file but not for pyproject.toml itself.
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Bumps `1.3.1` → `1.4.0`.

## Why minor

Three commits since `v1.3.1`, one of which is a `feat:` — `run a repo-owned setup hook
as part of install`. The two `fix:` commits sit on top of that feature. No breaking
changes (`0` commits carrying `!` or `BREAKING CHANGE`).

## Files the bump touched

| File | What moved |
| --- | --- |
| `pyproject.toml` | `[project] version` (bump-my-version's PEP 621 provider — this repo declares no `current_version` key) |
| `src/rhiza_task/__init__.py` | package version |
| `uv.lock` | this package's own locked version, so `uv lock --check` in `install` stays green |
| `README.md`, `docs/*.md` (6 files), `docs/paper/paper.tex` | the `rhiza-task@X.Y.Z` usage pins |
| `CHANGELOG.md` | the new section below |

No self-referencing `uses: Jebel-Quant/rhiza-task@...` pin exists in `.github/`, so
there is no stub pin to move — confirmed by grep.

## Changelog section added

```
## [1.4.0] - 2026-08-25

### 🚀 Features

- Run a repo-owned setup hook as part of install

### 🐛 Bug Fixes

- Do not ask an executable question Windows cannot answer
- Reach both executable-check branches without patching os.name
```

Generated with `git-cliff --unreleased --tag v1.4.0 --prepend`. As `CLAUDE.md` warns,
`--prepend` displaced the `# Changelog` title; it was restored, and the diff is the new
section only — no prior section was touched.

## Merging this PR does not publish the release

There is **no tag yet**, deliberately. A squash-merge replaces this branch's commit, so a
tag cut here would name a SHA that never lands on `main`. The tag is created afterwards,
from the merged commit, by a second `/rhiza:release` run.
