### PR TITLE
Address the four findings from the quality run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,27 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv run rhiza-task test-pyproject
 
+      # The maintainability ceiling, and it is here rather than in `rhiza-task complexity`
+      # on purpose. That task is shipped: adding an MI floor to it would tighten a gate for
+      # every consumer on upgrade, which is a `feat:` and a new setting, to answer a finding
+      # about one module in this repository (#153). A step in this repo's own CI costs
+      # neither.
+      #
+      # The ceiling is **no module worse than B**, not "config.py reaches A". config.py sits
+      # just under the A threshold, and the blocks holding it there -- `Config.load`'s layer
+      # walk, `_coerce`'s flat dispatch on value shape -- are the flat forms this repo
+      # prefers on purpose; splitting them to move a composite metric two points would be
+      # exactly the shape-over-substance trade that got test-layout parity dropped as a
+      # score. What was worth fixing is that the figure was read back by nothing.
+      #
+      # `radon mi -n C` prints the modules at C or worse and says nothing when there are
+      # none, so the emptiness *is* the assertion; radon has no failing exit code of its own.
+      - name: no module below the maintainability ceiling
+        if: ${{ !cancelled() }}
+        run: |
+          worse=$(uvx radon mi src -n C)
+          test -z "$worse" || { echo "::error::below the B ceiling:"; echo "$worse"; exit 1; }
+
   # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
   # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four
   # entry points and the tests assert on what would have run. That is the point of the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,15 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv run rhiza-task docs-examples
 
+      # The third gate outside `all`, and outside it for a different reason than the two
+      # above: `rhiza-test` already runs pytest-rhiza's pyproject checks, so this is the same
+      # assertions at higher verbosity for whoever is reading a failure. Looking redundant is
+      # how it came to run nowhere at all (#152) -- but the *vector* is its own, a different
+      # `--pyargs` selection and a `-v`, and `rhiza-test` would not notice either breaking.
+      - name: rhiza-task test-pyproject
+        if: ${{ !cancelled() }}
+        run: uv run rhiza-task test-pyproject
+
   # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
   # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four
   # entry points and the tests assert on what would have run. That is the point of the
@@ -353,6 +362,16 @@ jobs:
       # pytest rejects fails here, which is the whole point: no stub can reject one.
       - name: rhiza-task test
         run: uv run rhiza-task test --root "$RUNNER_TEMP/pyproj"
+
+      # `coverage` is not `test` with a flag -- it runs its own vector, writing the Cobertura
+      # XML the book and any badge generator read. It ran nowhere until #152, so a vector
+      # producing no file, or writing it somewhere else, was well-formed and undetectable.
+      # Hence the file check: `coverage` exiting 0 having written nothing is exactly the
+      # failure this step is for, and an exit status cannot see it.
+      - name: rhiza-task coverage
+        run: |
+          uv run rhiza-task coverage --root "$RUNNER_TEMP/pyproj"
+          test -s "$RUNNER_TEMP/pyproj/_tests/coverage.xml"
 
   go-layer:
     name: go tasks against a real toolchain
@@ -568,6 +587,49 @@ jobs:
           uv run rhiza-task failed-workflows
           uv run rhiza-task workflow-status
           uv run rhiza-task latest-release
