### PR TITLE
Fix the two findings from the third quality run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,20 @@ jobs:
           uvx radon cc src --json --output-file "$RUNNER_TEMP/cc.json"
           uv run python "$GITHUB_WORKSPACE/.github/scripts/accumulation_ceiling.py" "$RUNNER_TEMP/cc.json"
 
+      # The script above is Python this repository's own gates do not otherwise reach, and
+      # #161 is what that cost: `typecheck` runs over `src`, bandit runs over `src`, and the
+      # coverage floor measures `--cov=src`, so a planted `def broken(x: int) -> str: return x`
+      # in `.github/scripts` passed all three. Only ruff saw the file, and ruff does not
+      # typecheck.
+      #
+      # This closes the *class* -- a second script inherits the check rather than the hole --
+      # while `tests/test_ci_scripts.py` covers the logic of the one that exists. `uvx mypy`
+      # rather than `rhiza-task typecheck`, whose scope is `src` and which is shipped: widening
+      # it would tighten a gate for every consumer to settle a question about this directory.
+      - name: static checks for the CI scripts
+        if: ${{ !cancelled() }}
+        run: uvx mypy --strict .github/scripts
+
   # The Rust and Go layers are 165 statements at 100% coverage, and every one of those
   # statements is covered by an *argument-vector assertion*: conftest.py patches uv.py's four
   # entry points and the tests assert on what would have run. That is the point of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,29 @@ toolchain. So a new task's test asserts *what it would run*, not that running it
 If you find yourself wanting a real subprocess in a test, that is a signal the logic under
 test belongs in a task body rather than in the plumbing.
 
+### The gates' own scopes are `src/`, and `.github/scripts/` is not in it
+
+`typecheck` runs `ty`/`mypy --strict` over `src`, `security` runs bandit over `src`, and the
+coverage floor measures `--cov=src`. That is right for a package whose product is `src/` —
+and it means **Python added anywhere else is checked by ruff alone**, which lints and formats
+but does not typecheck.
+
+#156 put a real script under `.github/scripts/`, and #161 measured the hole by planting
+`def broken(x: int) -> str: return x` in it: `typecheck`, `security` and `docs-coverage` all
+reported `ok`. Only ruff objected, and only to the missing docstring. The script enforcing a
+complexity gate was the least-checked Python in the repository.
+
+Two things close it, and the split is worth copying rather than the specifics. `ci.yml` runs
+`uvx mypy --strict .github/scripts`, which closes the **class** — a second script inherits the
+check instead of the hole — and `tests/test_ci_scripts.py` closes the **logic**, loading the
+script by path (that directory is not a package and must not become one) and asserting the
+off-by-one at the ceiling boundary that a manual run against a comfortably-passing repository
+could never have distinguished.
+
+`uvx mypy` rather than widening `rhiza-task typecheck`: that task is shipped, so changing its
+scope would tighten a gate for every consumer to answer a question about this repository's
+own `.github/`.
+
 The exception is the doctests: `Config.load`, `Config.field_for`, `Run.exit_code`,
 `lookup` and `Guard.check` carry 39 executable examples that do run. `tests/test_doctests.py`
 is what runs them — `doctest.testmod` over every module `pkgutil` finds under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,11 +209,26 @@ a starter this package begins using is covered before anyone notices they had to
 `os` is the door that stays open, because it cannot be closed the same way: every module uses
 it for paths, so stubbing its attributes would break the suite rather than protect it. So the
 guarantee is asserted from the other side — `test_uv.py` walks `src/`'s **AST** (not a grep;
