### PR TITLE
feat: add `update`, the template sync as one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,3 +880,76 @@ jobs:
       # exists to check.
       - name: Run tests against the floors
         run: uv run --all-extras --all-groups --resolution lowest-direct pytest -ra
+
+  # The one task with no fixture-free way to be exercised, and the one whose unit tests are
+  # least able to speak for it: `update` drives *another repository's* scripts, so what the
+  # suite asserts is the vector this package sends and nothing at all about whether `sync.py`
+  # still accepts it. That is exactly the gap #148 shipped a release through -- a vector
+  # well-formed, unit-asserted and wrong -- so it gets a job rather than a promise.
+  #
+  # Read a failure here as "the front door and the scripts disagree", which is actionable in
+  # this repository even when the change was upstream. That is the line `links` draws for the
+  # network half of its checks, and it falls on the other side of it.
+  template-layer:
+    name: update against the real sync scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.16"
+          enable-cache: true
+
+      # Plain "$RUNNER_TEMP", not the `${RUNNER_TEMP//\\//}` rewrite `python-layer` needs: that
+      # one exists because a backslash path means two different things to bash and to Python's
+      # `Path` inside one step, and this job is Linux-only, where the value has no backslashes
+      # to rewrite. Adding Windows here would mean adopting it.
+      #
+      # A real git repository with a real pointer file, because `sync.py` refuses a dirty tree
+      # and writes a lock relative to the repository root -- neither of which a bare directory
+      # can exercise. The ref is deliberately an *old* one: syncing to a release that is behind
+      # the latest is the case a consumer is in, and it keeps the job off whatever landed
+      # upstream this morning.
+      - name: Build a throwaway managed repository
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/managed/.rhiza"
+          cd "$RUNNER_TEMP/managed"
+          git init -q -b main
+          git config user.email ci@example.com
+          git config user.name CI
+          # Every field here was corrected by running this for real, which is the argument for
+          # the job in miniature. `repo:` is not the key -- `_validate_fields.py` requires
+          # `template-repository` or `repository` -- and there is no `python` bundle; the two
+          # a Python repo actually names are `core` and `python-core`. Both mistakes came
+          # straight from the guide in rhiza#1654, and both exit non-zero here.
+          cat > .rhiza/template.yml <<'EOF'
+          template-repository: "jebel-quant/rhiza"
+          ref: "v1.7.0"
+          templates:
+            - core
+            - python-core
+          EOF
+          git add -A
+          git commit -qm "chore: a repository with a template pointer"
+
+      # TEMPLATE_REF exercises the bump as well as the sync: the `ref:` rewrite is the only
+      # file this task writes itself, so a job that left it unset would test three quarters of
+      # the command. Asserted below rather than trusted, since a no-op rewrite still exits 0.
+      - name: Sync it, as a consumer would
+        env:
+          TEMPLATE_REF: v1.7.1
+        run: uv run rhiza-task update --root "$RUNNER_TEMP/managed"
+
+      # Three assertions, because a zero exit separates none of them. The pointer moved; the
+      # sync wrote its lock; and the staged set is non-empty -- that last one is what fails if
+      # `stage_synced.py` grew an argument this package does not pass, which is the drift this
+      # whole job exists to notice.
+      - name: Check the sync actually landed
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/managed"
+          grep -q 'ref: "v1.7.1"' .rhiza/template.yml
+          test -f .rhiza/template.lock
+          git diff --cached --quiet && { echo "nothing was staged"; exit 1; }
+          echo "staged $(git diff --cached --name-only | wc -l) file(s)"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,20 @@ exports one for every caller and deliberately leaves it empty for consumers, who
 | `license_ignore_packages` | `()` | packages exempt from the copyleft scan |
 | `deptry_ignore` | `()` | deptry rule codes to suppress |
 
+### The template sync
+
+| setting | default | what |
+|---|---|---|
+| `template_ref` | `""` | the ref `update` moves `.rhiza/template.yml` to; empty re-syncs at the pinned one |
+
+Two environment variables belong to the same task and are deliberately *not* settings, for
+the reason `RHIZA_UV_BIN` is not one — they say where a tool lives on this machine, which is
+not a property of the repository:
+
+- **`RHIZA_CLAUDE_DIR`** — an existing rhiza-claude clone to read the sync scripts from.
+  Never written to.
+- **`XDG_CACHE_HOME`** — where this package keeps its own clone when the above is unset.
+
 !!! tip "Adopting `docs-coverage` on a codebase that already exists"
     The floor defaults to 100 and stays there, because a docstring is either present or it
     is not. A repository arriving at 89% has no way to reach it in one commit, though, and

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -256,6 +256,66 @@ Every other binary the package reaches for — docker, gh, git-lfs, tectonic, ma
 an install URL. `doctor.mk` also probed GNU make, which was honest while the task layer *was*
 make; nothing here needs it, so it is not probed at all.
 
