### PR TITLE
Publish the coverage report this repo already measures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,39 @@ jobs:
       - name: rhiza-task all
         run: uv run rhiza-task all
 
+      # `coverage` is outside `all` for the same reason `complexity` is, below: `all` is what
+      # every consumer's CI invokes, so adding a prerequisite would fail builds in
+      # repositories that changed nothing. This repository opts in by naming it here -- the
+      # mechanism a consumer would use too.
+      #
+      # It is named here rather than left to a human because the report is *published*, and
+      # nothing published should depend on somebody remembering a command. The fleet board
+      # reads coverage from an artifact by the name below, and until this step existed this
+      # was one of two repositories that produced none -- so the board reported "no report"
+      # about the package whose own floor is `coverage_fail_under = 100`.
+      #
+      # The file check is the point of the step as much as the task is: `coverage` exiting 0
+      # having written nothing is exactly the failure the upload would otherwise turn into a
+      # silently empty column.
+      - name: rhiza-task coverage
+        if: ${{ !cancelled() }}
+        run: |
+          uv run rhiza-task coverage
+          test -s _tests/coverage.xml
+
+      # The artifact name is load-bearing: the collector reading this looks for
+      # `coverage-report` and nothing else. `if-no-files-found: error` so a future change
+      # that stops writing the file fails this job rather than quietly emptying the board.
+      # Published even when another gate failed: the board should show the coverage a
+      # commit actually has, not go blank because an unrelated check was red.
+      - name: Upload coverage report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: _tests/coverage.xml
+          if-no-files-found: error
+
       # `complexity` is deliberately outside `all` -- tasks/python.py says why, in one line:
       # `all` is what every consumer's CI invokes, so adding a prerequisite to it would fail
       # builds in repositories that changed nothing. So this repository opts in by naming it


### PR DESCRIPTION
The fleet board reads coverage from a `coverage-report` artifact. This was one of two repositories that produced none — so the board reported **"no report" about the package whose own floor is `coverage_fail_under = 100`.**

Nothing was missing but the publishing. `rhiza-task coverage` already writes `_tests/coverage.xml`, and the suite sits at **100% of 1450 statements across 420 tests**. But `coverage` is not an `all` prerequisite — deliberately, for the reason `tasks/python.py` gives: `all` is what every consumer's CI invokes, so adding a prerequisite would fail builds in repositories that changed nothing. So CI never ran it, and the only copy of the report was whatever a human had last produced by hand.

This opts in by naming the task in the `gates` job — exactly the mechanism `complexity` already uses two steps below — and then uploads the result.

## Three details, each of which would have failed quietly

- **`test -s _tests/coverage.xml`.** `coverage` exiting 0 having written nothing is precisely the failure the upload would otherwise turn into a silently empty column. The same check the `python-layer` job already makes against its scratch project.
- **The artifact name is load-bearing** — the collector looks for `coverage-report` and nothing else — and `if-no-files-found: error`, so a future change that stops writing the file fails this job rather than emptying the board.
- **`if: ${{ !cancelled() }}` on both steps**, matching the opt-in steps around them: the board should show the coverage a commit actually has, not go blank because an unrelated gate was red.

## Verified

The consuming parser accepts the output — the collector's `_coverage()` returns `(100.0, 1450)` on the exact file this step uploads. Workflow is valid YAML and the action pin matches the `upload-artifact` SHA already used in `rhiza_book.yml`, `rhiza_paper.yml` and `rhiza_release.yml`.