### PR TITLE
feat: make the docstring floor a setting instead of a literal 100

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,11 +125,30 @@ exports one for every caller and deliberately leaves it empty for consumers, who
 | setting | default | what |
 |---|---|---|
 | `coverage_fail_under` | `90` | the coverage floor, enforced wherever `test` runs |
+| `docs_coverage_fail_under` | `100` | the docstring floor `docs-coverage` hands interrogate |
 | `complexity_max` | `15` | the cyclomatic-complexity ceiling `complexity` enforces |
 | `typechecker` | `ty` | `ty`, `mypy` or `both` |
 | `license_fail_on` | `("GPL", "LGPL", "AGPL")` | matched as **substrings** |
 | `license_ignore_packages` | `()` | packages exempt from the copyleft scan |
 | `deptry_ignore` | `()` | deptry rule codes to suppress |
+
+!!! tip "Adopting `docs-coverage` on a codebase that already exists"
+    The floor defaults to 100 and stays there, because a docstring is either present or it
+    is not. A repository arriving at 89% has no way to reach it in one commit, though, and
+    the two workarounds are both worse than saying so: writing docstrings for every nested
+    helper in one sitting, or shadowing the recipe in `local.mk` — which CI never reads, so
+    the gate then passes locally and fails on the runner.
+
+    Set the floor to what you have and raise it as a ratchet:
+
+    ```toml
+    [tool.rhiza-task]
+    docs_coverage_fail_under = 89
+    ```
+
+    Only the Python layer takes a number. Rust and Go express the same gate as
+    `-D missing_docs` and revive's `exported` rule, which are pass/fail on one item rather
+    than a percentage over a tree, so there is no threshold for them to read.
 
 !!! warning "`typechecker = "both"` masks `ty`"
     `python.mk` documented it and the behaviour is unchanged: `both` hides `ty`'s exit

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -179,6 +179,21 @@ class Config:
 
     coverage_fail_under: int = 90
 
+    # The floor ``docs-coverage`` hands interrogate. 100 because a docstring is present or
+    # it is not -- unlike a line of code, which can be covered by a test that asserts
+    # nothing -- so there is no honest reason to aim lower in a repo starting from scratch.
+    #
+    # A setting rather than the literal it was, because the repos adopting this are not
+    # starting from scratch. A codebase arriving at 89% has one gate it cannot pass and no
+    # way to say so, and the two answers left were both worse than a number: write
+    # docstrings for every nested helper in one sitting, or shadow the whole recipe in
+    # ``local.mk`` -- which is CI-invisible, so the gate then passes locally and fails in
+    # CI. Both were observed on the same upgrade; see jebel-quant/rhiza#1654.
+    #
+    # Lowering it is a ratchet to raise again, not a destination. The default is unchanged,
+    # so a repo that says nothing is gated exactly as before.
+    docs_coverage_fail_under: int = 100
+
     # The ceiling the ``complexity`` gate enforces, as radon's own cyclomatic-complexity
     # number rather than its A-F rank. A number and not a rank because rank C spans 11-20,
     # which is too coarse to hold a decision: this repository's four deliberate C blocks
@@ -297,8 +312,9 @@ class Config:
         validated setting" stop being an open-ended growth rule.
 
         Raises:
-            ValueError: When ``typechecker`` is not one of ty, mypy, both,
-                ``coverage_fail_under`` is outside 0-100, ``complexity_max`` is below 1,
+            ValueError: When ``typechecker`` is not one of ty, mypy, both, either of
+                ``coverage_fail_under`` and ``docs_coverage_fail_under`` is outside 0-100,
+                ``complexity_max`` is below 1,
                 ``layers`` names a layer that does not exist, :attr:`root` is not an
                 existing directory, or a ``*_folder`` escapes it. Each helper below raises
                 for its own settings and documents the message it uses.
@@ -369,14 +385,22 @@ class Config:
             raise ValueError(msg)
 
     def _validate_coverage(self) -> None:
-        """Reject a :attr:`coverage_fail_under` that is not a percentage.
+        """Reject a coverage floor that is not a percentage.
+
+        Both floors are checked in one loop rather than in two helpers, because they are
+        the same validation and not merely a similar one: whatever a third percentage
+        setting turns out to be, it joins the tuple and adds no branch here. That is the
+        ceiling this helper commits to -- a name, never an ``if``.
 
         Raises:
-            ValueError: When ``coverage_fail_under`` is outside 0-100.
+            ValueError: When ``coverage_fail_under`` or ``docs_coverage_fail_under`` is
+                outside 0-100.
         """
-        if not 0 <= int(self.coverage_fail_under) <= 100:
-            msg = f"coverage_fail_under must be a percentage (got {self.coverage_fail_under!r})"
-            raise ValueError(msg)
+        for name in ("coverage_fail_under", "docs_coverage_fail_under"):
+            value = getattr(self, name)
+            if not 0 <= int(value) <= 100:
+                msg = f"{name} must be a percentage (got {value!r})"
+                raise ValueError(msg)
 
     def _validate_complexity_max(self) -> None:
         """Reject a :attr:`complexity_max` below 1.

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -352,7 +352,11 @@ def license_(cfg: Config) -> None:
     guards=(Guard("source_folder"),),
 )
 def docs_coverage(cfg: Config) -> None:
-    """Require 100% docstring coverage over the source and test folders.
+    """Enforce :attr:`Config.docs_coverage_fail_under` over the source and test folders.
+
+    The floor was the literal ``100`` until it became a setting; it still *defaults* to
+    100, so a repo that configures nothing is gated exactly as it was. The field's own
+    comment carries why it is now askable.
 
     Args:
         cfg: The resolved config.