+## Template
+
+| task | needs | does |
+|---|---|---|
+| `update` | — | sync the rhiza template into this repository |
+
+The one task here that replaces a *document* rather than a make recipe.
+[jebel-quant/rhiza#1654](https://github.com/Jebel-Quant/rhiza/issues/1654) logs an upgrade
+that took eight steps, a clone into `~/.local/share`, three scripts run in sequence and four
+commits — and the guide written from it says `git add -A`, where the upstream document says
+never to. `update` is those steps as one command:
+
+```bash
+TEMPLATE_REF=v1.8.0 uvx rhiza-task update
+```
+
+The ref is a setting rather than a flag, because a task body takes a `Config` and nothing
+else. The environment layer is the spelling above; a repo pinning its next target in
+`pyproject.toml` works too. Leave it unset to re-sync at whatever `.rhiza/template.yml`
+already names.
+
+**It wraps, and does not reimplement.** `rhiza-claude`'s `docs/headless.md` settles that:
+*"A separate CLI would be a second implementation of sync to keep in step with the first,
+and that is the one thing this project has decided not to maintain. One operation, one entry
+point."* So nothing here parses `template.yml`, resolves a bundle, walks the lock or merges a
+file — `sync.py`, `resolve_conflicts.py` and `stage_synced.py` do, and this runs them in
+their documented order and reads their documented exit codes. `resolve_conflicts.py` is
+reached **only** on exit 1, which means "synced, with conflicts"; exit 2 means the sync
+refused and applied nothing, so there is no half-done state to unpick.
+
+Why it lives in this package: `rhiza-task` is the only piece of the ecosystem on PyPI, so
+`uvx rhiza-task update` needs no install — and the install was the step people tripped over.
+
+**It stops before the commit**, and prints the command instead:
+
+```text
+[INFO] staged the synced files. To commit exactly that set:
+[INFO]   SKIP=check-managed-files git commit -m "chore: apply rhiza sync v1.8.0"
+```
+
+That `SKIP=` is not decoration. rhiza-hooks' `check-managed-files` refuses a commit touching
+any path in the lock's `files:` list, and this commit is by construction exactly that list —
+better seen once than hidden. A sync that resolved conflicts has just taken the template's
+side of each one, which is right for a managed file and still a diff worth reading before it
+becomes history.
+
+`RHIZA_CLAUDE_DIR` points at an existing rhiza-claude clone — the `~/.local/share/rhiza-claude`
+that `headless.md` tells you to make. Set, it is read and **never written to**: a
+`git reset --hard` into your working clone is not something a sync command should be able to
+do to you. Unset, this package keeps its own shallow clone under `XDG_CACHE_HOME` and
+refreshes that, because a stale `sync.py` is a correctness risk and its own copy has nothing
+to lose.
+
+!!! warning "This is the one task this repository cannot run against itself"
+    `rhiza-task` is not rhiza-managed and has no `.rhiza/` — see `CLAUDE.md` — so `update`
+    skips here, and CI's `gates` job cannot dogfood it the way it does every other gate. Its
+    vectors are unit-asserted and exercised against a scratch repository, but nothing in
+    *this* repository proves `sync.py` still takes the arguments it is passed. What would is
+    a job in rhiza-claude running its scripts against this front door.
+
 ## Bundle-owned sections
 
 The last five sections are the bundle-owned fragments. **None is a gate**: no `all` names
@@ -356,6 +416,9 @@ reader can tell "skipped deliberately" from "forgotten":
 - **`complexity`** and **`docs-examples`** — adding either to `all` would fail builds in
   repositories that changed nothing, so a repo opts in by naming it in its own CI, which
   is what this one does.
+- **`update`** — it *changes* the repository rather than measuring it, which is the opposite
+  of what an aggregate of gates is for. A sync inside `all` would mean `rhiza-task all`
+  rewriting managed files mid-run.
 - **the bundle-owned sections** — none is a gate, as above.
 
 Anything else registered *is* in `all` for its layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ docker = "rhiza_task.tasks.docker"
 lfs = "rhiza_task.tasks.lfs"
 paper = "rhiza_task.tasks.paper"
 presentation = "rhiza_task.tasks.presentation"
+# `update` is the odd one out: it wraps another project's scripts rather than a make recipe,
+# and it is the only task this repository cannot run against itself -- there is no `.rhiza/`
+# here to sync. See the module docstring, which says so at length rather than leaving it to
+# be discovered.
+template = "rhiza_task.tasks.template"
 
 [project.urls]
 Homepage = "https://github.com/jebel-quant/rhiza-task"

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -205,6 +205,15 @@ class Config:
     # does not should either raise it or not run the gate.
     complexity_max: int = 15
 
+    # The ref ``update`` moves .rhiza/template.yml to, e.g. ``v1.8.0``. Empty means "sync at
+    # the ref the file already names", which is the re-sync case rather than the upgrade one.
+    #
+    # A setting and not a flag because a task body takes a Config and nothing else -- see
+    # spec.Task.run. That is not a workaround: the environment layer already spells it
+    # (``TEMPLATE_REF=v1.8.0 rhiza-task update``), and a repo pinning its next target in
+    # pyproject.toml is a use the flag would not have served.
+    template_ref: str = ""
+
     # ty | mypy | both. python.mk documents that ``both`` masks ty's exit status behind
     # mypy's, and jointview sets ``ty`` in .rhiza/.env for that reason. The shell ``case``
     # whose fourth branch validated this is replaced by __post_init__, so a typo now fails

--- a/src/rhiza_task/tasks/template.py
+++ b/src/rhiza_task/tasks/template.py
@@ -1,0 +1,286 @@
+"""The template sync, as one command, for people who are not driving it from Claude.
+
+Every other module here replaces a make recipe. This one replaces a *README section*:
+jebel-quant/rhiza#1654 logs an upgrade that took eight documented steps, a clone into
+``~/.local/share``, three scripts run in sequence and four commits, and the guide that came
+out of it is wrong in one place that matters -- it says ``git add -A`` where the upstream
+document says never to, because the lock records exactly which paths the sync materialised
+and staging everything sweeps unrelated work into the sync commit.
+
+**This is a wrapper, and that is the whole design.** ``rhiza-claude``'s ``docs/headless.md``
+settles the question this module would otherwise re-open:
+
+    Nothing here is a re-implementation. ``/rhiza:update`` shells out to the very
+    ``sync.py`` invocation shown below [...] A separate CLI would be a second
+    implementation of sync to keep in step with the first, and that is the one thing this
+    project has decided not to maintain. One operation, one entry point.
+
+So nothing below parses ``template.yml``, resolves a bundle, walks the lock or merges a
+file. Those live in ``sync.py``, ``resolve_conflicts.py`` and ``stage_synced.py``, which are
+stdlib-only, type-checked and covered in the repository that owns them. This module
+provisions them, runs them in the documented order, reads the documented exit codes, and
+stops. A third caller of one entry point is not a second implementation of it.
+
+**Why it lives here** rather than beside the scripts: ``rhiza-task`` is the only thing in
+this ecosystem published to PyPI, so ``uvx rhiza-task update`` needs no install at all --
+and the install was the step the issue's users tripped over. The scripts stay where they
+are; only the front door moves to where a consumer already is.
+
+**Where it stops, and why it stops there.** After ``stage_synced.py`` the change is on disk
+and staged, and this task prints the commit command instead of running it. Two reasons, and
+neither is timidity. The commit needs ``SKIP=check-managed-files`` -- rhiza-hooks refuses a
+commit touching any path in the lock's ``files:`` list, and this commit is by construction
+exactly that list -- which is a thing a person should see once rather than have hidden. And
+a sync that reported conflicts has just resolved them by taking the template's side, which
+is right for a managed file and is still a diff worth reading before it is history.
+
+**This is the one task in the package that this repository cannot dogfood.** ``ci.yml``'s
+``gates`` job runs ``rhiza-task all`` against this tree, and there is no ``.rhiza/`` here to
+sync -- CLAUDE.md's first section says why, at length. So the guard below skips, and the
+vectors are asserted the way every other module's are, plus a scratch-repo job in CI. That
+is a real gap and worth naming rather than leaving for someone to discover: nothing here
+proves ``sync.py`` still takes the arguments this module passes it. What would prove it is a
+job in *rhiza-claude* running its scripts against this front door, which is that
+repository's call to make.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ..config import Config
+from ..spec import Failed, Guard, task
+from ..uv import tool, uv_run
+
+SCRIPTS_REPO = "https://github.com/Jebel-Quant/rhiza-claude"
+"""Where the sync scripts come from. Not a setting: which implementation of the template
+sync is authoritative is not a per-repository choice, and a repo pointing this at a fork
+would be running a second implementation -- the thing the module docstring rules out."""
+
+SCRIPTS_SUBDIR = "plugin/scripts"
+"""Where the scripts sit inside that clone. ``headless.md`` spells the same path into its
+``$RHIZA`` export, so a reader following either document lands in the same directory."""
+
+SCRIPTS_PYTHON = "3.12"
+"""The interpreter the scripts are run under.
+
+``headless.md`` is unambiguous: ``tomllib`` and ``datetime.UTC`` put their floor at 3.11,
+but 3.12 is what every command pins and the only version their CI exercises -- and a bare
+``python3`` on macOS is 3.9, which crashes ``sync.py``. Pinning it here is what stops this
+front door being the one that reintroduces that crash. It is deliberately *not* tied to
+:attr:`Config.python_version`, which is the target repository's interpreter and has nothing
+to say about a different project's scripts."""
+
+TEMPLATE_YML = ".rhiza/template.yml"
+"""The pointer file. Its presence is what makes a repository rhiza-managed, so it is also
+the guard: a repo without one has no template to sync and skips rather than fails."""
+
+REF_KEYS = ("template-branch", "ref")
+"""The keys that can hold the template ref, in the precedence the sync itself applies.
+
+Not a preference: ``_validate_fields.py`` picks ``template-branch`` over ``ref`` when a file
+has both, so this order is a mirror of that one. Reversing it would produce a pointer file
+that disagrees with the version actually synced, with nothing non-zero anywhere to say so."""
+
+CONFLICTS = 1
+"""``sync.py``'s exit code for "synced, with conflicts" -- an expected outcome, not an error.
+
+The three codes are a contract that document states: 0 synced cleanly or already current,
+1 synced with conflicts and the merged files are on disk, 2 refused and applied nothing.
+Only 1 is named here because 0 needs no branch and anything else is a failure; treating 1 as
+an error is the mistake this constant exists to make hard."""
+
+
+def _cache_root() -> Path:
+    """Return the directory this module keeps its own clone of the scripts in.
+
+    ``XDG_CACHE_HOME`` is honoured because it is the standard answer and because it is what
+    makes the clone path testable without writing to a real home directory.
+
+    Returns:
+        The clone directory, which may not exist yet.
+    """
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base).expanduser() / "rhiza-task" / "rhiza-claude"
+
+
+def _ensure_scripts(cfg: Config) -> Path:
+    """Return the scripts directory, cloning it first when this module owns the copy.
+
+    Two cases, and the difference between them is who the clone belongs to. With
+    ``RHIZA_CLAUDE_DIR`` set the directory is *someone else's* -- most likely the
+    ``~/.local/share/rhiza-claude`` that ``headless.md`` tells people to make -- so it is
+    used exactly as found and never written to. A ``git reset --hard`` into a working clone
+    would discard whatever the person had in it, which is not a thing a sync command should
+    be able to do to you.
+
+    The cache copy is ours, so it is refreshed: a stale ``sync.py`` is a correctness risk,
+    and here there is nothing to lose by moving it.
+
+    Args:
+        cfg: The resolved config, for the working directory git is invoked from.
+
+    Returns:
+        The directory holding ``sync.py`` and its siblings.
+
+    Raises:
+        Failed: When ``RHIZA_CLAUDE_DIR`` names a directory with no scripts in it. Silently
+            falling back to the cache would run a different copy than the one asked for.
+    """
+    override = os.environ.get("RHIZA_CLAUDE_DIR")
+    if override:
+        scripts = Path(override).expanduser() / SCRIPTS_SUBDIR
+        if not scripts.is_dir():
+            msg = f"RHIZA_CLAUDE_DIR is set to {override}, which has no {SCRIPTS_SUBDIR}/"
+            raise Failed(2, msg)
+        return scripts
+
+    cache = _cache_root()
+    if (cache / ".git").is_dir():
+        tool("git", "-C", str(cache), "fetch", "--depth", "1", "origin", "HEAD", cwd=cfg.root)
+        tool("git", "-C", str(cache), "reset", "--hard", "FETCH_HEAD", cwd=cfg.root)
+    else:
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        tool("git", "clone", "--depth", "1", SCRIPTS_REPO, str(cache), cwd=cfg.root)
+    return cache / SCRIPTS_SUBDIR
+
+
+def _bump_ref(path: Path, ref: str) -> None:
+    r"""Rewrite the pointer's ref line, and nothing else in the file.
+
+    **Which key holds the ref is not a fixed answer**, and getting it wrong fails silently
+    rather than loudly. ``_validate_fields.py`` resolves it as ``"template-branch" if
+    "template-branch" in config else "ref"`` -- so in a file carrying both, ``template-branch``
+    is what the sync obeys. Rewriting ``ref:`` there would leave the file *claiming* the new
+    version while the sync fetched the old one, and every exit code would be 0. The same
+    precedence is applied here for exactly that reason.
+
+    The anchor is column zero, copied from ``headless.md``'s own
+    ``sed -i "s/^ref: .*/ref: \"$TARGET\"/"``: ``profiles:``, ``templates:``, ``exclude:`` and
+    ``language:`` are a separate decision a version bump must not carry, and matching at any
+    indentation would reach a nested key inside them.
+
+    Args:
+        path: The ``.rhiza/template.yml`` to edit.
+        ref: The target ref, e.g. ``v1.8.0``.
+
+    Raises:
+        Failed: When the file holds neither key at top level. Appending one would be a guess
+            about a file this module has already said it does not parse.
+    """
+    lines = path.read_text().splitlines(keepends=True)
+    for key in REF_KEYS:
+        if not any(line.startswith(f"{key}:") for line in lines):
+            continue
+        rewritten = [f'{key}: "{ref}"\n' if line.startswith(f"{key}:") else line for line in lines]
+        path.write_text("".join(rewritten))
+        return
+    msg = f"{TEMPLATE_YML} has no top-level {' or '.join(REF_KEYS)} line to bump"
+    raise Failed(2, msg)
+
+
+def _commit_bump(cfg: Config) -> None:
+    """Commit the pointer bump, because ``sync.py`` refuses to run with it uncommitted.
+
+    This is the one commit the task makes, and it is not a relaxation of the rule that the
+    *sync* commit is the caller's -- it is a precondition of getting a sync at all.
+    ``headless.md`` has it as step 2 for the same reason, and a real run is what proved it
+    load-bearing: bump, then sync, and sync reports ``Working tree is not clean`` naming the
+    file this task just wrote. Vector tests cannot find that, since the refusal is a fact
+    about ``sync.py`` rather than about the arguments handed to it.
+
+    The pathspec is not decoration. ``headless.md`` says ``git commit -am``, which would
+    sweep every other modified tracked file into a commit whose message claims to be a
+    version bump; naming the path commits that path and nothing else. A tree dirty for other
+    reasons is then still refused by ``sync.py``, which is upstream's call to make and not
+    this module's to pre-empt.
+
+    Args:
+        cfg: The resolved config.
+    """
+    tool("git", "commit", "-m", f"chore: bump rhiza to {cfg.template_ref}", "--", TEMPLATE_YML, cwd=cfg.root)
+
+
+def _script(cfg: Config, scripts: Path, name: str, *args: str, check: bool = True) -> int:
+    """Run one headless script against the target repository.
+
+    ``--no-project`` is not optional: without it uv resolves the *target* repo's environment
+    for a script that imports nothing outside the standard library, which at best is a slow
+    no-op and at worst fails in a repo whose own dependencies do not resolve.
+
+    Args:
+        cfg: The resolved config.
+        scripts: The directory holding the scripts.
+        name: The script's filename, e.g. ``sync.py``.
+        *args: Arguments after the repository path.
+        check: Raise on a non-zero exit rather than returning it.
+
+    Returns:
+        The script's exit status.
+    """
+    return uv_run(
+        "python",
+        str(scripts / name),
+        str(cfg.root),
+        *args,
+        cwd=cfg.root,
+        no_project=True,
+        python=SCRIPTS_PYTHON,
+        check=check,
+    )
+
+
+@task(
+    "update",
+    "sync the rhiza template into this repository",
+    section="Template",
+    # No `Guard(tool="git")`, and that is a rule rather than an omission: `doctor` names uv
+    # and git as the two prerequisites a process running `uvx rhiza-task` cannot do without,
+    # and fails on a miss. Guarding a task on one of them would demote that hard requirement
+    # to a per-task skip, so `test_probes_nothing_a_guard_already_owns` asserts the two sets
+    # are disjoint -- and caught this guard on the first run. A machine with no git gets the
+    # OS's own message from the clone, which is what `uv.py`'s `_bin` already settles for uv.
+    guards=(Guard(file=TEMPLATE_YML, reason=f"no {TEMPLATE_YML}; this repository is not rhiza-managed"),),
+)
+def update(cfg: Config) -> None:
+    """Bump the template pointer if asked, then sync, resolve and stage.
+
+    The four steps ``headless.md`` documents, in its order and reading its exit codes. What
+    is left to the caller is the commit, for the reasons the module docstring gives.
+
+    Args:
+        cfg: The resolved config. :attr:`Config.template_ref` is the ref to move to; empty
+            re-syncs at whatever ``template.yml`` already names.
+
+    Raises:
+        Failed: When ``sync.py`` refused -- a dirty tree, an invalid ``template.yml`` or a
+            git failure -- or when a later step failed. A refusal applies nothing, so there
+            is no half-done state to unpick.
+    """
+    scripts = _ensure_scripts(cfg)
+    if cfg.template_ref:
+        _bump_ref(cfg.root / TEMPLATE_YML, cfg.template_ref)
+        _commit_bump(cfg)
+        print(f"[INFO] {TEMPLATE_YML} now points at {cfg.template_ref}")
+
+    code = _script(cfg, scripts, "sync.py", check=False)
+    if code == CONFLICTS:
+        # Taking the template's side of every marker is what resolve_conflicts.py does, and
+        # it is right rather than merely convenient: a rhiza-managed file is the template's
+        # to own, so local divergence in one is drift to undo, not work to preserve.
+        print("[INFO] sync reported conflicts; taking the template's side")
+        _script(cfg, scripts, "resolve_conflicts.py")
+    elif code:
+        # Naming the bump matters when there was one: the pointer is committed by then, so
+        # "applied nothing" is true of the sync and not of the run, and a reader with a dirty
+        # tree needs to know there is a commit to drop.
+        detail = "sync refused and applied nothing: dirty tree, invalid template.yml, or git failure"
+        if cfg.template_ref:
+            detail += f" (the bump to {cfg.template_ref} is already committed)"
+        raise Failed(code, detail)
+
+    _script(cfg, scripts, "stage_synced.py", "--json")
+    target = cfg.template_ref or "the pinned ref"
+    print("[INFO] staged the synced files. To commit exactly that set:")
+    print(f'[INFO]   SKIP=check-managed-files git commit -m "chore: apply rhiza sync {target}"')

