### PR TITLE
fix: run the setup hook through sh where the platform cannot exec it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,35 @@ jobs:
           uv run --python ${{ matrix.python-version }} rhiza-task doctor
           uv run --python ${{ matrix.python-version }} rhiza-task todos
 
+      # The bug this step exists for is #148: four red Windows cells at 1.4.0 with every
+      # other job in the run green. `setup` exec'd the repository's own `local-setup.sh`,
+      # Windows answered `%1 is not a valid Win32 application`, and because `install` names
+      # `setup` and every gate names `install`, a consumer whose matrix included
+      # `windows-latest` could not adopt the hook at all. Nothing here caught it: the suite
+      # asserts the argument vector, and this vector was well-formed and unrunnable -- the
+      # exact hazard the language-layer jobs below exist for, arriving at the one task those
+      # jobs cannot host. `setup` needs a hook at a repository root, and this repository
+      # cannot commit one of its own: a real `local-setup.sh` here would run on every gate,
+      # forever. So the root is built in $RUNNER_TEMP, which also keeps the step from
+      # provisioning anything -- the rule the CLI smoke above states.
+      #
+      # Left on the runner's default shell rather than `shell: bash`, and that is the whole
+      # assertion on Windows: `setup` finds its `sh` with `shutil.which`, git-bash puts its
+      # own `usr/bin` on PATH for anything it launches, so a bash step would resolve one even
+      # from an image that did not offer it to a normal job. The default shell is the PATH a
+      # consumer's job actually has.
+      #
+      # The hook writes a marker and the third line demands it, rather than reading `ok
+      # setup` and stopping. An *absent* hook reports ok too, deliberately -- see
+      # tasks/setup.py -- so a step that only checked the exit status would stay green if the
+      # file never arrived, which is the silent green this whole task exists to remove.
+      - name: Setup-hook smoke (the one gate that starts a POSIX script)
+        if: ${{ !cancelled() }}
+        run: |
+          uv run --python ${{ matrix.python-version }} python -c "import os, pathlib; d = pathlib.Path(os.environ['RUNNER_TEMP']) / 'hook-repo'; d.mkdir(exist_ok=True); h = d / 'local-setup.sh'; h.write_text('#!/bin/sh\nprintf ran > ran.txt\n'); h.chmod(0o755)"
+          uv run --python ${{ matrix.python-version }} rhiza-task setup --root ${{ runner.temp }}/hook-repo
+          uv run --python ${{ matrix.python-version }} python -c "import os, pathlib, sys; sys.exit(None if (pathlib.Path(os.environ['RUNNER_TEMP']) / 'hook-repo' / 'ran.txt').is_file() else 'the hook reported ok without running')"
+
   # ruff.toml is 9 KB of deliberate rule selection, and this job is not the only thing
   # enforcing it: `.pre-commit-config.yaml` carries the same ruff hooks, so `rhiza-task
   # fmt` -- and the dogfood `all` in the `gates` job below -- runs them too. It was the

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -231,6 +231,15 @@ apt/brew/winget logic — the rule `lfs-install` states.
 A hook that exists but is not executable **fails**, with the `chmod` hint — a provisioning
 step someone wrote and believed was running is exactly what must not pass quietly.
 
+**Windows runs the same hook**, handed to `sh` rather than started directly, because the OS
+execs no `.sh` — it answers *%1 is not a valid Win32 application* before the shebang is read.
+GitHub's `windows-latest` runners ship git-bash, so there is an `sh` on PATH to hand it to,
+and one hook file still covers every platform. Two consequences: the shebang is **not**
+consulted there, so a hook that means `bash` should keep to POSIX shell; and a machine with no
+`sh` at all fails naming `sh`, rather than naming the hook that never started. The execute bit
+is not asked about on Windows either — `os.access(X_OK)` calls every existing file executable
+there, so the question would pass vacuously.
+
 An absent hook, by contrast, **succeeds**; it does not skip. That is deliberate and is the
 one place in this package where "nothing happened" is not a `skipped`. `Skip` means work was
 asked for and did not happen, which is why `--strict` promotes it to a failure. Nothing is

