### PR TITLE
feat(config): add a deploy_pages setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ $(CURDIR))` cannot be spelled as a dataclass default, and keeping it empty keeps
 |---|---|---|
 | `uv_sync_args` | `("--all-extras", "--all-groups")` | what `install` passes to `uv sync` |
 | `ci_os_matrix` | `("ubuntu-latest",)` | feeds `ci-os-matrix` |
+| `deploy_pages` | `true` | whether rhiza's reusable book workflow publishes to GitHub Pages |
 | `pytest_rhiza` | pinned to a tag | the `rhiza-test` provider — a gate that moves under you is not a gate |
 
 **Empty means "omit `--with` entirely."** The pin is right for a consumer, and wrong for the
@@ -257,6 +258,21 @@ pytest-rhiza = ""
 
 TOML only, for the same reason as `mkdocs-extra-packages = []` above: `RHIZA_PYTEST_RHIZA=`
 reads as unset, and only TOML tells an empty string from an absent key.
+
+**`deploy_pages` is read by a workflow, not by a task**, which `ci_os_matrix` above already
+is. It exists because the choice had nowhere else to live. rhiza's reusable `rhiza_book.yml`
+takes a `deploy-pages` input, so the only place to spell it was the caller — and for a rhiza
+consumer the caller is the `github-book` bundle's workflow stub, which is template-owned: an
+edit there survives review and merge and is then overwritten by the next sync. Set it here
+instead and the stub stays managed:
+
+```toml
+[tool.rhiza-task]
+deploy-pages = false
+```
+
+That is the artifact-only mode rhiza's book guide describes — the generic `book` artifact is
+still uploaded, and a consumer-owned job deploys it wherever it likes.
 
 `pytest-rhiza = "."` looks like the shorthand and is a trap. `uv run --with .` resolves to a
 **cached built copy** that is not rebuilt on edit, so a broken check goes uncaught while the

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -292,6 +292,21 @@ class Config:
     uv_sync_args: tuple[str, ...] = ("--all-extras", "--all-groups")
     ci_os_matrix: tuple[str, ...] = DEFAULT_CI_OS_MATRIX
 
+    # Whether rhiza's reusable book workflow publishes to GitHub Pages. No task here reads
+    # it -- `ci_os_matrix` already had that shape, and for the same reason: a workflow needs
+    # a *repo-owned* answer, and this is the only config surface every consumer has.
+    #
+    # The alternative was the one it replaces. `rhiza_book.yml` takes a `deploy-pages`
+    # input, so the choice could only be spelled in the caller -- which for a rhiza consumer
+    # is the `github-book` bundle's workflow stub, a template-owned file. Editing it works,
+    # is reviewed, is merged, and is overwritten by the next sync; rhiza-hooks'
+    # `check-managed-files` now refuses the commit outright. So the toggle existed and had
+    # nowhere to live short of excluding the file from management.
+    #
+    # Defaults true, which is what the input already defaulted to: a repo that says nothing
+    # deploys exactly as before.
+    deploy_pages: bool = True
+
     # Pinned to a tag rather than a branch: a gate that moves under you is not a gate.
     #
     # Set it **empty** and `rhiza-test` passes no `--with` at all, resolving pytest-rhiza

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -571,3 +571,34 @@ def test_a_settings_table_that_is_not_a_table_is_ignored(tmp_path: Path) -> None
     cfg = Config.load(root=tmp_path)
     assert cfg.coverage_fail_under == 90
     assert cfg.source_folder == "src"
+
+
+def test_deploy_pages_defaults_on_and_is_settable_from_every_layer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``deploy_pages`` defaults true and turns off from TOML, the env file or the environment.
+
+    All three spellings matter for this one. TOML is the documented home, because the whole
+    point of the setting is to be *repo-owned* -- the alternative was editing the
+    template-owned ``github-book`` workflow stub, which the next sync overwrites. The other
+    two matter because a reusable workflow reads the value through the environment, which is
+    how a caller keeps an explicit ``deploy-pages: false`` input winning over the file.
+
+    Args:
+        tmp_path: The repository root.
+        monkeypatch: Used to export ``RHIZA_DEPLOY_PAGES``.
+    """
+    assert Config.load(root=tmp_path).deploy_pages is True
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "d"\nversion = "0"\n\n[tool.rhiza-task]\ndeploy-pages = false\n'
+    )
+    assert Config.load(root=tmp_path).deploy_pages is False
+
+    (tmp_path / "pyproject.toml").unlink()
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / ".env").write_text("DEPLOY_PAGES=false\n")
+    assert Config.load(root=tmp_path).deploy_pages is False
+
+    monkeypatch.setenv("RHIZA_DEPLOY_PAGES", "false")
+    assert Config.load(root=tmp_path).deploy_pages is False


### PR DESCRIPTION
## Why

`jebel-quant/rhiza`'s reusable `rhiza_book.yml` takes a `deploy-pages` input, so the only place to spell the choice is the caller. For a rhiza consumer the caller is the `github-book` bundle's workflow stub — a **template-owned** file. An edit there survives review and merge and is then overwritten by the next sync, and rhiza-hooks' `check-managed-files` refuses the commit outright. So the toggle existed and had nowhere to live short of excluding the file from management.

This adds the repo-owned surface, so the stub stays managed:

```toml
[tool.rhiza-task]
deploy-pages = false
```

## No task reads it, deliberately

`ci_os_matrix` already has that shape, and for the same reason: a reusable workflow needs a repo-owned answer, and `[tool.rhiza-task]` / `rhiza.toml` is the only config surface every consumer has — a Rust crate has `Cargo.toml`, a Go module has no manifest at all, and `_from_rhiza_toml` covers both. `rhiza_book.yml` will resolve it with `uvx rhiza-task print deploy-pages`, the way `rhiza_ci.yml` resolves the OS matrix.

## Behaviour

Defaults `true`, matching the input's own default, so a repo that says nothing deploys exactly as before. `_coerce` already parses `true`/`false`, and TOML types it natively, so all four spellings work with no reader changes — asserted across TOML, `.rhiza/.env` and the environment, the last because the workflow keeps an explicit input override winning over the file by exporting `RHIZA_DEPLOY_PAGES`.

Verified against the built CLI rather than only the dataclass: `print deploy-pages` answers `True` by default, `False` from a `pyproject.toml` table, and `True` again under `RHIZA_DEPLOY_PAGES=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)