### PR TITLE
Fix the three findings from the second quality run

### DIFF
--- a/.github/scripts/accumulation_ceiling.py
+++ b/.github/scripts/accumulation_ceiling.py
@@ -1,0 +1,80 @@
+"""Fail when one module carries too many complex blocks, whatever their individual ranks.
+
+``rhiza-task complexity`` gates the worst *block* at ``complexity_max``. Nothing gated
+*accumulation* -- a module whose blocks are each defensible and collectively a lot -- and
+issue #153 filled that gap with radon's maintainability index, which was the wrong
+instrument.
+
+MI counts length, comments count as length, and dense comments are this repository's stated
+house style: writing the note that explained the MI ceiling cost 1.78 points for 19 lines of
+prose, a quarter of the headroom, with no branch added or removed. A gate the convention
+erodes is one people learn to raise rather than heed. See #156.
+
+The measurement that decided the replacement is worth keeping, because it says the old gate
+was not merely fragile but wrong: MI ranked ``config.py`` B and ``tasks/fences.py`` A, while
+fences.py carries *more* blocks at rank B or worse and the same total complexity. Whatever MI
+was reporting there, it was not complexity -- so counting the blocks directly loses nothing.
+
+A file rather than an inline heredoc in ``ci.yml`` because it is the only step in that
+workflow with real logic, and a step whose reasoning does not fit on one line is a step whose
+reasoning ends up nowhere.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HARD = 6
+"""The rank-B boundary: radon calls CC 6-10 a B, and anything at or above this is a block
+worth counting rather than a getter."""
+
+CEILING = 6
+"""How many such blocks one module may hold, one above the current worst.
+
+A ceiling rather than a target, and the rule CLAUDE.md already states for a block's own
+figure applies: a module that reaches it is the point to decompose, not the point to raise
+the number.
+"""
+
+
+def over_ceiling(report: dict[str, object]) -> dict[str, int]:
+    """Return each module holding more than :data:`CEILING` blocks at :data:`HARD` or above.
+
+    Args:
+        report: radon's ``cc --json`` output. A module radon could not parse maps to a dict
+            carrying its error rather than to a list of blocks, and is skipped -- a syntax
+            error is `ruff`'s finding to report, and swallowing it here would be a second
+            gate answering for the first.
+
+    Returns:
+        Module path to count, for the modules over the ceiling.
+    """
+    counted = {
+        path: sum(1 for block in blocks if block["complexity"] >= HARD)
+        for path, blocks in report.items()
+        if isinstance(blocks, list)
+    }
+    return {path: n for path, n in counted.items() if n > CEILING}
+
+
+def main(argv: list[str]) -> int:
+    """Report every module over the ceiling and set the exit status.
+
+    Args:
+        argv: One path, to radon's JSON report.
+
+    Returns:
+        1 when any module is over the ceiling, else 0.
+    """
+    over = over_ceiling(json.loads(Path(argv[1]).read_text()))
+    for path, n in sorted(over.items()):
+        print(f"::error::{path} holds {n} blocks at CC >= {HARD}; the ceiling is {CEILING}")
+    if not over:
+        print(f"[INFO] no module holds more than {CEILING} blocks at CC >= {HARD}")
+    return 1 if over else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - the CI entry point, exercised by the job itself
+    sys.exit(main(sys.argv))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,26 +281,32 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv run rhiza-task test-pyproject
 
-      # The maintainability ceiling, and it is here rather than in `rhiza-task complexity`
-      # on purpose. That task is shipped: adding an MI floor to it would tighten a gate for
-      # every consumer on upgrade, which is a `feat:` and a new setting, to answer a finding
-      # about one module in this repository (#153). A step in this repo's own CI costs
-      # neither.
+      # The accumulation ceiling, and it is here rather than in `rhiza-task complexity`
+      # on purpose. That task is shipped: tightening it would fail every consumer's build on
+      # upgrade to answer a question about this repository. A step in this repo's own CI
+      # costs them nothing.
       #
-      # The ceiling is **no module worse than B**, not "config.py reaches A". config.py sits
-      # just under the A threshold, and the blocks holding it there -- `Config.load`'s layer
-      # walk, `_coerce`'s flat dispatch on value shape -- are the flat forms this repo
-      # prefers on purpose; splitting them to move a composite metric two points would be
-      # exactly the shape-over-substance trade that got test-layout parity dropped as a
-      # score. What was worth fixing is that the figure was read back by nothing.
+      # What it measures, and why not the obvious thing. `complexity` gates the worst
+      # *block* at 15; nothing gated *accumulation* -- a module whose blocks are each
+      # defensible and collectively a lot. #153 filled that hole with `radon mi -n C`, and
+      # #156 is what that cost: MI counts length, comments count as length, and dense
+      # comments are this repo's stated house style -- so writing the note that explained
+      # the ceiling ate a quarter of its headroom, 1.78 points for 19 lines of prose. A gate
+      # the convention erodes is one people raise rather than heed.
       #
-      # `radon mi -n C` prints the modules at C or worse and says nothing when there are
-      # none, so the emptiness *is* the assertion; radon has no failing exit code of its own.
-      - name: no module below the maintainability ceiling
+      # The measurement that settled it: MI ranked `config.py` B and `fences.py` A, while
+      # fences.py has *more* blocks at rank B or worse and the same total complexity. So MI's
+      # verdict was not a complexity verdict, and replacing it loses nothing -- this counts
+      # blocks at CC >= 6 per module, which no amount of prose can move.
+      #
+      # The ceiling is 6, one above the current worst. A module reaching it is the point to
+      # decompose rather than to raise the number, which is the rule CLAUDE.md already
+      # states for a block's own ceiling.
+      - name: no module above the complexity-accumulation ceiling
         if: ${{ !cancelled() }}
         run: |
-          worse=$(uvx radon mi src -n C)
-          test -z "$worse" || { echo "::error::below the B ceiling:"; echo "$worse"; exit 1; }
+          uvx radon cc src --json --output-file "$RUNNER_TEMP/cc.json"
+          uv run python "$GITHUB_WORKSPACE/.github/scripts/accumulation_ceiling.py" "$RUNNER_TEMP/cc.json"
 
   # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
   # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,8 +349,35 @@ jobs:
   # folder settings, so what runs here is the *shipped defaults* -- which is precisely what a
   # consumer gets, and what this repository's own manifest overrides.
   python-layer:
-    name: python tasks against a real toolchain
-    runs-on: ubuntu-latest
+    name: python tasks against a real toolchain (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    # Windows is here and not on the other layer jobs, and #158 is where that was reasoned
+    # out rather than left implicit. The precedent is #148: a vector that was well-formed,
+    # unit-asserted and unrunnable on Windows shipped in a release, and what caught it was a
+    # consumer's red matrix. Layer jobs exist to find exactly that, and until now they all
+    # looked at one platform -- so the class of bug they guard against was guarded on Linux
+    # only.
+    #
+    # This job is the cheapest place to fix that and the most exposed: it needs no docker, no
+    # `gh`, no git-lfs, no cargo, no go -- just uv and a scratch project -- and `test` and
+    # `coverage` are the vectors that touch paths hardest. The other layer jobs stay
+    # Linux-only *deliberately*, each for a reason of its own: docker and git-lfs behave
+    # differently enough on a Windows runner to be testing the runner, and cargo and go would
+    # each need their own toolchain install per cell. That is a decision, and it is written
+    # here rather than inferred from the absence of a matrix.
+    #
+    # `shell: bash` for the whole job, which is git-bash on Windows and is fine *here* --
+    # unlike the setup-hook smoke in the `test` job, where the runner's default shell is the
+    # thing under test, because git-bash puts its own `usr/bin` on PATH. Nothing in this job
+    # asks a question about PATH; the heredoc fixture and `test -s` just need a POSIX shell.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -362,10 +389,18 @@ jobs:
       # would be testing the fixture. `coverage_fail_under = 0` because the subject is the
       # vector, not the fixture's coverage -- leaving the shipped default would fail this job
       # on a fixture detail and teach nothing about the vector.
+      #
+      # `${RUNNER_TEMP//\\//}` is not noise. On Windows that variable is a backslash path
+      # (`D:\a\_temp`), and the two consumers read it differently: bash treats backslashes
+      # as literal characters while Python's `Path` wants them as separators, so the same
+      # string means two things in one step. Rewriting to forward slashes gives
+      # `D:/a/_temp`, which bash and Python-on-Windows both read the same way, and which is
+      # a no-op on Linux.
       - name: Build a throwaway Python project
         run: |
-          mkdir -p "$RUNNER_TEMP/pyproj/src/demo" "$RUNNER_TEMP/pyproj/tests"
-          cd "$RUNNER_TEMP/pyproj"
+          proj="${RUNNER_TEMP//\\//}/pyproj"
+          mkdir -p "$proj/src/demo" "$proj/tests"
+          cd "$proj"
           cat > pyproject.toml <<'EOF'
           [project]
           name = "demo"
@@ -388,7 +423,7 @@ jobs:
       # `--root` addresses the scratch project, as the two layer jobs do. A vector that uv or
       # pytest rejects fails here, which is the whole point: no stub can reject one.
       - name: rhiza-task test
-        run: uv run rhiza-task test --root "$RUNNER_TEMP/pyproj"
+        run: uv run rhiza-task test --root "${RUNNER_TEMP//\\//}/pyproj"
 
       # `coverage` is not `test` with a flag -- it runs its own vector, writing the Cobertura
       # XML the book and any badge generator read. It ran nowhere until #152, so a vector
@@ -397,9 +432,14 @@ jobs:
       # failure this step is for, and an exit status cannot see it.
       - name: rhiza-task coverage
         run: |
-          uv run rhiza-task coverage --root "$RUNNER_TEMP/pyproj"
-          test -s "$RUNNER_TEMP/pyproj/_tests/coverage.xml"
+          proj="${RUNNER_TEMP//\\//}/pyproj"
+          uv run rhiza-task coverage --root "$proj"
+          test -s "$proj/_tests/coverage.xml"
 
+  # Linux-only, deliberately: a Windows cell would need its own Go toolchain install and
+  # would be asking a question about the runner rather than about the vector. `python-layer`
+  # above carries the cross-platform half of this argument, and #158 records why the split
+  # falls there.
   go-layer:
     name: go tasks against a real toolchain
     runs-on: ubuntu-latest
@@ -429,6 +469,7 @@ jobs:
       - name: rhiza-task go:test
         run: uv run rhiza-task go:test --root "$RUNNER_TEMP/gomod"
 
+  # Linux-only, for the same reason go-layer is: see the note there and #158.
   rust-layer:
     name: cargo tasks against a real toolchain
     runs-on: ubuntu-latest
@@ -483,6 +524,9 @@ jobs:
   #
   # `lfs-pull` is left out because it needs a remote holding LFS objects; the fixture has no
   # remote at all, and inventing one would test the fixture.
+  # Linux-only, deliberately: docker, git-lfs and `gh` all behave differently enough on a
+  # Windows runner that a second cell would be reporting on the runner rather than on the
+  # vector. See #158, and `python-layer` for where the cross-platform line is drawn.
   bundle-layer:
     name: bundle tasks against a real toolchain
     runs-on: ubuntu-latest
@@ -681,6 +725,7 @@ jobs:
   # "anything more would be testing the fixture" and is right: these three need a benchmarks
   # folder, a stress folder, marker registrations and a property test, which is four
   # additions to a fixture whose point is that it has none.
+  # Linux-only, for the same reason the layer jobs above are: see #158.
   extras-layer:
     name: testing-extras tasks against a real toolchain
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,23 @@ nothing, but a module switching to `from subprocess import run` binds the functi
 own namespace and slips the guard in silence — which is why `test_uv.py` pins the import
 *form* as well as the guard itself.
 
+**#157 is the third instalment of the same mistake, and where it was finally derived.** The
+guard's own scope was written down by hand — `("run", "call")`, accurate for what `src/`
+called that week — which is #116's tuple of twelve module names wearing a different hat.
+`SUBPROCESS_ENTRY_POINTS` now comes from `subprocess.__all__`, minus three *properties*
+rather than three names: the ints (`PIPE`, `DEVNULL`, `STDOUT`), the exception types, and
+`CompletedProcess`, which the tests construct themselves. What is left starts a process, and
+a starter this package begins using is covered before anyone notices they had to.
+
+`os` is the door that stays open, because it cannot be closed the same way: every module uses
+it for paths, so stubbing its attributes would break the suite rather than protect it. So the
+guarantee is asserted from the other side — `test_uv.py` walks `src/`'s **AST** (not a grep;
+a docstring naming `os.system` is not a call) and fails on any `os.system`, `os.popen`,
+`exec*` or `spawn*`. **bandit does not already cover this**, which is the assumption worth
+checking rather than repeating: `B605` reports a literal `os.system` at LOW severity and
+`security` runs `bandit -ll`, so a planted one passes that gate today. Verified by planting
+one.
+
 This is the point of the package rather than a shortcut: the make recipes expressed their
 contract as shell, and the vectors are that contract made assertable without provisioning a
 toolchain. So a new task's test asserts *what it would run*, not that running it works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,17 +449,23 @@ lone method of 5 scores its class 6, and adding a second of 1 scores it **4**, n
 *down* rather than up. Prefer a module-level function when it needs no `self` or when
 laziness matters, as `_clauses` does; not to dodge a class score that works the other way.
 
-**Maintainability has a ceiling too, and it is a ceiling rather than a target.** `config.py`
-ranks B where every other module is A, and #153 is where that was argued out: the blocks
-holding it there are `Config.load`'s six-layer walk and `_coerce`'s dispatch on value shape,
-both flat on purpose, and splitting them to move a composite metric two points is the
-shape-over-substance trade this file declines elsewhere. So the rule is **no module worse
-than B**, enforced by a `radon mi -n C` step in `ci.yml`'s `gates` job — not by an MI floor
-in `rhiza-task complexity`, because that task is shipped and tightening it would fail every
-consumer's build on upgrade to settle a question about one module here. Note the direction
-the metric runs before chasing it: writing the paragraph that explains all this into
-`config.py` moved its figure *down*, because radon's MI counts length, and dense comments
-are the house style two sections up.
+**Accumulation has a ceiling too, and it is one metric replacing another.** `complexity`
+gates the worst *block*; nothing gated a module whose blocks are each defensible and
+collectively a lot. #153 filled that with `radon mi -n C`, and #156 is the correction: MI
+counts length, comments count as length, and dense comments are the house style two sections
+up — so writing the note that explained the ceiling moved the figure **down**, 1.78 points
+for 19 lines of prose with no branch touched. A gate the convention erodes is one people
+raise rather than heed.
+
+The measurement that settled it is the part worth keeping, because it says MI was not merely
+fragile here but wrong: it ranked `config.py` B and `tasks/fences.py` A, while fences.py
+carries *more* blocks at rank B or worse and the same total complexity. So the ceiling is now
+a count of blocks at CC ≥ 6 per module — `.github/scripts/accumulation_ceiling.py`, run from
+the `gates` job, prose-insensitive by construction. **A module reaching the ceiling is the
+point to decompose, not the point to raise the number**, which is the same rule this section
+already states for a block's own figure. The lesson generalises past radon: when a gate and
+the convention it runs beside pull in opposite directions, one of them is measuring the wrong
+thing, and it is worth finding out which before adjusting either.
 
 Unlike the layering invariant above, this one **is** gated: `rhiza-task complexity` fails on
 any block above `complexity_max`, which `pyproject.toml` leaves at the shipped 15, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,7 +353,21 @@ an integer in this sentence would be one more measured figure with nothing readi
   asks whether fences parse, markdownlint whether the markdown is well-formed, and neither
   follows a link.
 - **`python-layer`**, **`go-layer`** and **`rust-layer`** — the three layers' vectors against
-  a *real* toolchain, on a throwaway project built in `$RUNNER_TEMP`. These exist because
+  a *real* toolchain, on a throwaway project built in `$RUNNER_TEMP`. **`python-layer` runs on
+  Windows as well as Linux; the others do not, and that is a decision rather than an
+  omission** — see #158 and the comment on the job. The precedent is #148: a vector that was
+  well-formed, unit-asserted and unrunnable on Windows shipped in a release, and a consumer's
+  red matrix caught it rather than anything here. Layer jobs exist to catch exactly that, so
+  all of them looking at one platform meant the class of bug was guarded on Linux only.
+  `python-layer` is the cheapest place to fix that and the most exposed — no docker, no `gh`,
+  no cargo, no go, just uv and a scratch project, and `test` and `coverage` are the vectors
+  that touch paths hardest. The rest stay Linux-only: docker and git-lfs on a Windows runner
+  are more runner than vector, and cargo and go would each need a toolchain install per cell.
+
+  One thing to keep if that job is edited: `${RUNNER_TEMP//\//}`. On Windows that variable
+  is a backslash path, and bash reads backslashes as literal characters where Python's `Path`
+  reads them as separators — so the raw value means two different things inside one step.
+  Rewriting to forward slashes is understood identically by both, and is a no-op on Linux. These exist because
   those layers' coverage is entirely argument-vector assertions, so a vector that is
   well-formed and *wrong* passes every other gate here and breaks in the first consumer that
   runs it. The Python one was added last and is the least obvious: `gates` already runs

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -35,24 +35,24 @@ them was a bundle contributing something it owned, which the task body can now *
 by asking whether the contributing task is registered. See ``tasks/python.py``'s ``deps``
 and ``license``.
 
-**This module is the one that ranks B on maintainability, and that is deliberate** -- see
-issue #153. The blocks holding it there are ``Config.load``'s six-layer walk and
-``_coerce``'s dispatch on value shape, both of which are flat by choice: the walk *is* the
-precedence order this docstring spends thirty lines explaining, and reading it as a sequence
-of ``raw.update`` calls is the point. Splitting either to move a composite metric two points
-would be the shape-over-substance trade this repo declines elsewhere.
+**This module used to be the one that ranks B on maintainability** -- see issues #153 and
+#156, which are worth reading together because the second corrects the first. The blocks
+that put it there are ``Config.load``'s six-layer walk and ``_coerce``'s dispatch on value
+shape, both flat by choice: the walk *is* the precedence order this docstring spends thirty
+lines explaining, and reading it as a sequence of ``raw.update`` calls is the point.
 
-What was worth fixing is that the figure was read back by nothing. **The ceiling is now no
-module worse than B**, enforced by a step in ``ci.yml``'s ``gates`` job rather than by an MI
-floor in ``rhiza-task complexity`` -- that task is shipped, so tightening it would fail
-consumers' builds on upgrade to settle a question about one module here. A third block
-joining these two is the point to decompose rather than to lower the ceiling.
+#153 recorded that as deliberate and gated the rank so the figure was read back by something.
+#156 found the gate was measuring the wrong thing. radon's MI counts length and comments
+count as length, so **writing the note that explained the ceiling moved the figure down** --
+1.78 points for 19 lines of prose, with no branch added or removed. Worse, MI's verdict did
+not agree with any measure of complexity: it ranked this module B and ``tasks/fences.py`` A,
+while fences.py carries *more* blocks at rank B or worse and the same total.
 
-One measured thing worth knowing before anyone tries to chase A here: **writing the
-paragraph above moved the figure down.** radon's MI is a function of length as well as
-branching, so prose in a module counts against it -- and dense comments are this repo's
-house style, stated as such. That is a reason to hold a ceiling rather than a target, and
-a reason not to read the rank as a verdict on the module.
+So the ceiling is now an accumulation count -- blocks at CC >= 6, per module -- in
+``.github/scripts/accumulation_ceiling.py``, run from ``ci.yml``'s ``gates`` job. It measures
+what MI was standing in for and no amount of prose can move it. The rank of this module is no
+longer gated at all, which is the honest outcome: it was never the complexity signal it
+looked like.
 """
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,14 +56,85 @@ UV_ENTRY_POINTS = ("uv", "uvx", "uv_run", "tool")
 """The four entry points returning an exit status. ``capture`` returns stdout, so it needs a
 different stand-in and is handled separately."""
 