--- a/src/rhiza_task/tasks/setup.py
+++ b/src/rhiza_task/tasks/setup.py
@@ -31,17 +31,33 @@ to be spelled the same on apt and brew; ``libgl1-mesa-glx`` is not, and a list c
 would be a schema this package then had to keep honest across three package managers, for the
 subset of needs that happen to be a package name.
 
-The hook is POSIX shell by name and by nature, and Windows is where that shows. The
-executable check is skipped there -- ``os.access(X_OK)`` reports every existing file as
-executable, so asking would be a guard that guarantees nothing -- and the OS refusing to run
-a ``.sh`` is reported as a failure with the reason attached rather than as a traceback. A
-project that must provision on Windows needs its own arrangement; this task will tell you
-clearly that it could not.
+The hook is POSIX shell by name and by nature, and Windows is where that shows -- but not, as
+this module first had it, as a wall. Windows cannot ``exec`` a ``.sh`` at all: the OS answers
+*%1 is not a valid Win32 application* before the shebang is read, so the first version of this
+task reported that as a failure and told the reader their platform needed its own arrangement.
+Which was one insertion point short of the design's own claim -- ``install`` is a prerequisite
+of every gate, so a consumer whose matrix includes ``windows-latest`` could not adopt the hook
+at all, even for a dependency that only matters on one job. See #148.
+
+So on a platform with no execute bit the hook is handed to ``sh`` rather than started
+directly, and there is one to hand it to: GitHub's ``windows-latest`` runners ship git-bash,
+whose ``sh`` is on PATH and is what :func:`shutil.which` finds. One hook file still covers
+every platform, which is the whole point of putting the seam here; a project that provisions
+differently per OS branches inside the script, where the platform knowledge already is.
+
+Two things follow from handing it to ``sh`` instead of exec'ing it, and both are why the
+POSIX branch is left alone rather than unified with it. The shebang is **not** consulted --
+a hook whose first line names ``python3`` runs under python3 on POSIX and under ``sh`` on
+Windows -- which is what the ``.sh`` in the name is promising and this docstring is repeating.
+And a machine with no ``sh`` on PATH is told *that*, rather than being handed the Win32 error
+from an exec that was never going to work.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
+from pathlib import Path
 
 from ..config import Config
 from ..spec import Failed, task
@@ -57,19 +73,63 @@ can be used, and there is nothing a project could express by moving it. It sits 
 repository.
 """
 
-CHECKS_EXECUTABLE_BIT = os.name == "posix"
-"""Whether this platform has an execute bit worth asking about.
+POSIX = os.name == "posix"
+"""Whether this platform can start the hook itself.
 
-Windows does not. ``os.access(path, os.X_OK)`` reports *every* existing file as executable
-there, so the check below would pass vacuously -- a guard that reads like protection while
-guaranteeing nothing, which is worse than not asking. What covers Windows instead is the
-``OSError`` handler: the OS refuses to start the script, and that is reported with its reason.
+One platform fact with two consequences, which is why it is one constant rather than two.
+
+It decides whether there is an **execute bit worth asking about**. Windows has none:
+``os.access(path, os.X_OK)`` reports *every* existing file as executable there, so the check
+below would pass vacuously -- a guard that reads like protection while guaranteeing nothing,
+which is worse than not asking.
+
+And it decides **how the hook is started**: exec'd directly where the OS honours a shebang,
+handed to ``sh`` where it does not. The two answers move together because they are the same
+question asked twice -- a platform that has no execute bit is a platform that will not start
+the file for you.
 
 Named rather than inlined as ``os.name == "posix"`` so the assumption is visible at module
 level, and so a test can reach *both* branches on either platform. Patching ``os.name`` to
 get there is not an option -- it is read by :mod:`pathlib` at import, and forcing it makes
 ``Path`` unconstructible.
 """