+
+      # `clean` is the Dev task that ran nowhere (#152), and the one worth the fixture: it is
+      # the only vector in the package that *deletes* -- `git clean -d -X -f`, an rmtree over
+      # CLEAN_ARTIFACTS, and `git branch -D` for every branch whose upstream is gone. Its unit
+      # tests patch `subprocess.run` and assert the vectors, which is right and cannot answer
+      # whether real git agrees that a branch is gone.
+      #
+      # So the fixture is a real repository with a real remote, and the branch is made gone
+      # the way it goes gone in life: pushed, then deleted upstream. `--prune` inside the task
+      # is what turns that into the `: gone]` marker it greps for.
+      #
+      # Three assertions, because `clean` exiting 0 says nothing about which half ran: the
+      # ignored file is gone (the `git clean` path), `.env` survived it (the `-e !.env`
+      # exclusion, which is the part a reader would not guess), and the gone branch was
+      # deleted (the `branch -vv` walk). `scratch.log` rather than `dist/` deliberately --
+      # `dist` is in CLEAN_ARTIFACTS and would be removed by the rmtree even if git clean
+      # never ran, so it cannot tell the two paths apart.
+      - name: Build a throwaway git repository with a gone branch
+        run: |
+          git init -q --bare "$RUNNER_TEMP/cleanremote.git"
+          mkdir -p "$RUNNER_TEMP/cleanrepo"
+          cd "$RUNNER_TEMP/cleanrepo"
+          git init -q -b main
+          git config user.email ci@example.com
+          git config user.name CI
+          printf '*.log\n.env\n' > .gitignore
+          git add .gitignore
+          git commit -q -m "init"
+          git remote add origin "$RUNNER_TEMP/cleanremote.git"
+          git push -q -u origin main
+          git checkout -q -b doomed
+          git push -q -u origin doomed
+          git checkout -q main
+          git push -q origin --delete doomed
+          printf 'ignored\n' > scratch.log
+          printf 'SECRET=keep-me\n' > .env
+
+      - name: rhiza-task clean
+        run: |
+          uv run rhiza-task clean --root "$RUNNER_TEMP/cleanrepo"
+          test ! -e "$RUNNER_TEMP/cleanrepo/scratch.log"
+          test -s "$RUNNER_TEMP/cleanrepo/.env"
+          ! git -C "$RUNNER_TEMP/cleanrepo" rev-parse --verify doomed 2>/dev/null
 
   # bundle-layer's argument, carried to the one family it stopped short of. Cross-referencing
   # `rhiza-task list` against every `rhiza-task <task>` in .github/ showed the Testing extras

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -190,3 +190,22 @@ jobs:
           fi
 
           git push origin "$commit:refs/heads/paper"
+
+      # `paper-clean` ran nowhere at all until #152, and this is the only job in the
+      # repository with a compiled paper to clean -- anywhere else it would pass by finding
+      # nothing, which is the shape of a step that proves nothing.
+      #
+      # Last, and after the push, because it removes the **PDF as well as** the aux files:
+      # `paper_clean` adds `.pdf` to AUX_SUFFIXES on the grounds that removing the output is
+      # the point of a clean. So the two steps above have to have finished with it.
+      #
+      # Both assertions name what tectonic actually leaves, which is not what a TeX
+      # distribution would: tectonic writes only the PDF plus, because `paper` passes
+      # `--keep-logs`, the `.log`. There is no `.aux` here to look for, so asserting one was
+      # gone would pass on a `paper-clean` that deleted nothing at all.
+      - name: rhiza-task paper-clean
+        if: ${{ steps.check_tex.outputs.tex_present == 'true' }}
+        run: |
+          uv run rhiza-task paper-clean
+          test ! -e "${{ steps.pdf.outputs.pdf_path }}"
+          test -z "$(find docs/paper -maxdepth 1 -name '*.log')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,3 +549,31 @@ increase wherever its commit type puts it, so the upgrade note is always manual*
 body* separately with `git-cliff --latest` from commits, so a note added here does **not** reach
 it. And **`git-cliff --prepend` eats this file's `# Changelog` heading**: prior sections survive,
 the title does not, so restore it and diff before committing. Both of v1.1.0's prepends did it.
+
+### What counts as public, when the question is a name rather than a gate
+
+The rule above is about gate *strictness*, and v1.4.1 found the gap it leaves: that release
+renamed `tasks/setup.py`'s `CHECKS_EXECUTABLE_BIT` to `POSIX` under a **patch**. Nothing
+imports it and no consumer could have noticed, but nothing written down said so either, and
+the answer was being decided per change by whoever was making it. #154 is where it was
+settled, and the split is not new — it is what the repository already documents, now said
+out loud:
+
+> **Public: the task names, their flags, and the five modules `docs/api.md` documents**
+> (`spec`, `uv`, `config`, `runner`, `cli`). **Internal: everything under `tasks/`.**
+
+Both halves are checkable rather than asserted. `__init__.py`'s `__all__` exports
+`__version__` and nothing else; `docs/api.md`'s table lists exactly those five modules and no
+task module; and `adding_a_task.md` — the one page telling a consumer to import anything —
+imports from `spec` and `uv`. A task is reached by *name*, through the CLI, which is why
+renaming a task, dropping one of its flags, or changing what a setting is spelled is
+breaking, while renaming the Python object behind it is not.
+
+So: a module-level name under `tasks/` may be renamed in a `refactor:` or alongside the
+`fix:` that motivated it, with no minor. A name in those five modules may not — `Config`,
+`Guard`, `task`, `uvx` and their kin are what `adding_a_task.md` teaches, and moving one is a
+`feat!:` at least. **The underscore prefix is not the signal here**; layering rule 4 governs
+who may import a private name across a module boundary *inside* this package, which is a
+different question from what a consumer may rely on, and a name can be public to the fourth
+rule and internal to this one. `install_hooks` is exactly that: public because three sibling
+modules need the same spelling, internal because no consumer was ever told it exists.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,8 +323,12 @@ an integer in this sentence would be one more measured figure with nothing readi
   deliberate**, as the assertion that the shell dependency is gone, and the job carries a
   CLI smoke step because the suite stubs every subprocess and so never starts the CLI.
 - **`lint`** — `ruff check` and `ruff format --check`, both halves always running.