-SUBPROCESS_ENTRY_POINTS = ("run", "call")
-"""The two ways this package reaches a process without going through :mod:`rhiza_task.uv`.
+
+def _process_starters() -> tuple[str, ...]:
+    """Derive subprocess's process-starting API from the module rather than from our usage.
+
+    ``("run", "call")`` was the hand-written pair this replaces, and it was accurate: those
+    are the two functions ``src/`` calls today. Accurate-by-inspection is the property that
+    failed twice already -- #116's missing ``capture``, #151's four direct users -- and the
+    cure this file already applies to the module list is to derive it. See #157.
+
+    The derivation is over :data:`subprocess.__all__`, so the *inclusion* side needs no
+    maintenance: a starter this package begins using, or one the stdlib adds, is patched
+    without anyone noticing they had to. Three kinds of public name are excluded, and each
+    exclusion is a property rather than a name -- ``DEVNULL``/``PIPE``/``STDOUT`` are ints,
+    the errors are exception types, and ``CompletedProcess`` is a result container the tests
+    themselves construct. What is left starts a process.
+
+    Returns:
+        Every public subprocess name that starts a process, sorted.
+    """
+    starters = []
+    for name in subprocess.__all__:
+        obj = getattr(subprocess, name)
+        if isinstance(obj, int) or obj is subprocess.CompletedProcess:
+            continue
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            continue
+        starters.append(name)
+    return tuple(sorted(starters))
+
+
+SUBPROCESS_ENTRY_POINTS = _process_starters()
+"""Every way :mod:`subprocess` starts a process, derived rather than listed.
 
 ``uv.py`` is not the only door. Four task modules import :mod:`subprocess` directly, because
 what they run is not a uv form at all: ``tasks/quality.py``'s ``_git``, ``tasks/doctor.py``'s
