### PR TITLE
feat: run the suite at its floors, and pin what typechecks it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,14 @@ jobs:
           build-backend = "hatchling.build"
 
           [dependency-groups]
-          test = ["pytest", "pytest-cov"]
+          # The floors are not decoration, and `test-lowest` is why: a requirement with no
+          # lower bound is not a floor at all, so `--resolution lowest-direct` resolves it
+          # to the oldest release on PyPI -- `pytest 2.0.0`, whose sdist does not build.
+          # This fixture had bare names and the step below failed on both platforms before
+          # anything was measured. That is not this task being strict: the plain-uv job it
+          # replaces resolves the same set the same way and fails identically, which is
+          # checked rather than assumed.
+          test = ["pytest>=8.0.0", "pytest-cov>=5.0.0"]
 
           [tool.rhiza-task]
           coverage_fail_under = 0
@@ -471,6 +478,20 @@ jobs:
       # pytest rejects fails here, which is the whole point: no stub can reject one.
       - name: rhiza-task test
         run: uv run rhiza-task test --root "${RUNNER_TEMP//\\//}/pyproj"
+
+      # `test-lowest` runs here as well as in `lowest-deps` below, for the reason this job
+      # exists at all: that job runs it against *this* repository, whose manifest is tuned to
+      # it, so the shipped defaults a consumer actually gets would otherwise go unexercised.
+      #
+      # It is also the only place `PYTEST_WITHS`'s floors are read back, and the fixture above
+      # is what makes that true: it declares `pytest` and `pytest-cov` and nothing else, so
+      # xdist, html, mock and timeout are supplied entirely by the injected pins -- and
+      # `-n auto` is the flag that would fail if the xdist floor were wrong. A `--with` is an
+      # overlay resolved separately from the project, which is worth knowing before reading
+      # this step's failures: an injected floor bounds the runner and cannot rescue a bare
+      # name in the manifest.
+      - name: rhiza-task test-lowest
+        run: uv run rhiza-task test-lowest --root "${RUNNER_TEMP//\\//}/pyproj"
 
       # `coverage` is not `test` with a flag -- it runs its own vector, writing the Cobertura
       # XML the book and any badge generator read. It ran nowhere until #152, so a vector
@@ -853,10 +874,16 @@ jobs:
   # The floors in pyproject.toml -- typer>=0.15, rich>=13.0, python-dotenv>=1.0 -- are a
   # claim, and `--frozen` everywhere else means nothing tests it: the lockfile resolves
   # typer 0.27.1 and rich 15.0.0, nine and two minor versions above what the manifest
-  # says is enough. This job is the only place those numbers are asserted. Lifted from
-  # rhiza's rhiza_ci.yml `lowest-deps`, which is the one job there that calls plain uv
-  # rather than a pinned older rhiza-task, so it carries no circular dependency on this
-  # package.
+  # says is enough. This job is the only place those numbers are asserted.
+  #
+  # It used to be the one job here that called plain uv, with `--all-extras --all-groups
+  # --resolution lowest-direct` spelled out twice and a comment arguing that `rhiza-task
+  # test` could not be used because its `--with` flags resolved newest and would undo the
+  # floors. #169 answered that in both directions. The injected packages now carry floors of
+  # their own, so they bound the runner instead of replacing it -- and a job that calls uv
+  # directly is a job that never reaches `setup`, which for a consumer whose
+  # `local-setup.sh` provisions a native binary meant a red floors job diagnosing a missing
+  # binary as a resolution problem. So the vector lives in the package and this job runs it.
   lowest-deps:
     name: lowest-direct dependency floors
     runs-on: ubuntu-latest
@@ -867,19 +894,17 @@ jobs:
           version: "0.11.16"
           enable-cache: true
 