-- **`gates`** — the dogfood `uv run rhiza-task all`, plus the two gates deliberately outside
-  `all`: `complexity` and `docs-examples`.
+- **`gates`** — the dogfood `uv run rhiza-task all`, plus the gates deliberately outside
+  `all`: `complexity`, `docs-examples` and `test-pyproject`. The last is outside it for a
+  different reason than the other two — `rhiza-test` already runs pytest-rhiza's pyproject
+  checks, so this is the same assertions at higher verbosity — and looking redundant is how
+  it came to run nowhere at all until #152. Its `--pyargs` selection is its own, and nothing
+  else would notice it breaking.
 - **`links`** — lychee with `--offline` over `README.md` and `docs/`, so only *local*
   targets are resolved. The network half stays in `weekly.yml`: an external 404 is somebody
   else's deploy, and a gate that fails for reasons its author cannot fix is one people learn
@@ -351,6 +355,16 @@ an integer in this sentence would be one more measured figure with nothing readi
   download a browser per run, and its vector differs from `presentation`'s by one flag the
   suite already asserts. `lfs-pull` needs a remote holding LFS objects, and the fixture has
   no remote.
+
+  **`clean` runs here too, and it is the one with a fixture rather than a flag.** It ran
+  nowhere until #152 — the only *deleting* vector in the package, `git clean -d -X -f` plus
+  an rmtree plus `git branch -D`, covered by unit tests that patch `subprocess.run` and so
+  cannot ask whether real git agrees a branch is gone. The fixture is a real repository with
+  a real remote, and the branch is made gone the way it goes gone in life: pushed, then
+  deleted upstream. Its three assertions separate the halves that a zero exit cannot —
+  and the ignored file it looks for is `scratch.log` rather than `dist/` on purpose, because
+  `dist` is in `CLEAN_ARTIFACTS` and the rmtree would remove it whether `git clean` ran or
+  not.
 - **`extras-layer`** — the same argument again, and the family it had stopped short of. The
   Testing extras bundle was the last set with no real execution: `benchmark`, `stress` and
   `hypothesis-test` ran **nowhere**. It is the sharpest case rather than the mildest, because
@@ -365,6 +379,16 @@ an integer in this sentence would be one more measured figure with nothing readi
   section runs here.
 - **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
   are real.
+
+Two additions live outside `ci.yml` and are easy to miss when counting: `python-layer` now
+also runs **`coverage`** against the throwaway project — it is not `test` with a flag, it
+writes the Cobertura XML the book and any badge reads, so the step checks the *file* rather
+than the exit status — and `rhiza_paper.yml` runs **`paper-clean`** as its last step, because
+that is the only job in the repository with a compiled paper to clean. Both are #152. The
+`paper-clean` step is last for a reason worth knowing before moving it: `paper_clean` removes
+the **PDF as well as** the aux files, so the upload and the `paper`-branch push must already
+have finished with it. Its assertions name `.pdf` and `.log`, which is what tectonic actually
+leaves — looking for a `.aux` would pass against a `paper-clean` that deleted nothing.
 
 Two things follow for a change to `pyproject.toml`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,31 @@ a forgotten patch ran `gh` for real rather than erroring. `tests/test_uv.py` now
 no task module holds a real entry point once the fixture has run, so the sentence above is
 checked by a test rather than by this file being kept up to date.
 