-version probe, ``tasks/fences.py``'s ``bash -n`` and ``tasks/go.py``'s cobertura pipe. Between
-them they use exactly these two functions, which is why the guard below can be a pair of names
-rather than a wrapper each module has to adopt.
+version probe, ``tasks/fences.py``'s ``bash -n`` and ``tasks/go.py``'s cobertura pipe.
+"""
+
+OS_PROCESS_STARTERS = frozenset(
+    {
+        "system",
+        "popen",
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "posix_spawn",
+        "posix_spawnp",
+        "fork",
+        "forkpty",
+    }
+)
+"""The other door, and the one no guard here can close by patching.
+
+:mod:`os` cannot be stubbed the way :mod:`subprocess` can -- every module in ``src/`` uses it
+for paths and the environment, so replacing its attributes would break the suite rather than
+protect it. So this set is not patched; ``test_uv`` asserts ``src/`` does not *reach* for any
+of it, which is the same guarantee arrived at from the other side.
+
+**bandit does not cover this**, which is worth stating because it looks like it should:
+``B605`` reports ``os.system`` with a literal command at LOW severity, and ``security`` runs
+``bandit -ll``. Checked rather than assumed -- an ``os.system("echo hi")`` planted in ``src/``
+passes that gate today.
+
+Listed, unlike the set above, because :mod:`os` offers no property that separates these from
+``os.path.join``. It is a list of the *stdlib's* API rather than of this repo's usage, so it
+does not drift when this package changes -- which was the whole complaint in #157.
 """
 
 

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -7,6 +7,7 @@ string, and the reason rhiza.mk needs a Windows shell probe that this package do
 
 from __future__ import annotations
 
+import ast
 import subprocess
 from pathlib import Path
 
@@ -16,7 +17,7 @@ from rhiza_task import uv as uv_module
 from rhiza_task.spec import Failed
 from rhiza_task.tasks import github as github_tasks
 
-from .conftest import SUBPROCESS_ENTRY_POINTS, UV_ENTRY_POINTS, Recorder, task_modules
+from .conftest import OS_PROCESS_STARTERS, SUBPROCESS_ENTRY_POINTS, UV_ENTRY_POINTS, Recorder, task_modules
 
 
 @pytest.fixture
@@ -349,6 +350,47 @@ class TestTheSuiteStubsEveryEntryPoint:
         for name in SUBPROCESS_ENTRY_POINTS:
             with pytest.raises(AssertionError, match="no test in this suite runs a tool"):
                 getattr(subprocess, name)(["definitely-not-a-tool"])
+
+    def test_the_guard_covers_every_way_subprocess_starts_a_process(self) -> None:
+        """The patched set is derived from the stdlib, so it cannot go stale as `src/` changes.
+
+        `("run", "call")` was the hand-written pair this replaces. It was accurate, and
+        accurate-by-inspection is the property that failed at #116 and again at #151 -- so
+        #157 applied the cure `conftest` already applies to the module list. The sanity
+        check is that the derivation did not quietly collapse: if the exclusion rules ever
+        matched everything, the guard would patch nothing and every test would pass.
+        """
+        assert {"run", "call", "Popen", "check_output"} <= set(SUBPROCESS_ENTRY_POINTS)
+        assert not [n for n in SUBPROCESS_ENTRY_POINTS if isinstance(getattr(subprocess, n), int)]
+
+    def test_src_starts_no_process_the_guard_cannot_see(self) -> None:
+        """`src/` reaches a process through subprocess and nothing else.
+
+        The derived set above closes :mod:`subprocess`. It cannot close :mod:`os`, which is
+        not stubbable here -- every module uses it for paths and the environment, so
+        replacing its attributes would break the suite rather than protect it. This asserts
+        the same guarantee from the other side: nothing in `src/` reaches for `os.system`,
+        `os.popen`, an `exec*` or a `spawn*`.
+
+        Not already covered by bandit, which is the assumption worth having checked: `B605`
+        reports `os.system` with a literal command at LOW severity and `security` runs
+        `bandit -ll`, so a planted `os.system("echo hi")` passes that gate today.
+
+        Reading the AST rather than grepping, because a comment or a docstring mentioning
+        `os.system` -- this docstring, for one -- is not a call, and a grep cannot tell the
+        difference.
+        """
+        offenders = []
+        for path in Path("src").rglob("*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name):
+                    continue
+                if node.value.id == "os" and node.attr in OS_PROCESS_STARTERS:
+                    offenders.append(f"{path}:{node.lineno}: os.{node.attr}")
+                if node.value.id == "subprocess" and node.attr not in dir(subprocess):
+                    offenders.append(f"{path}:{node.lineno}: subprocess.{node.attr}")
+        assert offenders == [], f"process started outside the guard's reach: {offenders}"
 
     def test_every_direct_subprocess_user_is_covered_by_that_guard(self) -> None:
         """Each module reaching subprocess directly holds the guarded module, not a copy.