-      # Deliberately not --frozen: resolving against the manifest rather than the
-      # lockfile is the whole point.
-      - name: Resolve the declared floors
-        run: uv sync --all-extras --all-groups --resolution lowest-direct
-
-      - name: Show what that resolved to
-        run: uv pip list
-
-      # pytest directly rather than `rhiza-task test`: the task provisions pytest through
-      # `uv run --with`, which resolves newest and would silently undo the floors this job
-      # exists to check.
-      - name: Run tests against the floors
-        run: uv run --all-extras --all-groups --resolution lowest-direct pytest -ra
+      # The `uv pip list` diagnostic this job used to carry is gone on purpose. `test-lowest`
+      # resolves into an ephemeral environment so that it cannot leave `.venv` and `uv.lock`
+      # downgraded, so listing the *project* environment afterwards would print the highest
+      # resolution while appearing to report the floors -- and uv names the versions it chose
+      # in the failure itself, which is the moment anyone wants them.
+      #
+      # Against a real manifest with real floors, which is what this job adds over
+      # `python-layer`'s scratch project: `requires-python >=3.11` is resolved here too, so
+      # the suite runs on the oldest interpreter the package claims to support.
+      - name: Run the tests against the declared floors
+        run: uv run rhiza-task test-lowest
 
   # The one task with no fixture-free way to be exercised, and the one whose unit tests are
   # least able to speak for it: `update` drives *another repository's* scripts, so what the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,7 +447,18 @@ an integer in this sentence would be one more measured figure with nothing readi
   property test. Unlike `bundle-layer`, this job leaves no vector out — every task in the
   section runs here.
 - **`lowest-deps`** — resolves `--resolution lowest-direct` to prove the manifest's floors
-  are real.
+  are real, and since #169 it does that by calling `rhiza-task test-lowest` rather than uv
+  directly. It was the last job here restating how the suite runs, and calling uv is exactly
+  what kept it outside `setup` — which is the whole argument for the task existing, since a
+  consumer whose `local-setup.sh` provisions a native binary got a red floors job diagnosing
+  a missing binary as a resolution failure. `python-layer` runs the same task against its
+  scratch project, and the two are not redundant: there the floors read back are the ones
+  `PYTEST_WITHS` injects, since that fixture declares only pytest and pytest-cov and leaves
+  xdist, html, mock and timeout entirely to the injection. Its bare `pytest` is also what
+  failed the job on the first run — **a requirement with no lower bound is not a floor**, and
+  `lowest-direct` resolves it to the oldest release on PyPI. That is not the task being
+  stricter than the job it replaced: plain `uv sync --all-extras --all-groups --resolution
+  lowest-direct` fails identically, which is checked rather than assumed.
 
 Two additions live outside `ci.yml` and are easy to miss when counting: `python-layer` now
 also runs **`coverage`** against the throwaway project — it is not `test` with a flag, it

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ keep working owns that `Makefile` itself and forwards each target to `uvx rhiza-
 
 | section | tasks |
 |---|---|
-| Python | `install` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
+| Python | `install` `test` `test-lowest` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Rust | `install` `cargo-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Go | `install` `go-tools` `test` `coverage` `typecheck` `security` `deps` `license` `docs-coverage` `all` |
 | Quality | `fmt` `semgrep` `rhiza-test` `test-pyproject` `todos` `complexity` `docs-examples` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,8 @@ exports one for every caller and deliberately leaves it empty for consumers, who
 | `docs_coverage_fail_under` | `100` | the docstring floor `docs-coverage` hands interrogate |
 | `complexity_max` | `15` | the cyclomatic-complexity ceiling `complexity` enforces |
 | `typechecker` | `ty` | `ty`, `mypy` or `both` |
+| `ty_version` | `==0.0.78` | what `typecheck` provisions `ty` as, appended to the name |
+| `mypy_version` | `""` | the same for mypy, empty meaning whatever is newest |
 | `license_fail_on` | `("GPL", "LGPL", "AGPL")` | matched as **substrings** |
 | `license_ignore_packages` | `()` | packages exempt from the copyleft scan |
 | `deptry_ignore` | `()` | deptry rule codes to suppress |
@@ -163,6 +165,26 @@ not a property of the repository:
     Only the Python layer takes a number. Rust and Go express the same gate as
     `-D missing_docs` and revive's `exported` rule, which are pass/fail on one item rather
     than a percentage over a tree, so there is no threshold for them to read.
+
+!!! warning "`ty` is pinned, and `mypy` is not"
+    `typecheck` used to pass the bare name to `uv run --with`, so the gate ran whatever was
+    newest at the moment it ran. For a 0.0.x checker that is not a detail: one consumer saw
+    a single warning locally, where `--with ty` reused the `ty` their lock file supplied,
+    and twenty-four errors on a runner that had none to reuse — same commit, different
+    checker. So `ty` ships pinned and mypy, being post-1.0, does not.
+
+    Both are settings because neither answer is right for everyone. Move the pin to adopt a
+    newer `ty` deliberately:
+
+    ```toml
+    [tool.rhiza-task]
+    ty_version = "==0.0.60"
+    mypy_version = "==1.18.2"
+    ```
+
+    Set either **empty** to go back to whatever is newest. That is a manifest-only
+    spelling, for the reason `pytest_rhiza` documents below: the environment layer drops an
+    empty value as unset, and only TOML tells an empty string from an absent key.
 
 !!! warning "`typechecker = "both"` masks `ty`"
     `python.mk` documented it and the behaviour is unchanged: `both` hides `ty`'s exit

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,6 +21,12 @@ You should. An unpinned task layer can change under a green pull request without
 touching your repository — which is the failure mode the whole package exists to remove.
 `rhiza-task@1.5.0` makes a bump a deliberate commit that carries whatever fixes it wants.
 