+**"Or any other tool" was the half that was still prose, and #151 is what it cost.** `uv.py`
+is not the only door: four modules import `subprocess` directly, because what they run is not
+a uv form at all — `tasks/quality.py`'s `_git`, `tasks/doctor.py`'s version probe,
+`tasks/fences.py`'s `bash -n`, `tasks/go.py`'s cobertura pipe. Those were patched per test, by
+hand, in exactly the shape #116 had already diagnosed one level up — and the fix for `capture`
+did not generalise, because the leak assertion it added is built from `rhiza_task.uv`'s five
+names and so cannot see a module that never bound one.
+
+`conftest`'s `no_real_subprocess` closes them, and two things about its shape are the reusable
+part. It is **autouse**, so a test that asks for no fixture at all is still covered — needing
+to request `recorder` was itself a way to forget. And it **refuses rather than records**:
+there is no single vector shape across a git call, a `--version` probe, a `bash -n` and a pipe
+holding `stdin`/`stdout`, so a recorder would have to hand back a plausible zero to a test that
+never said what it expected, which is a pass invented by the fixture. An `AssertionError`
+naming the vector cannot be read as green.
+
+It found five on the first run: `TestQuality`'s `rhiza-test` group was calling real
+`git tag --list`, and passing only because a tmp directory is not usually inside a git
+repository — on a machine where it is, those tests read that repository's tags. **That is the
+argument for a guard that fails closed over a convention that holds**, and the rule to carry
+forward is narrower than "patch your subprocesses": a new direct `subprocess` user needs
+nothing, but a module switching to `from subprocess import run` binds the function into its
+own namespace and slips the guard in silence — which is why `test_uv.py` pins the import
+*form* as well as the guard itself.
+
 This is the point of the package rather than a shortcut: the make recipes expressed their
 contract as shell, and the vectors are that contract made assertable without provisioning a
 toolchain. So a new task's test asserts *what it would run*, not that running it works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,6 +449,18 @@ lone method of 5 scores its class 6, and adding a second of 1 scores it **4**, n
 *down* rather than up. Prefer a module-level function when it needs no `self` or when
 laziness matters, as `_clauses` does; not to dodge a class score that works the other way.
 
+**Maintainability has a ceiling too, and it is a ceiling rather than a target.** `config.py`
+ranks B where every other module is A, and #153 is where that was argued out: the blocks
+holding it there are `Config.load`'s six-layer walk and `_coerce`'s dispatch on value shape,
+both flat on purpose, and splitting them to move a composite metric two points is the
+shape-over-substance trade this file declines elsewhere. So the rule is **no module worse
+than B**, enforced by a `radon mi -n C` step in `ci.yml`'s `gates` job — not by an MI floor
+in `rhiza-task complexity`, because that task is shipped and tightening it would fail every
+consumer's build on upgrade to settle a question about one module here. Note the direction
+the metric runs before chasing it: writing the paragraph that explains all this into
+`config.py` moved its figure *down*, because radon's MI counts length, and dense comments
+are the house style two sections up.
+
 Unlike the layering invariant above, this one **is** gated: `rhiza-task complexity` fails on
 any block above `complexity_max`, which `pyproject.toml` leaves at the shipped 15, and
 `ci.yml`'s `gates` job names it. So a ceiling a comment commits to is read back by a build

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -34,6 +34,25 @@ The ``+=`` accumulators do not survive as a mechanism, and do not need to: every
 them was a bundle contributing something it owned, which the task body can now *derive*
 by asking whether the contributing task is registered. See ``tasks/python.py``'s ``deps``
 and ``license``.