--- a/src/rhiza_task/uv.py
+++ b/src/rhiza_task/uv.py
@@ -174,6 +174,7 @@ def uv_run(
     cwd: Path,
     withs: Sequence[str] = (),
     no_project: bool = False,
+    python: str | None = None,
     check: bool = True,
     env: Mapping[str, str] | None = None,
 ) -> int:
@@ -186,6 +187,12 @@ def uv_run(
         withs: Packages to inject, e.g. ``("pytest", "pytest-cov")``.
         no_project: Pass ``--no-project``, for a tool that must not see the project
             environment. marimo.mk's ``marimo`` target is the one case.
+        python: Interpreter to run under, as ``uvx``'s parameter of the same name already
+            does. Usually omitted -- a tool run against the project environment takes that
+            environment's interpreter, which is the point of this form. ``update`` is the
+            exception: the scripts it drives are a *different* project's, pinned by that
+            project to one version, so the interpreter is theirs to name rather than the
+            target repository's.
         check: Raise on non-zero rather than returning the status.
         env: Extra environment variables.
 
@@ -196,6 +203,8 @@ def uv_run(
         Failed: When ``check`` and the tool exited non-zero.
     """
     argv = [_bin("uv", "RHIZA_UV_BIN"), "run"]
+    if python:
+        argv += ["--python", python]
     if no_project:
         argv.append("--no-project")
     for w in withs:

--- a/tests/test_template_tasks.py
+++ b/tests/test_template_tasks.py
@@ -1,0 +1,394 @@
+"""``update``: the template sync wrapped as one command.
+
+Asserted the way every other task is -- on the argument vectors it *would* run -- with one
+addition that matters more here than elsewhere. This module drives another project's
+scripts, so the thing most likely to break is not the code below but the contract between
+them: the script filenames, the order, the ``--no-project`` and interpreter pin, and the
+exit codes ``sync.py`` documents. Those are what these tests pin, because they are what a
+change in either repository would silently invalidate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from rhiza_task.config import Config
+from rhiza_task.spec import Failed
+from rhiza_task.tasks import template
+
+from .conftest import Recorder
+
+
+@pytest.fixture
+def managed(cfg: Config) -> Config:
+    """Give the throwaway repository a ``.rhiza/template.yml`` so ``update``'s guard passes.
+
+    Args:
+        cfg: The resolved config.
+
+    Returns:
+        The same config, with the pointer file now on disk.
+    """
+    pointer = cfg.root / template.TEMPLATE_YML
+    pointer.parent.mkdir(parents=True, exist_ok=True)
+    pointer.write_text('template-repository: "jebel-quant/rhiza"\nref: "v1.3.2"\ntemplates:\n  - github-marimo\n')
+    return cfg
+
+
+@pytest.fixture
+def scripts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``RHIZA_CLAUDE_DIR`` at a directory that looks like a rhiza-claude clone.
+
+    The override path is used for most tests because it is the one that runs no git at all,
+    which keeps a test about the sync vectors from also being a test about cloning.
+
+    Args:
+        tmp_path: pytest's temporary directory.
+        monkeypatch: pytest's patcher.
+
+    Returns:
+        The scripts directory the task should resolve to.
+    """
+    clone = tmp_path / "rhiza-claude"
+    scripts_dir = clone / template.SCRIPTS_SUBDIR
+    scripts_dir.mkdir(parents=True)
+    monkeypatch.setenv("RHIZA_CLAUDE_DIR", str(clone))
+    return scripts_dir
+
+
+class TestUpdateVectors:
+    """What the task runs, in what order, against another project's scripts."""
+
+    def test_runs_the_three_scripts_in_the_documented_order(
+        self, managed: Config, scripts: Path, recorder: Recorder
+    ) -> None:
+        """A clean sync runs sync then stage, and never resolve.
+
+        Exit 0 means "synced cleanly, or already up to date", so reaching for
+        ``resolve_conflicts.py`` there would take the template's side of markers that are
+        not present -- work the upstream document explicitly scopes to exit 1.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(managed)
+        ran = [Path(call.args[1]).name for call in recorder.calls if call.tool == "python"]
+        assert ran == ["sync.py", "stage_synced.py"]
+
+    def test_resolves_conflicts_only_on_exit_one(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """Exit 1 is an expected outcome that adds a step, not a failure.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        recorder.codes = [template.CONFLICTS]
+        template.update(managed)
+        ran = [Path(call.args[1]).name for call in recorder.calls if call.tool == "python"]
+        assert ran == ["sync.py", "resolve_conflicts.py", "stage_synced.py"]
+
+    def test_a_refusal_stops_before_staging(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """Exit 2 applied nothing, so staging would stage a previous run's lock.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        recorder.codes = [2]
+        with pytest.raises(Failed, match="sync refused"):
+            template.update(managed)
+        ran = [Path(call.args[1]).name for call in recorder.calls if call.tool == "python"]
+        assert ran == ["sync.py"]
+
+    def test_a_refusal_after_a_bump_says_the_bump_is_committed(
+        self, managed: Config, scripts: Path, recorder: Recorder
+    ) -> None:
+        """Say that the bump is committed, since "applied nothing" is true only of the sync.
+
+        The bump has to be committed for sync to run at all, so a refusal leaves one commit
+        behind. Saying "applied nothing" without qualifying it would send someone looking for
+        a clean tree they no longer have.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        recorder.codes = [0, 2]
+        with pytest.raises(Failed, match=r"the bump to v1\.8\.0 is already committed"):
+            template.update(replace(managed, template_ref="v1.8.0"))
+
+    def test_pins_the_interpreter_and_skips_the_project(
+        self, managed: Config, scripts: Path, recorder: Recorder
+    ) -> None:
+        """The scripts are another project's: 3.12, and no resolution of this repo's env.
+
+        A bare ``python3`` on macOS is 3.9 and crashes ``sync.py``, and ``--no-project``
+        stops uv resolving the target repository for a stdlib-only script. Both are pinned
+        here because both are invisible until they fail on someone else's machine.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(managed)
+        call = recorder.find("python")
+        assert call.kwargs["python"] == "3.12"
+        assert call.kwargs["no_project"] is True
+
+    def test_stage_is_asked_for_json(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """``--json`` is the surface upstream pins; its human output may be reworded.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(managed)
+        stage = [c for c in recorder.calls if c.tool == "python" and c.args[1].endswith("stage_synced.py")]
+        assert stage[0].args[3:] == ("--json",)
+
+    def test_the_repository_is_passed_to_every_script(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """Each script takes the target repo as its first argument, not the cwd by luck.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        recorder.codes = [template.CONFLICTS]
+        template.update(managed)
+        assert all(c.args[2] == str(managed.root) for c in recorder.calls if c.tool == "python")
+
+
+class TestTemplateRef:
+    """Bumping the pointer, which is step one and the only file this module writes."""
+
+    def test_rewrites_only_the_ref_line(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """``profiles:``/``templates:``/``exclude:`` are a separate decision a bump must not carry.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(replace(managed, template_ref="v1.8.0"))
+        text = (managed.root / template.TEMPLATE_YML).read_text()
+        assert 'ref: "v1.8.0"' in text
+        assert "v1.3.2" not in text
+        assert "github-marimo" in text
+
+    def test_an_indented_ref_is_not_the_one_bumped(self, managed: Config, scripts: Path) -> None:
+        """Only column zero counts, so a nested ``ref:`` inside a list is left alone.
+
+        Matching at any indentation would rewrite a template's own pinned ref, which is the
+        bug the upstream ``sed`` anchor avoids and the reason it was copied rather than
+        improved on.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+        """
+        pointer = managed.root / template.TEMPLATE_YML
+        pointer.write_text('ref: "v1.3.2"\ntemplates:\n  - name: book\n    ref: "v0.1.0"\n')
+        template._bump_ref(pointer, "v1.8.0")
+        assert pointer.read_text() == 'ref: "v1.8.0"\ntemplates:\n  - name: book\n    ref: "v0.1.0"\n'
+
+    def test_a_file_with_no_ref_line_is_reported(self, managed: Config, scripts: Path) -> None:
+        """Appending a ``ref:`` would be a guess about a file this module does not parse.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+        """
+        pointer = managed.root / template.TEMPLATE_YML
+        pointer.write_text('template-repository: "jebel-quant/rhiza"\n')
+        with pytest.raises(Failed, match="no top-level template-branch or ref line"):
+            template._bump_ref(pointer, "v1.8.0")
+
+    def test_an_empty_ref_leaves_the_pointer_alone(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """Empty means "re-sync at what it already names", which is a real case.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        before = (managed.root / template.TEMPLATE_YML).read_text()
+        template.update(managed)
+        assert (managed.root / template.TEMPLATE_YML).read_text() == before
+
+    def test_template_branch_wins_over_ref(self, managed: Config, scripts: Path) -> None:
+        """The sync obeys ``template-branch`` when both keys are present, so the bump must too.
+
+        Rewriting ``ref:`` in a file like this would leave it *claiming* the new version while
+        the sync fetched the old one, and every exit code in the run would still be 0. This is
+        the one bug in this module that no exit status would have reported.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+        """
+        pointer = managed.root / template.TEMPLATE_YML
+        pointer.write_text('template-branch: "v1.7.0"\nref: "v1.3.2"\n')
+        template._bump_ref(pointer, "v1.8.0")
+        assert pointer.read_text() == 'template-branch: "v1.8.0"\nref: "v1.3.2"\n'
+
+    def test_ref_is_used_when_it_is_the_only_key(self, managed: Config, scripts: Path) -> None:
+        """A file carrying only ``ref:`` is the common case and is bumped there.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+        """
+        pointer = managed.root / template.TEMPLATE_YML
+        pointer.write_text('ref: "v1.3.2"\n')
+        template._bump_ref(pointer, "v1.8.0")
+        assert pointer.read_text() == 'ref: "v1.8.0"\n'
+
+    def test_the_bump_is_committed_before_the_sync(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """``sync.py`` refuses a dirty tree, and the bump is what makes it dirty.
+
+        Found by running the task for real against the actual scripts: sync reported
+        ``Working tree is not clean`` naming the file the task had just written. A vector
+        assertion could not have found it, because the refusal is a fact about ``sync.py``
+        rather than about the arguments handed to it -- which is the reason CI runs this
+        against the real scripts as well.
+
+        The pathspec is asserted too: ``git commit -am`` would sweep every other modified
+        tracked file into a commit whose message claims to be a version bump.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(replace(managed, template_ref="v1.8.0"))
+        order = [c.tool for c in recorder.calls]
+        assert order.index("git") < order.index("python")
+        commit = recorder.find("git")
+        assert commit.args[1] == "commit"
+        assert commit.args[-2:] == ("--", template.TEMPLATE_YML)
+
+    def test_no_commit_is_made_without_a_ref(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """A re-sync at the pinned ref writes no file, so it has nothing to commit.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(managed)
+        assert "git" not in recorder.tools()
+
+
+class TestScriptProvisioning:
+    """Where the scripts come from, and whose clone gets written to."""
+
+    def test_an_override_is_used_as_found(self, managed: Config, scripts: Path, recorder: Recorder) -> None:
+        """Someone else's clone is read, never fetched into or reset.
+
+        A ``git reset --hard`` into the ``~/.local/share/rhiza-claude`` that ``headless.md``
+        tells people to make would discard whatever they had in it.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            scripts: The scripts directory.
+            recorder: The uv recorder.
+        """
+        template.update(managed)
+        assert "git" not in recorder.tools()
+
+    def test_an_override_without_scripts_is_refused(
+        self, managed: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falling back to the cache would run a different copy than the one asked for.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            tmp_path: pytest's temporary directory.
+            monkeypatch: pytest's patcher.
+        """
+        empty = tmp_path / "not-a-clone"
+        empty.mkdir()
+        monkeypatch.setenv("RHIZA_CLAUDE_DIR", str(empty))
+        with pytest.raises(Failed, match="has no plugin/scripts"):
+            template.update(managed)
+
+    def test_a_missing_cache_is_cloned_shallow(
+        self, managed: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, recorder: Recorder
+    ) -> None:
+        """With no override the module makes its own clone, and owns it.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            tmp_path: pytest's temporary directory.
+            monkeypatch: pytest's patcher.
+            recorder: The uv recorder.
+        """
+        monkeypatch.delenv("RHIZA_CLAUDE_DIR", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+        template.update(managed)
+        assert recorder.find("git").args[:4] == ("git", "clone", "--depth", "1")
+        assert template.SCRIPTS_REPO in recorder.find("git").args
+
+    def test_a_cache_this_module_owns_is_refreshed(
+        self, managed: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, recorder: Recorder
+    ) -> None:
+        """A stale ``sync.py`` is a correctness risk, and our own copy has nothing to lose.
+
+        Args:
+            managed: A config whose repository carries a template pointer.
+            tmp_path: pytest's temporary directory.
+            monkeypatch: pytest's patcher.
+            recorder: The uv recorder.
+        """
+        monkeypatch.delenv("RHIZA_CLAUDE_DIR", raising=False)
+        cache = tmp_path / "cache"
+        monkeypatch.setenv("XDG_CACHE_HOME", str(cache))
+        (cache / "rhiza-task" / "rhiza-claude" / ".git").mkdir(parents=True)
+        template.update(managed)
+        git = [c.args for c in recorder.calls if c.tool == "git"]
+        assert [a[3] for a in git] == ["fetch", "reset"]
+
+    def test_the_cache_falls_back_to_the_home_directory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``XDG_CACHE_HOME`` is honoured where set; ``~/.cache`` is the standard default.
+
+        Args:
+            monkeypatch: pytest's patcher.
+        """
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        assert template._cache_root() == Path.home() / ".cache" / "rhiza-task" / "rhiza-claude"
+
+
+class TestUpdateGuards:
+    """The task is a no-op where there is no template to sync."""
+
+    def test_a_repo_with_no_pointer_skips(self) -> None:
+        """This repository is one of those, which is why the task cannot be dogfooded here."""
+        from rhiza_task.spec import REGISTRY
+
+        (guard,) = REGISTRY["update"].guards
+        assert guard.file == template.TEMPLATE_YML
+        assert "not rhiza-managed" in guard.reason
+
+    def test_git_is_not_guarded_because_doctor_owns_it(self) -> None:
+        """Guarding on git would demote a hard prerequisite to a per-task skip.
+
+        ``doctor`` names uv and git as the two things a process running ``uvx rhiza-task``
+        cannot do without, and fails on a miss;
+        ``TestDoctor::test_probes_nothing_a_guard_already_owns`` asserts the two sets stay
+        disjoint. It caught a ``Guard(tool="git")`` here on the first run, which is the whole
+        reason this test exists rather than the guard.
+        """
+        from rhiza_task.spec import REGISTRY
+
+        assert not any(guard.tool for guard in REGISTRY["update"].guards)

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -93,6 +93,22 @@ def test_uv_run_can_bypass_the_project(spy: list[dict[str, object]], tmp_path: P
     assert spy[0]["argv"][:4] == ["/fake/uv", "run", "--no-project", "--with"]
 
 
+def test_uv_run_can_pin_the_interpreter(spy: list[dict[str, object]], tmp_path: Path) -> None:
+    """``--python`` precedes ``--no-project``, which ``update`` relies on together.
+
+    The scripts that task drives belong to another project, pinned by it to 3.12, and are
+    stdlib-only -- so the interpreter is named and the target repo's environment is not
+    resolved. Both flags in one vector is the case worth pinning, since either alone would
+    leave the other's ordering unasserted.
+
+    Args:
+        spy: The subprocess spy.
+        tmp_path: Working directory.
+    """
+    uv_module.uv_run("python", "sync.py", cwd=tmp_path, no_project=True, python="3.12")
+    assert spy[0]["argv"] == ["/fake/uv", "run", "--python", "3.12", "--no-project", "python", "sync.py"]
+
+
 def test_uvx_passes_the_interpreter_and_extras(spy: list[dict[str, object]], tmp_path: Path) -> None:
     """``-p`` and ``--with`` both land before the tool spec.
 


### PR DESCRIPTION
> **Stacked on #166.** Base is `feat/configurable-docstring-floor` so this diff shows only the `update` work; GitHub retargets it to `main` when #166 merges. Both branches touch `config.py` and `docs/configuration.md`.

## What

There was no `update` task. ~40 tasks across ten sections and nothing that syncs a template — `template.yml` appeared in this package only as prose in `README.md` and `docs/`.

```bash
TEMPLATE_REF=v1.8.0 uvx rhiza-task update
```

## Why

That is the gap [rhiza#1654](https://github.com/Jebel-Quant/rhiza/issues/1654) is actually about — *"I should offer a simpler script to update without Claude."* The thread logs an upgrade taking eight documented steps, a clone into `~/.local/share`, three scripts in sequence and four commits. Its guide also says `git add -A`, where the upstream document says **never** to: the lock records exactly which paths the sync materialised, and staging everything sweeps unrelated work into the sync commit.

## It wraps, and does not reimplement

`rhiza-claude`'s `docs/headless.md` already settled this:

> A separate CLI would be a second implementation of sync to keep in step with the first, and that is the one thing this project has decided not to maintain. One operation, one entry point.

So nothing here parses `template.yml`, resolves a bundle, walks the lock or merges a file. It provisions `sync.py` / `resolve_conflicts.py` / `stage_synced.py`, runs them in the documented order, and reads the documented exit codes — `resolve_conflicts.py` **only** on exit 1; exit 2 means the sync applied nothing.

It lives in this package because `rhiza-task` is the only piece of the ecosystem on PyPI, so `uvx rhiza-task update` needs no install — and the install was the step people tripped over.

It **stops before the sync commit** and prints it, because it needs `SKIP=check-managed-files` (rhiza-hooks refuses a commit touching the lock's `files:` list, and this commit is exactly that list) and because a resolved conflict is a diff worth reading before it is history.

## Three bugs a real run found that vector assertions could not

This is why `ci.yml` gains a `template-layer` job against the actual scripts, rather than a promise in a docstring.

1. **`sync.py` refuses a dirty tree, and the pointer bump is what makes it dirty.** `headless.md` commits the bump as step 2; dropping that commit meant the sync never ran at all. It is committed with a pathspec, not `-am`, so an unrelated modified file is not swept into a commit claiming to be a version bump.
2. **The ref lives under `template-branch` *or* `ref`**, and `_validate_fields.py` prefers the former. Bumping `ref:` in a file holding both would leave it *claiming* the new version while the sync fetched the old one — **every exit code 0**. The one failure mode here that nothing non-zero would report.
3. **`repo:` is not a field, and there is no `python` bundle.** Both came straight from the issue's guide; both exit non-zero against the real schema.

## What the suite rejected

`Guard(tool="git")` was dropped because an existing invariant test caught it: `doctor` names uv and git as hard prerequisites that fail on a miss, and `test_probes_nothing_a_guard_already_owns` asserts a guard never demotes one to a per-task skip. The test that replaced it records why.

## Placement

`update` is outside `all` — it *changes* the repository rather than measuring it, and a sync inside `all` would mean `rhiza-task all` rewriting managed files mid-run. It is also the one task this repo cannot dogfood, having no `.rhiza/`; the module docstring and `docs/tasks.md` both say so, and name what would close it (a job in rhiza-claude running its scripts against this front door).

`uv_run` gains `python=`, mirroring `uvx`'s parameter of the same name: the scripts are another project's, pinned by it to 3.12, and a bare `python3` on macOS is 3.9 and crashes `sync.py`.

## Verification

- `rhiza-task all`, `complexity`, `docs-examples`, `test-pyproject`, the accumulation ceiling, pinned `ruff` check+format, `mypy --strict .github/scripts` — all green.
- 447 tests at the **100%** coverage floor; `template.py` fully covered with no new `# pragma: no cover`.
- **Run for real** against the live scripts on a scratch repo: 12 files synced, lock written, exactly that set staged, pointer at `v1.7.1`, nothing left unstaged.

Refs: jebel-quant/rhiza#1654