-a docstring naming `os.system` is not a call) and fails on any `os.system`, `os.popen`,
-`exec*` or `spawn*`. **bandit does not already cover this**, which is the assumption worth
-checking rather than repeating: `B605` reports a literal `os.system` at LOW severity and
-`security` runs `bandit -ll`, so a planted one passes that gate today. Verified by planting
-one.
+a docstring naming `os.system` is not a call) and fails on anything that looks like a way to
+start one. **bandit does not already cover this**, which is the assumption worth checking
+rather than repeating: `B605` reports a literal `os.system` at LOW severity and `security`
+runs `bandit -ll`, so a planted one passes that gate today. Verified by planting one.
+
+**#162 is the fourth instalment, and it landed inside the fix for the third** — worth stating
+because the pattern is now the most reliable thing to look for in this suite. That `os` check
+began as a frozenset of 22 names, and it was missing `os.startfile` on the day it was written.
+The #157 argument for it — *a list of the stdlib's API cannot drift when this package changes*
+— was true, and answered only one of the two ways a list fails. **The other is being wrong at
+the start, which not-drifting does nothing about.**
+
+So the check matches a *shape*: the names `system`/`popen`/`startfile`/`fork`/`forkpty`, plus
+anything beginning `exec`, `spawn` or `create_subprocess`. That cannot be short a member, and
+it picked up two doors the list never considered — `asyncio.create_subprocess_exec`, and
+`from os import system` followed by a bare call, which an attribute-only scan cannot see at
+all. **Deriving from `dir(os)` is the trap to avoid**: `startfile` exists only on Windows, so
+a runtime-derived set is complete on one platform and silently short on the others. The scan
+is over-broad by design — a `.execute()` would trip it — and the answer when that happens is
+`PROCESS_START_ALLOWED` with a reason, never a narrower pattern.
 
 This is the point of the package rather than a shortcut: the make recipes expressed their
 contract as shell, and the vectors are that contract made assertable without provisioning a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,48 +94,52 @@ what they run is not a uv form at all: ``tasks/quality.py``'s ``_git``, ``tasks/
 version probe, ``tasks/fences.py``'s ``bash -n`` and ``tasks/go.py``'s cobertura pipe.
 """
 
-OS_PROCESS_STARTERS = frozenset(
-    {
-        "system",
-        "popen",
-        "execl",
-        "execle",
-        "execlp",
-        "execlpe",
-        "execv",
-        "execve",
-        "execvp",
-        "execvpe",
-        "spawnl",
-        "spawnle",
-        "spawnlp",
-        "spawnlpe",
-        "spawnv",
-        "spawnve",
-        "spawnvp",
-        "spawnvpe",
-        "posix_spawn",
-        "posix_spawnp",
-        "fork",
-        "forkpty",
-    }
-)
-"""The other door, and the one no guard here can close by patching.
+PROCESS_START_NAMES = frozenset({"system", "popen", "startfile", "fork", "forkpty"})
+"""Exact names that start a process, whatever module they are reached through."""
 
-:mod:`os` cannot be stubbed the way :mod:`subprocess` can -- every module in ``src/`` uses it
-for paths and the environment, so replacing its attributes would break the suite rather than
-protect it. So this set is not patched; ``test_uv`` asserts ``src/`` does not *reach* for any
-of it, which is the same guarantee arrived at from the other side.
+PROCESS_START_PREFIXES = ("exec", "spawn", "posix_spawn", "create_subprocess")
+"""Name *shapes* that start a process: the ``os.exec*``/``os.spawn*`` families and asyncio's.
 
-**bandit does not cover this**, which is worth stating because it looks like it should:
-``B605`` reports ``os.system`` with a literal command at LOW severity, and ``security`` runs
-``bandit -ll``. Checked rather than assumed -- an ``os.system("echo hi")`` planted in ``src/``
-passes that gate today.
+Matching a shape rather than enumerating members is the point, and #162 is why. The set this
+replaces listed 22 ``os`` names and was **already missing ``os.startfile``** the day it was
+written -- the fourth time in this suite's history that a hand list was the weak part, after
+#116's missing ``capture``, #151's four unguarded modules and #157's ``("run", "call")``.
 
-Listed, unlike the set above, because :mod:`os` offers no property that separates these from
-``os.path.join``. It is a list of the *stdlib's* API rather than of this repo's usage, so it
-does not drift when this package changes -- which was the whole complaint in #157.
+#157 argued that a list of the *stdlib's* API cannot drift when this package changes. True,
+and it answers only one of the two ways a list fails. The other is being wrong at the start,
+which not-drifting does nothing about.
+
+**Deriving from ``dir(os)`` is the trap to avoid here**, and it is why this is shapes rather
+than a runtime query: ``os.startfile`` exists only on Windows, so a set derived on the machine
+running the tests would be complete on one platform and short on the others -- silently, and
+in the direction that passes.
+
+Deliberately over-broad: it matches any attribute of that shape on any object, so a
+``.execute()`` or a ``.spawner`` would trip it. ``src/`` has none today (checked), and the
+answer when one appears is :data:`PROCESS_START_ALLOWED` with a reason, not a narrower shape.
 """
+
+PROCESS_START_ALLOWED: frozenset[str] = frozenset()
+"""Names matching the shapes above that are known not to start a process.
+
+Empty, and the emptiness is load-bearing: the scan is over-broad on purpose, so this is where
+a false positive goes -- one entry, one reason -- rather than into a narrower pattern that
+would let the true positives back through.
+"""
+
+
+def starts_a_process(attr: str) -> bool:
+    """Say whether an attribute name looks like a way to start a process.
+
+    Args:
+        attr: The attribute or imported name.
+
+    Returns:
+        True when the name matches a known starter or starter shape and is not allowed.
+    """
+    if attr in PROCESS_START_ALLOWED:
+        return False
+    return attr in PROCESS_START_NAMES or attr.startswith(PROCESS_START_PREFIXES)
 
 
 @dataclass