@@ -362,7 +366,7 @@ def docs_coverage(cfg: Config) -> None:
         "interrogate",
         "-vv",
         "--fail-under",
-        "100",
+        str(cfg.docs_coverage_fail_under),
         "--ignore-init-method",
         "--ignore-magic",
         *folders,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,14 +262,29 @@ def test_invalid_typechecker_fails_at_load(tmp_path: Path) -> None:
         Config.load(root=tmp_path, typechecker="tpye")
 
 
-def test_invalid_coverage_threshold_fails_at_load(tmp_path: Path) -> None:
-    """A coverage threshold outside 0-100 is rejected.
+@pytest.mark.parametrize("field", ["coverage_fail_under", "docs_coverage_fail_under"])
+def test_invalid_coverage_threshold_fails_at_load(tmp_path: Path, field: str) -> None:
+    """A coverage threshold outside 0-100 is rejected, and named in the message.
+
+    Parametrised over both floors rather than asserted on one: the validator loops, so a
+    test that checked only ``coverage_fail_under`` would pass against a loop that had lost
+    the other name from its tuple.
+
+    Args:
+        tmp_path: The repository root.
+        field: The percentage setting under test.
+    """
+    with pytest.raises(ValueError, match=f"{field} must be a percentage"):
+        Config.load(root=tmp_path, **{field: 900})
+
+
+def test_the_docstring_floor_defaults_to_a_hundred(tmp_path: Path) -> None:
+    """Making the floor configurable did not lower it.
 
     Args:
         tmp_path: The repository root.
     """
-    with pytest.raises(ValueError, match="percentage"):
-        Config.load(root=tmp_path, coverage_fail_under=900)
+    assert Config.load(root=tmp_path).docs_coverage_fail_under == 100
 
 
 @pytest.mark.parametrize("value", [0, -1])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1122,7 +1122,10 @@ class TestPythonDocsCoverage:
     """python.mk's ``docs-coverage``."""
 
     def test_measures_both_folders_the_gate_claims(self, cfg: Config, recorder: Recorder) -> None:
-        """Both the source and the test tree are measured, at a 100% floor.
+        """Both the source and the test tree are measured, at the default 100% floor.
+
+        The literal is the assertion that making the floor a setting did not move the
+        default: a repo configuring nothing is gated exactly as it was before #1654.
 
         Args:
             cfg: The resolved config.
@@ -1132,6 +1135,19 @@ class TestPythonDocsCoverage:
         call = recorder.find("interrogate")
         assert call.flags[:5] == ["-vv", "--fail-under", "100", "--ignore-init-method", "--ignore-magic"]
         assert call.flags[5:] == ["src", "tests"]
+
+    def test_honours_a_configured_floor(self, cfg: Config, recorder: Recorder) -> None:
+        """A repo that cannot reach 100 today says so, rather than shadowing the recipe.
+
+        The point of the setting: ``local.mk`` could already override this gate locally and
+        was invisible to CI, so the override passed on a laptop and failed on a runner.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.docs_coverage(replace(cfg, docs_coverage_fail_under=85))
+        assert recorder.find("interrogate").flags[:3] == ["-vv", "--fail-under", "85"]
 
     def test_omits_a_folder_that_is_not_there(self, cfg: Config, recorder: Recorder) -> None:
         """A repository with no test folder is measured on what it has.


### PR DESCRIPTION
## What

`docs-coverage` hardcoded `--fail-under 100`. It was the only floor in the package that was not a setting — `coverage_fail_under` has been configurable and threaded through Python, Rust and Go since the beginning.

`docs_coverage_fail_under` is now a `Config` field. It **defaults to 100**, so a repo that configures nothing is gated exactly as it was.

## Why

[jebel-quant/rhiza#1654](https://github.com/Jebel-Quant/rhiza/issues/1654) logs a v1.3.2 → v1.7.1 upgrade. Most of that thread is people working around gates, and the docstring floor is the item with no way out: a codebase arriving at 89% had two answers, both worse than a number.

- Write docstrings for every nested helper, private function and property in one sitting.
- Shadow the whole recipe in `local.mk` — which **CI never reads**, so the gate then passes on a laptop and fails on the runner.

The issue's own guide documents the second as the recommended workaround, and the follow-up comment reports it as a surprise when CI disagreed. Lowering the floor is a ratchet to raise again; `docs/configuration.md` says so where a reader looking for the setting will find it.

## Shape

- `config.py` — the field, with its reasoning in the comment beside it.
- `_validate_coverage` now **loops** over the percentage settings rather than testing one. A third one adds a name to the tuple and no branch, which is the ceiling that helper's docstring now commits to. The message names the offending field, so the two are distinguishable.
- `tasks/python.py` — `str(cfg.docs_coverage_fail_under)` in interrogate's vector.
- Tests — the existing case keeps asserting the literal `100`, which is what makes it the assertion that the *default did not move*; a new case covers a configured floor, and the validation test is parametrised over both settings so it cannot pass against a loop that lost a name.

Python only. Rust's `-D missing_docs` and Go's revive `exported` rule are pass/fail on one item rather than a percentage over a tree, so they have no threshold to read.

## Gates

`rhiza-task all`, `complexity`, `docs-examples`, the full suite at the 100% floor, pinned `ruff` check and format — all green locally. Resolution from a manifest verified end-to-end on a scratch repo, under both the `docs-coverage-fail-under` and `docs_coverage_fail_under` spellings.

## Release

`feat:`, so a **minor**. It loosens rather than tightens, so no `⚠️ Upgrade note` is owed under the rule in `CLAUDE.md`.

Refs: jebel-quant/rhiza#1654