+
+SHELL = "sh"
+"""The interpreter the hook is handed to where the platform cannot start it.
+
+``sh`` rather than ``bash``, because the hook's contract is POSIX shell and ``sh`` is the
+spelling git-bash, WSL and every POSIX system agree on. Not a setting: a repository that
+needs a different interpreter says so in its shebang, which is honoured everywhere the
+platform starts the file itself.
+"""
+
+
+def _command(hook: Path) -> tuple[str, ...]:
+    """Build the argument vector that starts the hook on this platform.
+
+    Args:
+        hook: The absolute path to the hook.
+
+    Returns:
+        The vector to hand to :func:`~rhiza_task.uv.tool`.
+
+    Raises:
+        Failed: When the platform cannot start the file and has no ``sh`` to do it.
+    """
+    if POSIX:
+        return (str(hook),)
+    # A missing shell fails rather than skipping, for the same reason a missing execute bit
+    # does: the repository asked for provisioning and it did not happen. It is deliberately
+    # not a `Guard` either -- a guard is declared on the task and would skip the *common*
+    # case, a repository with no hook at all, on any machine without `sh`.
+    shell = shutil.which(SHELL)
+    if shell is None:
+        raise Failed(
+            1,
+            f"could not run {HOOK}: no `{SHELL}` on PATH to run it with -- "
+            "install Git for Windows, whose git-bash provides one",
+        )
+    return (shell, str(hook))
 
 
 @task("setup", "run the repository's own environment setup hook", section="Dev")
@@ -95,19 +155,21 @@ def setup(cfg: Config) -> None:
         cfg: The resolved config.
 
     Raises:
-        Failed: When the hook is not executable, or exits non-zero.
+        Failed: When the hook is not executable, cannot be started, or exits non-zero.
     """
     hook = cfg.root / HOOK
     if not hook.is_file():
         print(f"[INFO] no {HOOK}; nothing to provision")
         return
-    if CHECKS_EXECUTABLE_BIT and not os.access(hook, os.X_OK):
+    if POSIX and not os.access(hook, os.X_OK):
         raise Failed(1, f"{HOOK} is not executable -- run `chmod +x {HOOK}`")
+    command = _command(hook)
     try:
-        tool(str(hook), cwd=cfg.root)
+        tool(*command, cwd=cfg.root)
     except OSError as exc:
-        # Not a Windows special case, though it is how Windows arrives: the OS refuses to
-        # execute the file at all. A malformed shebang on POSIX raises ENOEXEC through the
-        # same path. Either way an unhandled OSError would surface as a traceback, which is
-        # a poor way to learn that a provisioning script cannot start.
+        # Windows no longer arrives here -- `_command` hands it a shell rather than the
+        # script. What still does is a malformed shebang on POSIX, which raises ENOEXEC
+        # through this same path, and a resolved `sh` that will not start. Either way an
+        # unhandled OSError would surface as a traceback, which is a poor way to learn that
+        # a provisioning script cannot begin.
         raise Failed(1, f"could not run {HOOK}: {exc}") from exc

--- a/tests/test_dev_tasks.py
+++ b/tests/test_dev_tasks.py
@@ -443,6 +443,20 @@ class TestSetupHook:
         hook.chmod(0o755 if executable else 0o644)
         return hook
 
+    @pytest.fixture
+    def on_posix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pin the POSIX branch, for the tests that are about something other than platform.
+
+        The suite runs on ``windows-latest`` too, where the hook is handed to ``sh`` and the
+        vector gains a leading interpreter -- a real difference, and one with its own two
+        tests below. Everything else here asserts the *shape* of the invocation, so it pins
+        the branch rather than accommodating both and asserting neither precisely.
+
+        Args:
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(setup_tasks, "POSIX", True)
+
     def test_no_hook_succeeds_rather_than_skipping(
         self, cfg: Config, recorder: Recorder, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -497,46 +511,81 @@ class TestSetupHook:
             recorder: The uv recorder.
             monkeypatch: pytest's patcher.
         """