### PR DESCRIPTION
The three findings from the second `/rhiza:quality` run, one commit each.

Closes #156
Closes #157
Closes #158

*(Separate lines — a combined `Closes #156, #157, …` closes only the first.)*

---

## #156 — the maintainability ceiling measured the wrong thing

The `radon mi -n C` gate added yesterday was eroded by the convention it runs beside. Measured across the two sides of its own commit, `config.py` went **18.74 → 16.96 for 19 lines of prose**, no branch added or removed — a quarter of its headroom, spent by the note explaining the ceiling.

**But the deciding measurement is stronger than "fragile": MI's verdict was not a complexity verdict at all.** It ranked `config.py` B and `tasks/fences.py` A, while fences.py carries *more* blocks at rank B or worse (5 vs 4) and the **same** total complexity (79). So replacing it loses no signal.

The replacement counts blocks at CC ≥ 6 per module — the accumulation `rhiza-task complexity` never covered, since that gates the worst *block* rather than the module. Ceiling 6, one above the current worst; prose cannot move it. `.github/scripts/accumulation_ceiling.py`, a file rather than a heredoc because it is the only step in `ci.yml` with real logic. Verified in both directions: passes at 6, and at a planted ceiling of 3 it correctly names `config.py`, `fences.py` and `book.py`.