+
+**This module is the one that ranks B on maintainability, and that is deliberate** -- see
+issue #153. The blocks holding it there are ``Config.load``'s six-layer walk and
+``_coerce``'s dispatch on value shape, both of which are flat by choice: the walk *is* the
+precedence order this docstring spends thirty lines explaining, and reading it as a sequence
+of ``raw.update`` calls is the point. Splitting either to move a composite metric two points
+would be the shape-over-substance trade this repo declines elsewhere.
+
+What was worth fixing is that the figure was read back by nothing. **The ceiling is now no
+module worse than B**, enforced by a step in ``ci.yml``'s ``gates`` job rather than by an MI
+floor in ``rhiza-task complexity`` -- that task is shipped, so tightening it would fail
+consumers' builds on upgrade to settle a question about one module here. A third block
+joining these two is the point to decompose rather than to lower the ceiling.
+
+One measured thing worth knowing before anyone tries to chase A here: **writing the
+paragraph above moved the figure down.** radon's MI is a function of length as well as
+branching, so prose in a module counts against it -- and dense comments are this repo's
+house style, stated as such. That is a reason to hold a ceiling rather than a target, and
+a reason not to read the rank as a verdict on the module.
 """
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,12 +23,25 @@ The module list is derived rather than written down, for the same reason. It use
 hand-maintained tuple of twelve names, which was complete but only by inspection; a new
 module binding an entry point and not added here would have been handed real subprocesses
 rather than an error -- the same fail-open shape one level up.
+
+**And uv is not the only door.** Four task modules call :mod:`subprocess` directly, because
+what they run is not a uv form: git, a ``--version`` probe, ``bash -n``, a cobertura pipe.
+Those were patched per test, by hand, for the same reason ``capture`` was -- and the same way
+it failed. :func:`no_real_subprocess` closes them for the whole suite, autouse and refusing
+rather than recording, so the opening sentence of this docstring is now true of *any* tool
+rather than of uv alone. It caught five tests on the first run: ``TestQuality``'s
+``rhiza-test`` group was shelling out to real ``git tag --list``, and passing only because a
+tmp directory is not usually inside a repository. See issue #151.
 """
 
 from __future__ import annotations
 
 import importlib
 import pkgutil
+
+# Imported to be *closed*, not to be used: `no_real_subprocess` below replaces this module's
+# two entry points for the whole suite. Nothing here starts a process.
+import subprocess  # nosec B404
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -42,6 +55,16 @@ from rhiza_task.config import Config
 UV_ENTRY_POINTS = ("uv", "uvx", "uv_run", "tool")
 """The four entry points returning an exit status. ``capture`` returns stdout, so it needs a
 different stand-in and is handled separately."""
+
+SUBPROCESS_ENTRY_POINTS = ("run", "call")
+"""The two ways this package reaches a process without going through :mod:`rhiza_task.uv`.
+
+``uv.py`` is not the only door. Four task modules import :mod:`subprocess` directly, because
+what they run is not a uv form at all: ``tasks/quality.py``'s ``_git``, ``tasks/doctor.py``'s
+version probe, ``tasks/fences.py``'s ``bash -n`` and ``tasks/go.py``'s cobertura pipe. Between
+them they use exactly these two functions, which is why the guard below can be a pair of names
+rather than a wrapper each module has to adopt.
+"""
 
 
 @dataclass
@@ -208,6 +231,64 @@ def task_modules() -> list[ModuleType]:
         Every submodule of :mod:`rhiza_task.tasks`, imported.
     """
     return [importlib.import_module(f"rhiza_task.tasks.{found.name}") for found in pkgutil.iter_modules(tasks.__path__)]
+
+
+@pytest.fixture(autouse=True)
+def no_real_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Close the four doors :func:`recorder` cannot reach, for every test in the suite.
+
+    ``recorder`` patches the five :mod:`rhiza_task.uv` entry points, and ``test_uv`` asserts
+    that none leaked -- so the guarantee at the top of this file is checked rather than
+    remembered. It was checked for *uv*. Four task modules reach :mod:`subprocess` directly,
+    and each test that touched one patched it by hand; every one of them did, so nothing ever
+    leaked, but the guarantee held the way ``capture``'s did before #116 -- by each author
+    remembering, and failing **open** when one did not. A test that forgot ran real ``git``,
+    ``bash`` or ``go`` and *passed* on a machine that had them. ``_git`` is the sharp end of
+    that: it runs ``git branch -D``. See issue #151.
+
+    **Autouse, and it refuses rather than records.** Refusing is what makes the failure mode
+    right: there is no single argument-vector shape to record across a ``git`` invocation, a
+    ``--version`` probe, a ``bash -n`` and a pipe with ``stdin``/``stdout`` handles, and a
+    recorder that accepted all four would hand back a plausible zero to a test that never said
+    what it expected. An ``AssertionError`` naming the vector cannot be mistaken for a pass.
+
+    Patched on the :mod:`subprocess` module itself rather than per importer, because that is
+    the object all five modules hold: ``quality.subprocess`` *is* this module. The tests that
+    legitimately need a stand-in keep working unchanged -- they patch the same attribute from
+    a non-autouse fixture or the test body, and a later patch wins.
+
+    Args:
+        monkeypatch: pytest's patcher.
+    """
+
+    def refuse(name: str) -> Callable[..., object]:
+        """Build a stand-in for one subprocess entry point.
+
+        Args:
+            name: ``run`` or ``call``.
+
+        Returns:
+            A callable that raises rather than starting anything.
+        """
+
+        def guard(argv: object = None, *_args: object, **_kwargs: object) -> object:
+            """Refuse to start a process, naming what would have been run.
+
+            Args:
+                argv: The argument vector the caller passed.
+                *_args: Ignored.
+                **_kwargs: Ignored.
+
+            Raises:
+                AssertionError: Always.
+            """
+            msg = f"no test in this suite runs a tool: subprocess.{name}({argv!r}) -- patch it"
+            raise AssertionError(msg)
+
+        return guard
+
+    for name in SUBPROCESS_ENTRY_POINTS:
+        monkeypatch.setattr(subprocess, name, refuse(name))
 
 
 @pytest.fixture

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -344,6 +344,22 @@ class TestDerivedAccumulators:
 class TestQuality:
     """quality.mk's gates."""
 