-        monkeypatch.setattr(setup_tasks, "CHECKS_EXECUTABLE_BIT", True)
+        monkeypatch.setattr(setup_tasks, "POSIX", True)
         monkeypatch.setattr(setup_tasks.os, "access", lambda *_a, **_k: False)
         self._write(cfg, executable=False)
         with pytest.raises(Failed, match="chmod"):
             setup_tasks.setup(cfg)
         assert recorder.calls == []
 
-    def test_the_executable_check_is_not_asked_on_windows(
+    def test_a_platform_that_cannot_start_the_hook_hands_it_to_a_shell(
         self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Windows has no execute bit, so the check would pass vacuously; it is not made.
+        """Windows execs no ``.sh``, so the hook is run *by* ``sh`` rather than *as* one.
 
-        ``os.access(X_OK)`` reports *every* existing file as executable there, which is why
-        this cannot be one code path with a platform-independent check: a guard that always
-        passes reads like protection while providing none. The hook is attempted instead, and
-        the OS's refusal is what reports it.
+        The failure this replaces was not a platform limitation but a wall: ``install`` is a
+        prerequisite of every gate, so a consumer whose matrix included ``windows-latest``
+        could not adopt the hook at all, whatever the hook did. GitHub's Windows runners ship
+        git-bash, so there is a shell to hand it to. See issue #148.
+
+        The execute bit is not asked about on the way past, and that is the same test as
+        before under a new name: ``os.access(X_OK)`` reports *every* existing file as
+        executable on Windows, so the guard would pass vacuously -- which is why the hook
+        here is written *without* the bit and still runs.
+
+        ``which`` is pinned rather than trusted, because this branch is exercised on POSIX
+        machines, where the answer would otherwise be a real path that differs per machine.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
             monkeypatch: pytest's patcher.
         """
-        monkeypatch.setattr(setup_tasks, "CHECKS_EXECUTABLE_BIT", False)
+        monkeypatch.setattr(setup_tasks, "POSIX", False)
+        monkeypatch.setattr(setup_tasks.shutil, "which", lambda name: f"C:\\Git\\{name}.exe")
         hook = self._write(cfg, executable=False)
         setup_tasks.setup(cfg)
-        assert recorder.find(str(hook)).kind == "tool"
+        call = recorder.find("C:\\Git\\sh.exe")
+        assert call.kind == "tool"
+        assert call.flags == [str(hook)]
+        assert call.kwargs["cwd"] == cfg.root
 
-    def test_a_hook_the_os_refuses_to_start_fails_with_the_reason(
+    def test_a_platform_with_no_shell_at_all_fails_with_that_reason(
         self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An OSError is reported as a failure, not raised as a traceback.
+        """The one Windows case still left, reported as itself rather than as ``WinError 193``.
 
-        How Windows arrives at a `.sh`, and how POSIX arrives at a malformed shebang
-        (ENOEXEC). Either way the script cannot start, and a traceback is a poor way to learn
-        that a provisioning step never began.
+        A failure rather than a skip, for the reason the missing execute bit is one: the
+        repository asked for provisioning and did not get it. Naming ``sh`` is what makes the
+        line actionable -- the Win32 error the exec used to produce named the hook instead,
+        which sent readers to look at a script that had never started.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
             monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(setup_tasks, "POSIX", False)
+        monkeypatch.setattr(setup_tasks.shutil, "which", lambda _name: None)
+        self._write(cfg, executable=True)
+        with pytest.raises(Failed, match=r"no `sh` on PATH"):
+            setup_tasks.setup(cfg)
+        assert recorder.calls == []
+
+    def test_a_hook_the_os_refuses_to_start_fails_with_the_reason(
+        self, cfg: Config, recorder: Recorder, monkeypatch: pytest.MonkeyPatch, on_posix: None
+    ) -> None:
+        """An OSError is reported as a failure, not raised as a traceback.
+
+        Windows no longer arrives here -- it is handed a shell instead. What still does is a
+        malformed shebang on POSIX (ENOEXEC), and a resolved ``sh`` that will not start. The
+        script cannot begin, and a traceback is a poor way to learn that.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+            monkeypatch: pytest's patcher.
+            on_posix: The pinned platform branch.
         """
         self._write(cfg, executable=True)
 
@@ -556,12 +605,13 @@ class TestSetupHook:
         with pytest.raises(Failed, match=r"could not run local-setup\.sh: Exec format error"):
             setup_tasks.setup(cfg)
 
-    def test_runs_the_hook_from_the_repository_root(self, cfg: Config, recorder: Recorder) -> None:
+    def test_runs_the_hook_from_the_repository_root(self, cfg: Config, recorder: Recorder, on_posix: None) -> None:
         """An absolute path, so it runs whatever the caller's working directory was.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            on_posix: The pinned platform branch.
         """
         hook = self._write(cfg, executable=True)
         setup_tasks.setup(cfg)
@@ -582,12 +632,13 @@ class TestSetupHook:
         """
         assert "setup" in REGISTRY[f"{layer}:install"].needs
 
-    def test_the_hook_precedes_the_dependency_sync(self, cfg: Config, recorder: Recorder) -> None:
+    def test_the_hook_precedes_the_dependency_sync(self, cfg: Config, recorder: Recorder, on_posix: None) -> None:
         """A native library needed to *build* a wheel has to be there before ``uv sync``.
 
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            on_posix: The pinned platform branch.
         """
         self._write(cfg, executable=True)
         run(["install"], cfg)


### PR DESCRIPTION
Closes #148.

## What was wrong

`setup` exec'd the repository's `local-setup.sh` directly, so Windows answered `%1 is not a valid Win32 application` before the script started. Because `install` names `setup` and essentially every gate names `install`, that was not a platform limitation but a wall — a consumer whose `ci-os-matrix` includes `windows-latest` could not adopt the hook at all, even for a dependency that only matters on one job.

## The fix

Issue option (1). On a platform with no execute bit the hook is handed to `sh` rather than started directly; GitHub's Windows runners ship git-bash, so `shutil.which("sh")` finds one. **One hook file still covers every platform**, which is the whole point of putting the seam at `install`. A machine with no `sh` fails naming `sh`, rather than handing back the Win32 error that named a hook which never began.

Two consequences, both documented in `tasks/setup.py` and `docs/tasks.md`:

- The shebang is **not** consulted on that branch — a hook meaning `bash` should keep to POSIX shell. This is why the POSIX branch is left exec'ing directly rather than unified with it.
- `CHECKS_EXECUTABLE_BIT` becomes `POSIX`. It was already the platform fact; it now decides both whether there is an execute bit worth asking about and whether the OS will start the file for you. The same question twice, so one constant.

## Why a CI step and not only tests

Nothing here caught the bug: the suite asserts the argument vector, and this vector was well-formed and unrunnable — the hazard the language-layer jobs exist for, at the one task those jobs cannot host, since `setup` needs a hook at a repository root and this repo cannot commit one of its own (it would run on every gate, forever).

So the `test` matrix gains a smoke step that builds a hook root in `$RUNNER_TEMP` and runs `rhiza-task setup --root` against it, on all twelve cells. It **demands the marker file** the hook writes rather than reading `ok setup`, because an absent hook reports ok too — deliberately — so an exit-status-only check would stay green if the file never arrived. It is left on the runner's default shell on purpose: `shell: bash` would put git-bash's `usr/bin` on PATH itself, which is exactly what is under test.

## Verification

`rhiza-task all`, `complexity`, `docs-examples` and `fmt` (actionlint included) all green locally; 401 tests, coverage still 100%; both `CLAUDE.md` layering greps clean. The non-POSIX branch was also run for real against `/bin/sh` here, including with the execute bit cleared.

## For whoever picks the version

A hook that previously **could not run** on Windows now runs there. It can only improve on an already-failing job — no consumer has a green Windows leg with a hook today — but the script does now execute on an OS it never reached, which is more than a patch usually carries.

And the release path from the issue still stands: `rhiza_ci.yml` pins `RHIZA_TASK: rhiza-task@1.4.0` inside the template, so a `rhiza-task` release alone does not reach consumer CI — it needs a `jebel-quant/rhiza` tag bump too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)