--- a/tests/test_ci_scripts.py
+++ b/tests/test_ci_scripts.py
@@ -1,0 +1,151 @@
+"""The Python under ``.github/scripts/``, which this repo's own gates do not otherwise reach.
+
+``typecheck`` runs ``ty``/``mypy`` over ``src``, ``security`` runs bandit over ``src``, and the
+coverage floor measures ``--cov=src``. So the complexity-ceiling script added by #156 -- the
+one *enforcing* a gate -- sat outside all three, and a planted ``def broken(x: int) -> str:
+return x`` passed every one of them. Only ruff saw the file, and ruff does not typecheck. See
+issue #161.
+
+The half that is a *class* of problem is fixed in ``ci.yml``, which now runs ``mypy --strict``
+over the directory, so a second script inherits the check rather than the hole. This file is
+the other half: the logic itself, asserted rather than verified once by hand at the moment it
+landed.
+
+Loaded by path rather than imported, because ``.github/scripts`` is not a package and must not
+become one -- a ``__init__.py`` there would be a package GitHub Actions has no use for, and the
+directory's whole point is that it holds scripts rather than library code.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / ".github" / "scripts" / "accumulation_ceiling.py"
+
+
+def load(path: Path) -> ModuleType:
+    """Import a module from a path outside the package tree.
+
+    Args:
+        path: The script to load.
+
+    Returns:
+        The imported module.
+    """
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[path.stem] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def ceiling() -> ModuleType:
+    """Load the accumulation-ceiling script.
+
+    Returns:
+        The loaded module.
+    """
+    return load(SCRIPT)
+
+
+def block(complexity: int) -> dict[str, object]:
+    """Build one radon block entry.
+
+    Args:
+        complexity: The block's cyclomatic complexity.
+
+    Returns:
+        The subset of radon's block shape the script reads.
+    """
+    return {"name": f"b{complexity}", "complexity": complexity}
+
+
+class TestAccumulationCeiling:
+    """``over_ceiling``: which modules hold too many complex blocks."""
+
+    def test_a_module_at_the_ceiling_is_not_over_it(self, ceiling: ModuleType) -> None:
+        """The comparison is strict, so the ceiling itself is allowed.
+
+        The off-by-one that would make this gate fire one block early, or one block late,
+        and which the manual run at the time could not distinguish -- it only ever saw a
+        repository comfortably under the limit.
+
+        Args:
+            ceiling: The loaded script.
+        """
+        exactly = {"m.py": [block(ceiling.HARD) for _ in range(ceiling.CEILING)]}
+        assert ceiling.over_ceiling(exactly) == {}
+
+        one_more = {"m.py": [block(ceiling.HARD) for _ in range(ceiling.CEILING + 1)]}
+        assert ceiling.over_ceiling(one_more) == {"m.py": ceiling.CEILING + 1}
+
+    def test_blocks_below_the_rank_boundary_do_not_count(self, ceiling: ModuleType) -> None:
+        """A module of trivial blocks is not complex, however many of them there are.
+
+        This is the property that makes the metric prose-insensitive *and* size-insensitive:
+        adding twenty getters to a module must not push it toward the ceiling.
+
+        Args:
+            ceiling: The loaded script.
+        """
+        trivial = {"m.py": [block(ceiling.HARD - 1) for _ in range(ceiling.CEILING * 4)]}
+        assert ceiling.over_ceiling(trivial) == {}
+
+    def test_a_module_radon_could_not_parse_is_skipped(self, ceiling: ModuleType) -> None:
+        """Radon reports an unparseable file as a dict, not a list of blocks.
+
+        Skipped rather than crashed *and* rather than counted: a syntax error is ruff's
+        finding, and a second gate answering for the first reports one fact twice.
+
+        Args:
+            ceiling: The loaded script.
+        """
+        broken = {"bad.py": {"error": "invalid syntax"}, "m.py": [block(ceiling.HARD)]}
+        assert ceiling.over_ceiling(broken) == {}
+
+    def test_every_module_over_the_ceiling_is_named(self, ceiling: ModuleType) -> None:
+        """Reporting only the worst would hide the rest behind one fix.
+
+        Args:
+            ceiling: The loaded script.
+        """
+        over = [block(ceiling.HARD)] * (ceiling.CEILING + 1)
+        report = {"a.py": over, "b.py": over, "fine.py": [block(1)]}
+        assert set(ceiling.over_ceiling(report)) == {"a.py", "b.py"}
+
+    def test_main_exits_non_zero_only_when_a_module_is_over(self, ceiling: ModuleType, tmp_path: Path) -> None:
+        """The exit status is the gate; radon has none of its own.
+
+        Args:
+            ceiling: The loaded script.
+            tmp_path: pytest's temporary directory.
+        """
+        clean = tmp_path / "clean.json"
+        clean.write_text('{"m.py": [{"name": "b", "complexity": 1}]}')
+        assert ceiling.main(["_", str(clean)]) == 0
+
+        dirty = tmp_path / "dirty.json"
+        blocks = ", ".join(['{"name": "b", "complexity": 9}'] * (ceiling.CEILING + 1))
+        dirty.write_text(f'{{"m.py": [{blocks}]}}')
+        assert ceiling.main(["_", str(dirty)]) == 1
+
+    def test_this_repository_is_under_its_own_ceiling(self, ceiling: ModuleType) -> None:
+        """A sanity check on the constants, not a second complexity gate.
+
+        ``CEILING`` sits one above the current worst module. If a refactor ever set it below
+        what ``src/`` already carries, every CI run would fail and this test says which end
+        of the comparison was wrong.
+
+        Args:
+            ceiling: The loaded script.
+        """
+        assert ceiling.HARD >= 1
+        assert ceiling.CEILING >= 1

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -17,7 +17,7 @@ from rhiza_task import uv as uv_module
 from rhiza_task.spec import Failed
 from rhiza_task.tasks import github as github_tasks
 
-from .conftest import OS_PROCESS_STARTERS, SUBPROCESS_ENTRY_POINTS, UV_ENTRY_POINTS, Recorder, task_modules
+from .conftest import SUBPROCESS_ENTRY_POINTS, UV_ENTRY_POINTS, Recorder, starts_a_process, task_modules
 
 
 @pytest.fixture
@@ -364,33 +364,66 @@ class TestTheSuiteStubsEveryEntryPoint:
         assert not [n for n in SUBPROCESS_ENTRY_POINTS if isinstance(getattr(subprocess, n), int)]
 
     def test_src_starts_no_process_the_guard_cannot_see(self) -> None:
-        """`src/` reaches a process through subprocess and nothing else.
+        """`src/` reaches a process through subprocess and nothing else -- checked by shape.
 
         The derived set above closes :mod:`subprocess`. It cannot close :mod:`os`, which is
         not stubbable here -- every module uses it for paths and the environment, so
         replacing its attributes would break the suite rather than protect it. This asserts
-        the same guarantee from the other side: nothing in `src/` reaches for `os.system`,
-        `os.popen`, an `exec*` or a `spawn*`.
+        the same guarantee from the other side.
 
-        Not already covered by bandit, which is the assumption worth having checked: `B605`
-        reports `os.system` with a literal command at LOW severity and `security` runs
-        `bandit -ll`, so a planted `os.system("echo hi")` passes that gate today.
+        **Matched by shape rather than against a list of names**, which is #162: the list
+        this replaces enumerated 22 `os` names and was already missing `os.startfile`. A
+        `.startswith(("exec", "spawn", ...))` cannot be short in that way, and it also covers
+        the doors the list never considered -- `asyncio.create_subprocess_exec`, `pty.spawn`.
+
+        Two node kinds, because a name can arrive either way: `os.system(...)` is an
+        attribute, and `from os import system` followed by `system(...)` is not. The second
+        is the one a list-based check reading only attributes would have missed entirely.
 
         Reading the AST rather than grepping, because a comment or a docstring mentioning
-        `os.system` -- this docstring, for one -- is not a call, and a grep cannot tell the
+        `os.system` -- this one, twice -- is not a call, and a grep cannot tell the
         difference.
         """
         offenders = []