+    @pytest.fixture
+    def no_tags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Report a repository with no tags, so ``rhiza-test`` sees no release in flight.
+
+        ``rhiza_test`` consults ``_release_pending``, which shells out to ``git tag --list``.
+        These five tests are about the pytest vector rather than release detection, and until
+        #151 they left that call unpatched -- so they ran **real git**, in a tmp directory,
+        and passed only because a tmp directory is not usually inside a repository. On a
+        machine where it is, they would have read that repository's tags. The autouse guard in
+        ``conftest`` is what turned that from a latent flake into a failing test.
+
+        Args:
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.setattr(quality, "_git", lambda *_a, **_k: "")
+
     def test_fmt_names_the_config_explicitly(self, cfg: Config, recorder: Recorder) -> None:
         """Without ``--config``, prek treats nested configs as separate projects.
 
@@ -355,7 +371,7 @@ class TestQuality:
         quality.fmt(cfg)
         assert recorder.find("prek").flags == ["run", "--all-files", "--config", ".pre-commit-config.yaml"]
 
-    def test_rhiza_test_runs_the_pinned_plugin(self, cfg: Config, recorder: Recorder) -> None:
+    def test_rhiza_test_runs_the_pinned_plugin(self, cfg: Config, recorder: Recorder, no_tags: None) -> None:
         """The checks arrive installed and enumerated, never globbed.
 
         Globbing would collect pytest-rhiza's Rust and Go modules, which cannot pass here.
@@ -364,6 +380,7 @@ class TestQuality:
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            no_tags: The pinned tag probe.
         """
         quality.rhiza_test(cfg)
         call = recorder.find("pytest")
@@ -372,7 +389,9 @@ class TestQuality:
         assert not [f for f in call.flags if "test_cargo_toml" in f or "test_go_module" in f]
         assert call.kwargs["withs"] == (cfg.pytest_rhiza,)
 
-    def test_rhiza_test_omits_the_with_when_the_provider_is_empty(self, cfg: Config, recorder: Recorder) -> None:
+    def test_rhiza_test_omits_the_with_when_the_provider_is_empty(
+        self, cfg: Config, recorder: Recorder, no_tags: None
+    ) -> None:
         """An empty ``pytest_rhiza`` drops ``--with`` rather than passing an empty spec.
 
         The pin is right for a consumer and wrong for anyone testing an unreleased check
@@ -384,11 +403,12 @@ class TestQuality:
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            no_tags: The pinned tag probe.
         """
         quality.rhiza_test(replace(cfg, pytest_rhiza=""))
         assert recorder.find("pytest").kwargs["withs"] == ()
 
-    def test_rhiza_test_reads_whitespace_as_empty(self, cfg: Config, recorder: Recorder) -> None:
+    def test_rhiza_test_reads_whitespace_as_empty(self, cfg: Config, recorder: Recorder, no_tags: None) -> None:
         """``pytest-rhiza = " "`` means the same thing as ``""``.
 
         A TOML value cannot be stripped on the way in -- :func:`_coerce` only sees the
@@ -398,11 +418,14 @@ class TestQuality:
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            no_tags: The pinned tag probe.
         """
         quality.rhiza_test(replace(cfg, pytest_rhiza="  "))
         assert recorder.find("pytest").kwargs["withs"] == ()
 
-    def test_rhiza_test_tells_the_docstring_check_where_to_look(self, cfg: Config, recorder: Recorder) -> None:
+    def test_rhiza_test_tells_the_docstring_check_where_to_look(
+        self, cfg: Config, recorder: Recorder, no_tags: None
+    ) -> None:
         """``RHIZA_DOCTEST_FOLDERS`` carries ``source_folder`` into the checks.
 
         Without it ``test_docstrings`` falls back to a literal ``src`` and reports