+Pinning this package is not the whole of it, because a gate can be pinned and still
+provision an unpinned tool. `typecheck` was that case: `--with ty` resolved whatever was
+newest at the moment the job ran, so a pinned `rhiza-task` still gave two machines two
+verdicts on one commit. Hence [`ty_version`](configuration.md#gates-and-thresholds) — the
+checker's version is part of the pin, and moving it is a commit too.
+
 ### A gate says `skipped`. Is that bad?
 
 Not by itself. A task whose subject is absent skips: `fmt` with no

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -30,6 +30,7 @@ special cases.
 |---|---|---|
 | `install` | — | create the venv and sync dependencies |
 | `test` | `install` | run all tests |
+| `test-lowest` | `install` | run the tests against the oldest dependencies the manifest allows |
 | `coverage` | `install` | measure coverage and write `_tests/coverage.xml` |
 | `typecheck` | `install` | run `ty` and/or `mypy` (`typechecker = ty \| mypy \| both`) |
 | `security` | `install` | run the bandit security scan |
@@ -46,6 +47,53 @@ badge step reads and what CI uploads.
 !!! info "`test` retries once, on exit 3 only"
     Exit 3 is the xdist teardown race. A retry on 1, 2 or 4 would be re-running a real
     failure and hoping, so it never happens.
+
+`test-lowest` shares that argument builder too, and adds `--resolution lowest-direct`: every
+direct requirement resolves to the oldest version its specifier allows, so a floor like
+`typer>=0.15` is read back rather than merely declared. It is **not** a prerequisite of
+`all` — it resolves from the manifest rather than the lock file, which is a different
+question from "is this commit green" — so CI names it as its own job.
+
+!!! info "Why `test-lowest` runs `--isolated`"
+    Asking uv for a different resolution mode makes it discard the lock file: without
+    `--isolated` the *project* environment is re-resolved in place, and `.venv` and
+    `uv.lock` are left downgraded once the gate finishes. On a runner nobody notices; on
+    your machine it is a gate that rewrites a tracked file and changes what every later
+    task runs against. The ephemeral environment costs one resolve and leaves nothing
+    behind.
+
+!!! warning "A requirement with no lower bound has no floor"
+    `--resolution lowest-direct` reads every direct requirement's *specifier*, so a bare
+    `pytest` in a dependency group is not "any version is fine" — it resolves to the oldest
+    release on PyPI, `pytest 2.0.0`, whose sdist no longer builds. The gate then fails
+    before measuring anything, naming the requirement that did it:
+
+    ```text
+    hint: `pytest` (v2.0.0) was included because `demo:test` (v0.1.0) depends on `pytest`
+    ```
+
+    The fix is a floor on the named requirement, not a flag here. It applies to
+    `[dependency-groups]` and `[project.optional-dependencies]` as much as to
+    `[project.dependencies]`, since all three are direct. This is not `test-lowest` being
+    stricter than the plain `uv sync --all-extras --all-groups --resolution lowest-direct`
+    it replaces: that resolves the same set the same way and fails on the same requirement.
+    What the task adds is floors for the packages *it* injects, so `-n auto` and the plugins
+    cannot be the thing that breaks.
+
+!!! question "Why there is no Rust or Go `test-lowest`"
+    It is one of the few places the gate-parity contract does not reach, and for reasons
+    belonging to the other two toolchains rather than to this package. Go already resolves
+    this way: module resolution is *minimum version selection*, so `go test` builds against
+    the versions `go.mod` names and a floors gate would be `test` again. Cargo does the
+    opposite and offers no stable way to ask — `-Z minimal-versions` is nightly-only — so a
+    task here would be a gate that most consumers' toolchains reject.
+
+!!! tip "It is a task so that `setup` runs"
+    The job this replaces called `uv` directly, and a caller outside the task graph is a
+    caller outside `install` — so a repository whose `local-setup.sh` provisions a native
+    binary got a green `test` and a red floors job on identical code, reporting a
+    resolution failure that was really a missing `dot`. Anything that runs the suite
+    should arrive through `install`; that is the whole reason the hook is anchored there.
 
 ## Rust
 

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -220,6 +220,29 @@ class Config:
     # before any tool is provisioned rather than after.
     typechecker: str = "ty"
 
+    # What ``typecheck`` provisions each checker *as*: appended to the checker's own name, so
+    # `==0.0.78` becomes `--with ty==0.0.78`. The shape `zensical_version` already uses, and
+    # an empty value means the bare name -- whatever is newest, which is what both settings
+    # replace.
+    #
+    # ty is pinned and mypy is not, and the asymmetry belongs to the checkers rather than to
+    # this package. ty is 0.0.x and its diagnostics change between patch releases, so an
+    # unpinned `--with ty` makes the verdict a fact about the day the job ran: a consumer
+    # migrating to this CLI saw one warning locally, where the project's lock supplied ty
+    # 0.0.18 for `--with ty` to reuse, and twenty-four errors on a runner that had no ty to
+    # reuse -- same commit, different checker. mypy is post-1.0 and moves slowly enough that
+    # the same pin would mostly buy staleness. See jebel-quant/rhiza-task#170.
+    #
+    # Moving the pin is a deliberate edit here, like `pytest-benchmark==5.2.3` in
+    # tasks/extras.py: both are places where the tool's *output* is the gate's meaning, so
+    # what version produced it is part of the gate. A consumer wanting a different ty sets
+    # this rather than forking the task; one wanting the newest sets it empty, which is a
+    # manifest-only spelling for the reason `pytest_rhiza` above documents -- `_from_environ`
+    # and `_from_env_file` drop an empty value as unset, and only TOML tells an empty string
+    # from an absent key.
+    ty_version: str = "==0.0.78"
+    mypy_version: str = ""
+
     # Matched as substrings -- see ``--partial-match`` in the ``license`` task.
     license_fail_on: tuple[str, ...] = ("GPL", "LGPL", "AGPL")
     license_ignore_packages: tuple[str, ...] = ()

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -20,18 +20,36 @@ from ..uv import uv, uv_run, uvx
 from .quality import install_hooks
 
 PYTEST_WITHS = (
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
-    "pytest-html",
-    "pytest-timeout",
-    "pytest-mock",
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
+    "pytest-xdist>=3.5.0",
+    "pytest-html>=4.1.0",
+    "pytest-timeout>=2.2.0",
+    "pytest-mock>=3.12.0",
 )
 """What ``test`` injects.
 
 A named tuple of packages rather than a literal in the call, so CI and this package's own
 tests can assert on it. The make recipe's six ``--with`` flags are invisible to anything
 but a human reading the recipe.
+
+**The floors change nothing under the default resolution** -- uv takes the newest of each
+either way -- and they are not there for it. ``test-lowest`` runs these same six through
+``--resolution lowest-direct``, which applies to every *direct* requirement including the
+injected ones, and a bare ``pytest`` there resolves to the oldest release uv can see --
+``pytest 2.0.0``, whose sdist does not build -- so the gate fails on its own instrumentation
+without ever reaching the floors it was asked about. Each name therefore carries the oldest version this package is
+willing to run a suite with.
+
+They bound the *instrumentation* and nothing else, which is the boundary to know before
+reading a failure: ``--with`` is an overlay uv resolves separately from the project, so a
+floor here cannot rescue a bare name in the manifest under test -- and should not. A
+requirement a repository declares without a lower bound has no floor for this gate to read
+back, and saying so is the gate working.
+
+That makes them a claim, and the claim is read back rather than asserted: ``ci.yml``'s
+``python-layer`` runs ``test-lowest`` against a real project on Linux and Windows, which is
+where a floor that cannot actually run ``-n auto`` shows up.
 """
 
 PYTEST_INTERNAL_ERROR = 3
@@ -44,6 +62,21 @@ test failed.
 """
 
 MAX_ATTEMPTS = 2
+
+LOWEST_DIRECT = ("--isolated", "--resolution", "lowest-direct")
+"""How ``test-lowest`` asks uv for the floors, and why it asks in an ephemeral environment.
+
+``--resolution lowest-direct`` is the gate itself: every direct requirement resolves to the
+oldest version its specifier allows and every transitive one to the newest, so what fails is
+a floor that was never true rather than a dependency somebody else moved.
+
+``--isolated`` is what keeps the answer free of charge. Without it uv re-resolves the
+*project* environment in place -- it says so, ``Ignoring existing lockfile due to change in
+resolution mode`` -- and leaves both ``.venv`` and ``uv.lock`` downgraded when the gate
+finishes. On a runner that is invisible; on a developer's machine it is a gate that rewrites
+a tracked file and silently changes what every later task runs against. An ephemeral
+environment costs one resolve per invocation and leaves nothing behind.
+"""
 
 
 # `setup` first, and in all three layers: a native library needed to *build* a wheel has to
@@ -168,6 +201,59 @@ def coverage(cfg: Config) -> None:
     for stale in cfg.root.glob(".coverage*"):
         stale.unlink(missing_ok=True)
     uv_run("pytest", *_pytest_args(cfg), *coverage_args(cfg), cwd=cfg.root, withs=PYTEST_WITHS)
+
+
+@task(
+    "test-lowest",
+    "run the tests against the oldest dependencies the manifest allows",
+    section="Python",
+    layer="python",
+    needs=("install",),
+    guards=(Guard("tests_folder", glob="test_*.py", reason="no test files found"),),
+)
+def test_lowest(cfg: Config) -> None:
+    """Run the suite with every direct dependency resolved to its declared floor.
+
+    A declared floor is a claim -- ``typer>=0.15`` says the package works with typer 0.15 --
+    and ``--frozen`` everywhere else means nothing reads it back: the lock file resolves
+    whatever is newest, so a floor can be years stale while every gate stays green.
+
+    **It is a task rather than a workflow step, and that is the whole of #169.** rhiza's
+    ``lowest-deps`` job called plain ``uv`` because there was nothing here to call, and a
+    caller that bypasses the task graph bypasses ``setup`` with it -- so a repository whose
+    ``local-setup.sh`` provisions a native binary got a green ``test`` and a red
+    ``lowest-deps`` on identical code, reporting a resolution problem that was really a
+    missing ``dot`` on the runner. Arriving through ``install`` puts this gate back inside
+    the single insertion point :mod:`rhiza_task.tasks.setup` documents, which is the whole
+    argument for anchoring the hook there.
+
+    Three things it shares rather than restates, because the job it replaces restated all
+    three by hand and the copy had already drifted by one flag:
+
+    * ``_pytest_args``, so the suite is selected the way ``test`` and ``coverage`` select it.
+    * :data:`PYTEST_WITHS`, so ``-n auto`` has an xdist to run under -- see that constant for
+      why its floors exist and why they are invisible anywhere else.
+    * :attr:`~rhiza_task.config.Config.uv_sync_args`, because "which of the manifest's
+      optional pieces count" is the same question ``install`` asks, and a repository that
+      answered it once has answered it here.
+
+    No coverage flags, deliberately. The subject is whether the suite *runs* at the floors,
+    and a coverage floor here would either report what ``test`` already reported or give this
+    gate a second way to go red that has nothing to do with resolution.
+
+    Args:
+        cfg: The resolved config.
+
+    Raises:
+        Failed: When pytest reports test failures.
+    """
+    uv_run(
+        "pytest",
+        *_pytest_args(cfg),
+        cwd=cfg.root,
+        withs=PYTEST_WITHS,
+        uv_args=(*LOWEST_DIRECT, *cfg.uv_sync_args),
+    )
 
 
 def _pytest_args(cfg: Config) -> list[str]:

--- a/src/rhiza_task/tasks/python.py
+++ b/src/rhiza_task/tasks/python.py
@@ -225,6 +225,15 @@ def typecheck(cfg: Config) -> None:
     the setting and errors. Validation moved to :meth:`Config.__post_init__`, so an
     invalid value fails before a tool is provisioned, and what is left is a loop.
 
+    **What each checker is provisioned *as* is a setting, and it has to be.** The ``--with``
+    here used to carry the bare name, so the gate ran whatever was newest at the moment it
+    ran -- and for a 0.0.x checker that is not a detail: one consumer saw a single warning
+    locally, where ``--with ty`` reused the ty their lock file supplied, and twenty-four
+    errors on a runner that had none to reuse, on the same commit. An unchanged repository
+    could go from green to red overnight, and two machines could disagree about it on the
+    same day. See #170, and ``ty_version`` in :mod:`rhiza_task.config` for why ty is pinned
+    by default and mypy is not.
+
     Args:
         cfg: The resolved config.
     """
@@ -232,7 +241,11 @@ def typecheck(cfg: Config) -> None:
     for checker in checkers:
         # The asymmetry is preserved from python.mk: mypy runs --strict, ty does not.
         args = ("check", cfg.source_folder) if checker == "ty" else ("--strict", cfg.source_folder)
-        uv_run(checker, *args, cwd=cfg.root, withs=(checker,))
+        # The second asymmetry, and this one is not python.mk's: `ty` is provisioned at an
+        # exact version and mypy is not. See `ty_version` in config.py for why -- both are
+        # settings, so a consumer needing the other answer changes it rather than the task.
+        requirement = f"ty{cfg.ty_version}" if checker == "ty" else f"mypy{cfg.mypy_version}"
+        uv_run(checker, *args, cwd=cfg.root, withs=(requirement,))
 
 
 @task(

--- a/src/rhiza_task/uv.py
+++ b/src/rhiza_task/uv.py
@@ -175,6 +175,7 @@ def uv_run(
     withs: Sequence[str] = (),
     no_project: bool = False,
     python: str | None = None,
+    uv_args: Sequence[str] = (),
     check: bool = True,
     env: Mapping[str, str] | None = None,
 ) -> int:
@@ -193,6 +194,13 @@ def uv_run(
             exception: the scripts it drives are a *different* project's, pinned by that
             project to one version, so the interpreter is theirs to name rather than the
             target repository's.
+        uv_args: Flags for ``uv run`` itself, placed before the tool. ``test-lowest`` is the
+            only caller, and what it passes is why this is one parameter rather than three:
+            ``--isolated``, ``--resolution lowest-direct`` and the repository's
+            ``uv_sync_args`` are a resolver mode plus the environment it is asked about, and
+            none of them means anything without the others. ``no_project`` and ``python``
+            stay named because each is a single decision with a single spelling -- a caller
+            wanting one of those should keep using them rather than spelling the flag here.
         check: Raise on non-zero rather than returning the status.
         env: Extra environment variables.
 
@@ -202,7 +210,7 @@ def uv_run(
     Raises:
         Failed: When ``check`` and the tool exited non-zero.
     """
-    argv = [_bin("uv", "RHIZA_UV_BIN"), "run"]
+    argv = [_bin("uv", "RHIZA_UV_BIN"), "run", *uv_args]
     if python:
         argv += ["--python", python]
     if no_project:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -259,6 +259,34 @@ class TestTypecheck:
         assert recorder.tools() == ["ty"]
         assert recorder.find("ty").flags == ["check", "src"]
 
+    def test_provisions_ty_at_the_pinned_version(self, cfg: Config, recorder: Recorder) -> None:
+        """``--with ty`` bare made the verdict a fact about the day the job ran -- see #170.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.typecheck(cfg)
+        assert recorder.find("ty").kwargs["withs"] == (f"ty{cfg.ty_version}",)
+        assert cfg.ty_version.startswith("==")
+
+    def test_a_consumer_can_move_or_drop_the_pin(self, repo: Path, recorder: Recorder) -> None:
+        """Both versions are settings, so the answer this package ships is not the only one.
+
+        An empty value is the bare name again -- whatever is newest -- which is why it is
+        spellable in the manifest at all.
+
+        Args:
+            repo: The repository root.
+            recorder: The uv recorder.
+        """
+        python.typecheck(Config.load(root=repo, typechecker="both", ty_version=">=0.0.18", mypy_version="==1.18.2"))
+        assert recorder.find("ty").kwargs["withs"] == ("ty>=0.0.18",)
+        assert recorder.find("mypy").kwargs["withs"] == ("mypy==1.18.2",)
+        recorder.calls.clear()
+        python.typecheck(Config.load(root=repo, ty_version=""))
+        assert recorder.find("ty").kwargs["withs"] == ("ty",)
+
     def test_both_runs_ty_then_mypy_strict(self, repo: Path, recorder: Recorder) -> None:
         """``both`` runs them in order, and only mypy gets ``--strict``.
 
@@ -266,9 +294,14 @@ class TestTypecheck:
             repo: The repository root.
             recorder: The uv recorder.
         """
-        python.typecheck(Config.load(root=repo, typechecker="both"))
+        cfg = Config.load(root=repo, typechecker="both")
+        python.typecheck(cfg)
         assert recorder.tools() == ["ty", "mypy"]
         assert recorder.find("mypy").flags == ["--strict", "src"]
+        # The other asymmetry, and the default: mypy is post-1.0, so it is provisioned
+        # unpinned where ty is not.
+        assert recorder.find("mypy").kwargs["withs"] == ("mypy",)
+        assert not cfg.mypy_version
 
 
 class TestDerivedAccumulators:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -245,6 +245,107 @@ class TestCoverage:
         assert (cfg.root / "_tests" / "html-coverage").is_dir()
 
 
+class TestTestLowest:
+    """The floors gate, and the reason it is a task at all -- see issue #169."""
+
+    def test_resolves_lowest_direct_in_an_ephemeral_environment(self, cfg: Config, recorder: Recorder) -> None:
+        """The resolver mode is the gate; ``--isolated`` is what keeps it side-effect free.
+
+        Without ``--isolated`` uv re-resolves the project environment in place and leaves
+        ``.venv`` and ``uv.lock`` downgraded, so a gate would rewrite a tracked file and
+        change what every later task runs against.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.test_lowest(cfg)
+        uv_args = recorder.find("pytest").kwargs["uv_args"]
+        assert list(python.LOWEST_DIRECT) == ["--isolated", "--resolution", "lowest-direct"]
+        assert set(python.LOWEST_DIRECT) <= set(uv_args)
+
+    def test_asks_about_the_pieces_install_syncs(self, cfg: Config, recorder: Recorder) -> None:
+        """The environment the floors are resolved for is the one ``install`` builds.
+
+        rhiza's workflow restated ``--all-extras --all-groups`` by hand beside a task that
+        already had the setting, which is the drift this reuse removes.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        cfg = replace(cfg, uv_sync_args=("--group", "test"))
+        python.test_lowest(cfg)
+        assert list(recorder.find("pytest").kwargs["uv_args"])[-2:] == ["--group", "test"]
+
+    def test_selects_the_suite_the_way_test_does(self, cfg: Config, recorder: Recorder) -> None:
+        """One argument builder, so the two gates cannot disagree about what the suite is.
+
+        Asserted as a subset of what ``test`` passes rather than against the builder itself:
+        that says both things at once -- every selection flag is shared, and this gate adds
+        none of its own.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.test(cfg)
+        from_test = set(recorder.find("pytest").flags)
+        recorder.calls.clear()
+        python.test_lowest(cfg)
+        flags = recorder.find("pytest").flags
+        assert set(flags) <= from_test
+        assert "auto" in flags
+
+    def test_measures_no_coverage(self, cfg: Config, recorder: Recorder) -> None:
+        """The subject is whether the suite runs at the floors, not what it covers.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        python.test_lowest(cfg)
+        assert not [f for f in recorder.find("pytest").flags if f.startswith("--cov")]
+
+    def test_every_injected_package_carries_a_floor(self) -> None:
+        """A bare name in :data:`PYTEST_WITHS` resolves to the oldest release on PyPI.
+
+        The injected packages are direct requirements too, so ``lowest-direct`` applies to
+        them: an unpinned ``pytest`` here resolves to 2.0.0, whose sdist does not build, and
+        the gate fails on its own instrumentation without reaching a single floor. Asserted
+        as the *shape* of every entry rather than as the six versions -- moving a floor is a
+        decision, while a seventh package arriving without one is the mistake this catches.
+        """
+        assert all(">=" in w or "==" in w for w in python.PYTEST_WITHS)
+
+    def test_skips_a_repository_with_no_tests(self, cfg: Config, recorder: Recorder) -> None:
+        """No test files is the same skip ``test`` reports, not a floors failure.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        from rhiza_task import runner
+
+        shutil.rmtree(cfg.path("tests_folder"))
+        state = runner.run(["test-lowest"], cfg)
+        assert state.status_of("test-lowest") is runner.Status.SKIPPED
+        assert "pytest" not in recorder.tools()
+
+    def test_arrives_through_install_so_the_setup_hook_runs(self, cfg: Config, recorder: Recorder) -> None:
+        """#169 itself: the gate that bypassed the graph bypassed ``local-setup.sh`` with it.
+
+        Args:
+            cfg: The resolved config.
+            recorder: The uv recorder.
+        """
+        from rhiza_task import runner
+
+        state = runner.run(["test-lowest"], cfg)
+        assert state.status_of("setup") is runner.Status.OK
+        assert state.status_of("install") is runner.Status.OK
+
+
 class TestTypecheck:
     """python.mk's ``typecheck``, including the ty/mypy asymmetry."""
 

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -109,6 +109,39 @@ def test_uv_run_can_pin_the_interpreter(spy: list[dict[str, object]], tmp_path: 
     assert spy[0]["argv"] == ["/fake/uv", "run", "--python", "3.12", "--no-project", "python", "sync.py"]
 
 
+def test_uv_run_places_uv_s_own_flags_before_the_injections(spy: list[dict[str, object]], tmp_path: Path) -> None:
+    """``uv_args`` reach ``uv run`` itself, ahead of every ``--with`` and the tool.
+
+    Position is the whole of the contract: ``--resolution`` after the tool name would be
+    pytest's argument rather than uv's, and pytest would reject it. ``test-lowest`` is the
+    caller, and it needs the resolver mode and the environment it applies to in one place.
+
+    Args:
+        spy: The subprocess spy.
+        tmp_path: Working directory.
+    """
+    uv_module.uv_run(
+        "pytest",
+        "-n",
+        "auto",
+        cwd=tmp_path,
+        withs=("pytest>=8.0.0",),
+        uv_args=("--isolated", "--resolution", "lowest-direct"),
+    )
+    assert spy[0]["argv"] == [
+        "/fake/uv",
+        "run",
+        "--isolated",
+        "--resolution",
+        "lowest-direct",
+        "--with",
+        "pytest>=8.0.0",
+        "pytest",
+        "-n",
+        "auto",
+    ]
+
+
 def test_uvx_passes_the_interpreter_and_extras(spy: list[dict[str, object]], tmp_path: Path) -> None:
     """``-p`` and ``--with`` both land before the tool spec.
 


### PR DESCRIPTION
Fixes the two open issues. Two commits, one per issue, each carrying its own `Closes` line.

## #169 — `test-lowest`

No task ran the suite under `--resolution lowest-direct`, so rhiza's `lowest-deps` job called plain `uv` — and a caller outside the task graph is a caller outside `install`, where the `local-setup.sh` hook is anchored. A repository whose native dependency comes from that hook got a green `test` and a red floors job on identical code, reporting a missing binary as a resolution problem.

`test-lowest` needs `install` like every other Python gate, and shares `_pytest_args`, `PYTEST_WITHS` and `uv_sync_args` rather than restating them — the job it replaces restated all three by hand and had already drifted from `_pytest_args` by one flag.

Two decisions worth reviewing:

- **`--isolated`.** Asking uv for a different resolution mode makes it discard the lock file, and without this flag it re-resolves the *project* environment in place: `.venv` and `uv.lock` are left downgraded once the gate finishes. Invisible on a runner; on a developer's machine it is a gate that rewrites a tracked file. Verified both ways — with `--isolated`, `uv.lock` is untouched.
- **`PYTEST_WITHS` grows a floor per package.** The injected packages are direct requirements too, so lowest-direct applies to them: a bare `pytest` resolves to `pytest 2.0.0`, whose sdist does not build, and the gate fails on its own instrumentation without reaching a single floor. The floors change nothing under the default resolution.

`uv_run` gains one parameter, `uv_args`, for flags belonging to `uv run` itself; `test-lowest` is its only caller.

**Where it now runs:** this repo's own `lowest-deps` job calls the task (its `uv pip list` diagnostic is gone, and the comment says why), and `python-layer` runs it against the scratch project on Linux and Windows — which is where the injected floors are read back, since that fixture declares none of its own.

Run for real against this repository before pushing: 457 passed, resolved on Python 3.11 with typer at its floor, and `git status` clean afterwards.

## #170 — the checkers are provisioned at a version

`typecheck` passed the bare name to `uv run --with`, so it ran whatever was newest at the moment it ran. For a 0.0.x checker that is the whole verdict: the reporter saw one warning locally, where `--with ty` reused the ty their lock file supplied, and twenty-four errors on a runner that had none — same commit.

`ty_version` (`==0.0.78`, today's latest, so this repo's own gate is unchanged) and `mypy_version` (empty, mypy being post-1.0) are settings in the shape `zensical_version` already uses. That covers both fixes the issue offered: pinned by default, movable without forking the task, and empty to go back to newest.

`--with ty==<pin>` overlays a project's own ty cleanly — checked against a project pinning a different version — so a consumer whose lock supplied an older ty now agrees with CI, and can set the setting to keep their green while they work through the diagnostics.

## Semver

Both are `feat:`, and deliberately: each makes a gate reject input it previously accepted, which per `CLAUDE.md` needs at least a minor. The release wants an `⚠️ Upgrade note` naming the ty pin, since a consumer relying on a locally-supplied older ty will see new diagnostics.

## Gates

`all`, `docs-examples`, `complexity`, `test-pyproject`, the accumulation ceiling and `fmt` (prek, including actionlint and markdownlint) all green locally; coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)