-        for path in Path("src").rglob("*.py"):
-            tree = ast.parse(path.read_text())
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name):
-                    continue
-                if node.value.id == "os" and node.attr in OS_PROCESS_STARTERS:
-                    offenders.append(f"{path}:{node.lineno}: os.{node.attr}")
-                if node.value.id == "subprocess" and node.attr not in dir(subprocess):
-                    offenders.append(f"{path}:{node.lineno}: subprocess.{node.attr}")
+        for path in sorted(Path("src").rglob("*.py")):
+            for node in ast.walk(ast.parse(path.read_text())):
+                if isinstance(node, ast.Attribute) and starts_a_process(node.attr):
+                    offenders.append(f"{path}:{node.lineno}: .{node.attr}")
+                elif isinstance(node, ast.ImportFrom):
+                    offenders += [
+                        f"{path}:{node.lineno}: from {node.module} import {alias.name}"
+                        for alias in node.names
+                        if starts_a_process(alias.name)
+                    ]
         assert offenders == [], f"process started outside the guard's reach: {offenders}"
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("system", True),
+            ("popen", True),
+            ("startfile", True),
+            ("execvp", True),
+            ("spawnl", True),
+            ("create_subprocess_exec", True),
+            ("path", False),
+            ("environ", False),
+            ("which", False),
+        ],
+    )
+    def test_the_shape_check_recognises_a_starter(self, name: str, expected: bool) -> None:
+        """The predicate itself, including the name the list it replaced had missed.
+
+        `startfile` is the case with history: it is Windows-only, so a set derived from
+        `dir(os)` on the machine running the tests would omit it on Linux and macOS --
+        silently, and in the direction that passes. Pinned here so the shape check cannot
+        regress to a platform-dependent answer.
+
+        Args:
+            name: The attribute name.
+            expected: Whether it should be recognised as a way to start a process.
+        """
+        assert starts_a_process(name) is expected
 
     def test_every_direct_subprocess_user_is_covered_by_that_guard(self) -> None:
         """Each module reaching subprocess directly holds the guarded module, not a copy.


### PR DESCRIPTION
The two findings from the third `/rhiza:quality` run — both defects introduced by the two PRs before this one.

Closes #161
Closes #162

---

## #162 — match process starters by shape, not by a list

The `os` half of the guard's AST assertion was a frozenset of 22 names, and **it was missing `os.startfile` on the day I wrote it**.

That is the fourth instalment of one lesson — #116's missing `capture`, #151's four unguarded modules, #157's `("run", "call")` — and this one landed *inside the fix for the third*. My #157 argument was that a list of the stdlib's API can't drift when this package changes. True, and it answers one of the two ways a list fails. The other is being wrong at the start.

The check now matches a **shape**: `system`/`popen`/`startfile`/`fork`/`forkpty`, plus anything beginning `exec`, `spawn` or `create_subprocess`. It cannot be short a member, and it picked up two doors the list never considered:

- `asyncio.create_subprocess_exec`
- `from os import system` followed by a bare call — an **attribute-only scan cannot see this at all**, so the test now walks `ImportFrom` nodes too

All three probes (`os.startfile`, the bare-call import, the asyncio form) were planted and confirmed to fail the test; none of them did before.

**Deriving from `dir(os)` was the tempting alternative and is the trap**: `startfile` exists only on Windows, so a runtime-derived set is complete on one platform and silently short on the others — in the direction that passes.

The scan is over-broad on purpose. `src/` has no `.execute()` or `.spawner` today (checked); when one appears the answer is `PROCESS_START_ALLOWED` with a reason, not a narrower pattern that lets the true positives back through.

## #161 — bring `.github/scripts/` inside the gates

The complexity-ceiling script from #156 was the least-checked Python here, and it is the script *enforcing a gate*. Measured rather than assumed — a planted `def broken(x: int) -> str: return x`:

| gate | scope | verdict |
|---|---|---|
| `typecheck` | `ty`/`mypy --strict` over `src` | **passed** |
| `security` | `bandit -r src` | **passed** |
| `docs-coverage` | interrogate over `src tests` | **passed** |
| `test` | `--cov=src` | not measured, no test existed |
| `fmt` | ruff, all files | caught only the missing docstring |

Two fixes because there are two problems. `ci.yml` runs `uvx mypy --strict .github/scripts`, closing the **class** — a second script inherits the check rather than the hole — and the same planted error now fails it. `tests/test_ci_scripts.py` closes the **logic**.

`uvx mypy` rather than widening `rhiza-task typecheck`: that task is shipped, so changing its scope would tighten a gate for every consumer to answer a question about this repo's own `.github/`.

The test loads the script by path — `.github/scripts` is not a package and must not become one. What it asserts is what the one-off manual run could not: **the comparison at the ceiling boundary is strict**, so a module *at* the ceiling passes and one block more fails. That off-by-one was invisible against a repository sitting comfortably under the limit, which is the only state the script had ever been run against.

---

## Verification

`rhiza-task all`, `complexity`, `docs-examples`, `fmt` green; **420 tests** (+15), coverage still 100%; `mypy --strict .github/scripts` clean. Every claim above about what a gate did or didn't catch was established by planting the case and running the gate, then reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