@@ -412,11 +435,12 @@ class TestQuality:
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            no_tags: The pinned tag probe.
         """
         quality.rhiza_test(cfg)
         assert recorder.find("pytest").kwargs["env"] == {"RHIZA_DOCTEST_FOLDERS": cfg.source_folder}
 
-    def test_rhiza_test_honours_a_relocated_source_folder(self, cfg: Config, recorder: Recorder) -> None:
+    def test_rhiza_test_honours_a_relocated_source_folder(self, cfg: Config, recorder: Recorder, no_tags: None) -> None:
         """A repo declaring ``source-folder = "utils"`` gets its doctests checked.
 
         The default would pass the assertion above by coincidence, since ``source_folder``
@@ -426,6 +450,7 @@ class TestQuality:
         Args:
             cfg: The resolved config.
             recorder: The uv recorder.
+            no_tags: The pinned tag probe.
         """
         relocated = replace(cfg, source_folder="utils")
         quality.rhiza_test(relocated)

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -16,7 +16,7 @@ from rhiza_task import uv as uv_module
 from rhiza_task.spec import Failed
 from rhiza_task.tasks import github as github_tasks
 
-from .conftest import UV_ENTRY_POINTS, Recorder, task_modules
+from .conftest import SUBPROCESS_ENTRY_POINTS, UV_ENTRY_POINTS, Recorder, task_modules
 
 
 @pytest.fixture
@@ -330,6 +330,39 @@ class TestTheSuiteStubsEveryEntryPoint:
             if getattr(module, name, None) is original
         ]
         assert leaked == [], f"unstubbed entry point(s) would run the real tool: {leaked}"
+
+    def test_no_module_can_reach_a_real_subprocess(self) -> None:
+        """The other four doors, closed by ``conftest``'s autouse guard.
+
+        The assertion above covers :mod:`rhiza_task.uv`'s entry points. It does **not** cover
+        the four modules that import :mod:`subprocess` directly, because what they run is not
+        a uv form -- and until #151 those were patched per test, by hand, which is the same
+        fail-open shape #116 fixed for ``capture``. This asserts the guard is in place rather
+        than trusting that every future test remembers.
+
+        Requests no fixture: the guard is autouse, so a test that asks for nothing at all is
+        exactly the case that must still be covered.
+
+        Raises:
+            AssertionError: Through the guard, which is what is being asserted.
+        """
+        for name in SUBPROCESS_ENTRY_POINTS:
+            with pytest.raises(AssertionError, match="no test in this suite runs a tool"):
+                getattr(subprocess, name)(["definitely-not-a-tool"])
+
+    def test_every_direct_subprocess_user_is_covered_by_that_guard(self) -> None:
+        """Each module reaching subprocess directly holds the guarded module, not a copy.
+
+        ``import subprocess`` binds the module object, so patching its attributes reaches
+        every importer -- but that is a property of how these modules import it, not a law.
+        A module that switched to ``from subprocess import run`` would bind the *function*
+        into its own namespace and slip the guard silently, which is the regression this
+        pins.
+        """
+        holders = [uv_module, *task_modules()]
+        direct = [m for m in holders if getattr(m, "subprocess", None) is not None]
+        assert [m.__name__ for m in direct if m.subprocess is not subprocess] == []
+        assert len(direct) >= 5, f"expected uv.py and the four direct users, found {len(direct)}"
 
     def test_capture_is_recorded_and_replays_canned_output(self, recorder: Recorder) -> None:
         """``capture`` records like the others and hands back the next canned string.


### PR DESCRIPTION
Addresses all four findings from the `/rhiza:quality` run, one commit each.

Closes #151
Closes #152
Closes #153
Closes #154

*(Four separate lines on purpose — a single `Closes #151, #152, …` closes only the first.)*

---

## #151 — close the four subprocess doors the uv fixture cannot reach