`config.py`'s own note is corrected rather than deleted — the two issues read together are the record — and its MI rank is now deliberately not gated at all.

## #157 — derive the guard's scope

`SUBPROCESS_ENTRY_POINTS = ("run", "call")` was accurate, and accurate-by-inspection is the property that failed at #116 and again at #151. **Third instalment of one mistake**, so this applies the cure `conftest` already applies to the module list.

The set now derives from `subprocess.__all__` minus three *properties* rather than three names — the ints, the exception types, and `CompletedProcess` (which the tests construct). What remains is exactly the seven starters: `Popen`, `run`, `call`, `check_call`, `check_output`, `getoutput`, `getstatusoutput`.

`os` can't be closed the same way — every module uses it for paths, so stubbing its attributes would break the suite rather than protect it. Asserted from the other side instead: a test walks `src/`'s **AST** and fails on any `os.system`, `os.popen`, `exec*` or `spawn*`. AST rather than grep because a docstring naming `os.system` is not a call, and that test's own docstring does.

**bandit does not already cover this**, which is the assumption I checked rather than repeated: `B605` reports a literal `os.system` at LOW severity and `security` runs `bandit -ll`. I planted one — it passes `security` today, and fails the new test.

## #158 — run the python layer on Windows, and say where the line falls

Every real-toolchain job ran on `ubuntu-latest`; Windows got the pytest matrix (which by design starts no process) plus four CLI invocations. #148 is why that is not theoretical — a well-formed, unit-asserted, unrunnable-on-Windows vector shipped, and a consumer's red matrix caught it rather than anything here.

`python-layer` becomes a two-cell matrix: it is the cheapest place to fix this (no docker, no `gh`, no cargo, no go) and the most exposed, since `test` and `coverage` touch paths hardest. The other four stay Linux-only and each now **says so on its own terms**, so the absence of a matrix reads as a decision rather than an oversight.

One wrinkle worth a look in review: on Windows `$RUNNER_TEMP` is a backslash path, and bash reads backslashes as literal characters where Python's `Path` reads them as separators — the same string meaning two things inside one step. `${RUNNER_TEMP//\\//}` yields forward slashes, which both read identically, and is a no-op on Linux. Checked against both shapes locally.

---

## Verification

`rhiza-task all`, `complexity`, `docs-examples`, `fmt` (actionlint included) green; **405 tests** (+2), coverage still 100%. The new ceiling script was exercised in both directions. The Windows `python-layer` cell has never run before — that is the part of this PR worth watching in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
