### PR TITLE
docs: point the zensical link at the project's own org

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -170,7 +170,7 @@ reach the published book.
 
 `book` aggregates the report-producing gates, copies `_tests/` into `docs/reports/`,
 exports every Marimo notebook to `docs/notebooks/*.html`, builds the site with
-[zensical](https://github.com/squidfunk/zensical), and generates a coverage badge. It
+[zensical](https://github.com/zensical/zensical), and generates a coverage badge. It
 skips entirely without a `mkdocs.yml`.
 
 `paper` is a prerequisite but needs no copy step, unlike `_tests/`: tectonic writes the PDF


### PR DESCRIPTION
The weekly link check ([run 32705859718](https://github.com/Jebel-Quant/rhiza-task/actions/runs/32705859718/job/97366714179)) fails on one link, in `docs/tasks.md:173`:

```
[404] https://github.com/squidfunk/zensical (at 173:1) | Rejected status code: 404 Not Found
```

zensical now lives at `github.com/zensical/zensical` and GitHub serves no redirect from the old path. PyPI's metadata for the version this package provisions (`zensical>=0.0.36`) names the new URL as `Source`, so that is what the link points at now. It is the only `squidfunk` reference in the tree.

Nothing on a pull request would have caught this: `ci.yml`'s `links` job runs lychee `--offline`, so only local targets are resolved — the network half is weekly's by design.

Checked the rest while here: every other external URL under `README.md`, `CONTRIBUTING.md` and `docs/` resolves. The run's other note is a 308 on `https://pepy.tech/project/rhiza-task` → `/projects/`, which lychee follows and accepts — left alone, happy to fold it in if you would rather the weekly report be silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)