`conftest` patches all five `rhiza_task.uv` entry points and `test_uv.py` asserts none leaked, so *"no test in this suite runs uv"* is checked rather than remembered. **"Or any other tool" was still prose.** Four modules import `subprocess` directly — `quality._git`, `doctor`'s version probe, `fences`' `bash -n`, `go`'s cobertura pipe — and each was patched per test, by hand. The #116 fix could not generalise to them: its leak assertion is built from uv's five names and cannot see a module that never bound one.

`no_real_subprocess` closes them for the whole suite. **Autouse**, so a test requesting no fixture is still covered; and **refusing rather than recording**, because there is no single vector shape across a git call, a `--version` probe, a `bash -n` and a pipe holding `stdin`/`stdout` — a recorder would hand a plausible zero to a test that never said what it expected, which is a pass the fixture invented.

**It caught five tests on the first run.** `TestQuality`'s `rhiza-test` group reached `_release_pending` and ran **real `git tag --list`**, passing only because a tmp directory is not usually inside a git repository. On a machine where it is, they read that repository's tags. They now pin the probe through a `no_tags` fixture.

`test_uv.py` gains two assertions: the guard is in place for a test requesting nothing, and every direct user still holds the *module* rather than a bound `run` — a switch to `from subprocess import run` would slip the guard in silence.

## #152 — run `clean`, `coverage`, `paper-clean` and `test-pyproject` for real

All four executed in no job, and carried no note saying why — so their absence read as an oversight rather than a decision, unlike the six genuinely un-runnable ones.

- **`clean`** is the one that needed a fixture rather than a line: the only *deleting* vector in the package, and its unit tests patch `subprocess.run`, which cannot ask whether real git agrees a branch is gone. `bundle-layer` now builds a real repository with a real remote and makes a branch gone the way it goes gone in life — pushed, then deleted upstream. Three assertions, because a zero exit does not say which half ran. The ignored file is `scratch.log` and not `dist/`, since `dist` is in `CLEAN_ARTIFACTS` and the rmtree would take it either way. **Verified locally end to end** before committing.
- **`coverage`** → `python-layer`, with a *file* check: it is not `test` with a flag, it writes the Cobertura XML the book reads, and a vector producing no file still exits 0.
- **`paper-clean`** → last step of `rhiza_paper.yml`, the only job with a compiled paper to clean. Last because `paper_clean` removes the **PDF as well as** the aux files. Its assertions name `.pdf` and `.log` — what tectonic actually leaves; my first draft looked for a `.aux`, which would have passed against a `paper-clean` that deleted nothing. Both corrected assertions were checked against a real local compile.
- **`test-pyproject`** → the `gates` job. Looking redundant next to `rhiza-test` is how it came to run nowhere, but its `--pyargs` selection is its own.

## #153 — hold `config.py`'s maintainability at a gated ceiling

The finding offered two outcomes; this takes the second, because the first is not an improvement here. The blocks holding `config.py` below A are `Config.load`'s six-layer walk and `_coerce`'s dispatch on value shape — both flat by choice, and the walk *is* the precedence order the module docstring spends thirty lines explaining. Splitting them to move a composite metric two points is the shape-over-substance trade this repo declined when it dropped test-layout parity as a score.

What was actually wrong is that the figure was **read back by nothing**. The ceiling — no module worse than B — is now a `radon mi -n C` step in the `gates` job; radon has no failing exit code, so the emptiness of its output is the assertion. Deliberately *not* an MI floor in `rhiza-task complexity`, which ships: tightening it would fail every consumer's build on upgrade to settle a question about one module here.

One measured thing the note records, because it inverts the instinct: **writing the explanation into `config.py` moved its figure down.** radon's MI counts length, and dense comments are this repo's stated house style.

## #154 — say what counts as public when the question is a name

The semver rule covered gate strictness and nothing else, which is how v1.4.1 renamed a module-level constant under a patch with no policy to check it against. The split recorded is not new — both halves are already checkable: `__all__` exports `__version__` alone, `docs/api.md` names exactly five modules and no task module, and `adding_a_task.md` imports from `spec` and `uv`.

> **Public: task names, their flags, and the five modules `docs/api.md` documents. Internal: everything under `tasks/`.**

The note also separates this from layering rule 4, because they look alike and are not — a name can be public to that rule and internal to this one, which is exactly what `install_hooks` is.

---

## Verification

`rhiza-task all`, `docs-examples`, `complexity`, `test-pyproject` and `fmt` (actionlint included) all green; 403 tests, coverage still 100%. The `clean` fixture and both `paper-clean` assertions were run for real locally, not just linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
