### PR TITLE
feat: derive the version from the git tag (#160)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "rhiza-task"
-version = "1.6.0"
+# Derived from the git tag by hatch-vcs, not written here. See [tool.hatch.version] below.
+dynamic = ["version"]
 description = "The rhiza developer tasks as a pinned CLI: one set of task names across Python, Rust and Go, replacing a synced make layer"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -84,19 +85,47 @@ Issues = "https://github.com/jebel-quant/rhiza-task/issues"
 test = ["pytest>=8.0", "pytest-cov>=6.0", "hypothesis>=6.98"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rhiza_task"]
 
+# The version is the tag, and nothing else records it. This is what makes a release one
+# step instead of the eleven the old flow took (Jebel-Quant/rhiza-task#160): there is no
+# number to write into pyproject.toml, into __init__.py and into uv.lock, and therefore no
+# release that can ship with two of the three updated -- v1.0.0 shipped exactly that way,
+# with uv.lock left behind, and every gate failed because `uv lock --check` is the first
+# thing `install` runs.
+#
+# `raw-options.version_scheme = "no-guess-dev"` keeps an untagged commit's version at the
+# last tag plus `.post1.devN` rather than guessing the *next* release number, which the
+# default `guess-next-dev` does. Guessing is worse than useless here: a development build
+# would claim to be 1.7.0.dev4 while 1.7.0 is unreleased, and `uvx rhiza-task@1.7.0` would
+# then resolve to something else entirely.
+#
+# One thing this cannot do for itself: a clone with no tags derives 0.1.dev1+g<sha>, so any
+# job that builds a distribution needs the full history. `fetch-depth: 0` in
+# rhiza_release.yml, asserted by tests/test_version_source.py.
+[tool.hatch.version]
+source = "vcs"
+raw-options = { version_scheme = "no-guess-dev" }
+
+# bump-my-version no longer writes this project's version -- hatch-vcs derives it from the
+# tag. What is left is the three entries below, which rewrite the `rhiza-task@X.Y.Z` pins in
+# the README, the docs and the paper. Those are *documentation* pins: they have to be right
+# in the commit the tag names, so they cannot be derived from a tag that does not exist yet.
+# That is the whole reason a release still commits something before it tags.
+#
+# With no `[project].version` and no `current_version` here, bump-my-version resolves the
+# current version from the newest reachable tag. That used to be a fallback worth warning
+# about (jebel-quant/rhiza#1453, where it meant a release got cut against `git describe`
+# instead of the project's version); with the version defined as the tag it is now simply
+# the right answer, and the same answer hatch-vcs gives.
 [tool.bumpversion]
 allow_dirty = false
 commit = false
 tag = false
-
-[[tool.bumpversion.files]]
-filename = "src/rhiza_task/__init__.py"
 
 # The README pins the CLI in its usage examples. Without this entry those examples drift:
 # they still read `rhiza-task@0.1.0` two releases after 0.1.0.
@@ -146,19 +175,6 @@ replace = "rhiza-task@{new_version}"
 filename = "docs/paper/paper.tex"
 search = "rhiza-task@{current_version}"
 replace = "rhiza-task@{new_version}"
-
-# The lockfile records this package's own version, and `uv lock --check` is the first
-# command `install` runs -- so a bump that leaves uv.lock behind fails every gate that
-# names `install` as a prerequisite, which is all of them. v1.0.0 shipped that way: the
-# release commit touched pyproject.toml, __init__.py and CHANGELOG.md only. The search is
-# anchored on the package name because a bare `version = "..."` matches every one of the
-# seventeen locked packages.
-[[tool.bumpversion.files]]
-filename = "uv.lock"
-search = """name = "rhiza-task"
-version = "{current_version}\""""
-replace = """name = "rhiza-task"
-version = "{new_version}\""""
 
 # `relative_files` makes coverage record paths relative to the project rather than absolute.
 # Without it every artefact carries the build machine's layout: `coverage.xml`'s Cobertura

--- a/src/rhiza_task/__init__.py
+++ b/src/rhiza_task/__init__.py
@@ -19,8 +19,23 @@ Layout:
 * :mod:`rhiza_task.tasks` -- the task modules themselves, loaded by entry point.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _installed_version
+
 __all__ = ["__version__"]
 
-# Kept in step with [project].version by bump-my-version, which needs a [[files]] entry
-# for this file but not for pyproject.toml itself.
-__version__ = "1.6.0"
+# Read from the installed distribution's metadata rather than written here. hatch-vcs
+# derives the version from the git tag at build time, so this file has no number to keep
+# in step and bump-my-version has no [[files]] entry for it -- which is the point: a
+# version written in two places is a version that can disagree with itself, and the release
+# that shipped 1.0.0 with a stale uv.lock is what that looks like.
+#
+# The fallback is for a source tree that was never installed -- someone running out of a
+# clone with `python -c "import rhiza_task"` and no `uv sync`. Every real invocation is
+# `uvx rhiza-task@X.Y.Z`, which installs the distribution, so metadata is present. A
+# literal here would be a second source of truth for exactly the case that does not
+# matter, so it says what it knows instead.
+try:
+    __version__ = _installed_version("rhiza-task")
+except PackageNotFoundError:  # pragma: no cover - requires an uninstalled source tree
+    __version__ = "0+unknown"

--- a/src/rhiza_task/config.py
+++ b/src/rhiza_task/config.py
@@ -301,7 +301,7 @@ class Config:
     # unset, and only TOML tells an empty string from an absent key. See
     # `tasks/quality.py`'s `_provider`, which also records why `"."` is not the shorthand it
     # looks like.
-    pytest_rhiza: str = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.2.0"
+    pytest_rhiza: str = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@v0.6.0"
 
     # Both are empty by default and filled in `_validate_layers`, because both depend on
     # the repository rather than on a constant: the layers come from the manifests present,

--- a/tests/test_version_source.py
+++ b/tests/test_version_source.py
@@ -1,0 +1,133 @@
+"""The version is the git tag, and these are the four ways that could quietly stop being true.
+
+Adopting hatch-vcs (#160) removed the version from every file that used to hold a copy of
+it: ``[project].version``, ``__version__`` and ``uv.lock``. That is what makes a release
+one step -- there is no number to write, so there is no release that can ship with two of
+the three updated. v1.0.0 shipped exactly that way, with ``uv.lock`` left behind, and every
+gate then failed because ``uv lock --check`` is the first thing ``install`` runs.
+
+The failure mode a *derived* version has instead is quieter than the one it replaces, which
+is why this module exists rather than trusting the config to stay put. setuptools-scm and
+hatch-vcs both fall back rather than fail: a clone with no tags derives
+``0.1.dev1+g<sha>``, so a distribution built from a shallow checkout is published at a
+version nobody asked for -- green build, wrong artifact on PyPI, and no error anywhere.
+That is the same silent-green shape rhiza keeps a record of (jebel-quant/rhiza#1505, #1511,
+#1516, #1535), reached here through a checkout depth.
+
+Security Notes:
+- S101 (assert usage): Asserts are the mechanism pytest reports failures through.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject() -> dict:
+    """Return the parsed manifest.
+
+    Returns:
+        pyproject.toml as a dict.
+    """
+    with (_ROOT / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_the_version_is_declared_dynamic_and_written_nowhere() -> None:
+    """``[project]`` must derive its version rather than carry one.
+
+    Both halves: PEP 621 forbids declaring it both ways, and a written version would be a
+    second source of truth that hatch-vcs silently overrides at build time -- so the number
+    a reader sees in the manifest would not be the number that ships.
+    """
+    project = _pyproject()["project"]
+    assert "version" in (project.get("dynamic") or ()), (
+        "[project] no longer lists `version` in `dynamic`, so hatch-vcs is not supplying it "
+        "and the build has no version source."
+    )
+    assert "version" not in project, (
+        '[project] writes a `version` alongside `dynamic = ["version"]`. PEP 621 forbids '
+        "that, and the written one is decoration hatch-vcs overrides -- a number in the "
+        "manifest that is not the number that ships."
+    )
+
+
+def test_hatch_takes_the_version_from_the_vcs_without_guessing_forward() -> None:
+    """The source must be the VCS, and an untagged commit must not claim the next release.
+
+    ``version_scheme`` defaults to ``guess-next-dev``, which reports an untagged commit as
+    ``1.7.0.dev4`` while 1.7.0 is unreleased -- a development build claiming a version that
+    ``uvx rhiza-task@1.7.0`` will later resolve to something else entirely.
+    """
+    hatch_version = _pyproject()["tool"]["hatch"]["version"]
+    assert hatch_version.get("source") == "vcs", (
+        "[tool.hatch.version].source is not `vcs`, so the version no longer comes from the tag"
+    )
+    raw = hatch_version.get("raw-options") or {}
+    assert raw.get("version_scheme") == "no-guess-dev", (
+        "the version scheme is not `no-guess-dev`, so an untagged commit reports itself as the "
+        "next unreleased version rather than as a post-release of the last real one."
+    )
+
+
+def test_no_bumpversion_entry_writes_a_version_number_again() -> None:
+    """The remaining entries must rewrite documentation pins, and nothing else.
+
+    ``src/rhiza_task/__init__.py`` and ``uv.lock`` each had an entry, and each entry existed
+    to keep a *copy* of the version in step. Re-adding either would reintroduce the copy --
+    and would fail, since bump-my-version errors on a file that does not contain the version
+    it searched for.
+    """
+    entries = _pyproject()["tool"]["bumpversion"].get("files") or []
+    targets = [entry.get("filename") or entry.get("glob") or "" for entry in entries]
+    for forbidden in ("src/rhiza_task/__init__.py", "uv.lock"):
+        assert forbidden not in targets, (
+            f"a [[tool.bumpversion.files]] entry targets {forbidden}, which holds no version "
+            f"any more -- hatch-vcs derives it from the tag. The entries here are for the "
+            f"`rhiza-task@X.Y.Z` documentation pins only."
+        )
+    assert targets, "every bumpversion entry is gone, so the docs pins are no longer rewritten on release"
+
+
+def test_the_dunder_version_is_read_from_the_installed_metadata() -> None:
+    """``__init__.py`` must not carry a literal version again.
+
+    Asserted on the source rather than on the value: the value is correct either way in an
+    installed tree, so a re-added literal would agree with the tag on the day it was written
+    and drift silently afterwards -- which is the whole defect.
+    """
+    source = (_ROOT / "src" / "rhiza_task" / "__init__.py").read_text(encoding="utf-8")
+    literal = re.search(r'^__version__\s*=\s*["\']', source, re.MULTILINE)
+    assert literal is None, (
+        "__init__.py assigns __version__ a string literal. It must read the installed "
+        "distribution's metadata, which hatch-vcs stamped from the tag; a literal is a "
+        "second copy that agrees with the tag only on the day it is written."
+    )
+    assert "importlib.metadata" in source, "__init__.py no longer reads its version from the package metadata"
+
+
+def test_every_release_checkout_fetches_the_full_history() -> None:
+    """A shallow checkout makes hatch-vcs derive a wrong version, and publish it.
+
+    This is the one coupling adopting hatch-vcs introduced that nothing else here would
+    notice. The workflow is template-owned, so a future sync is what would drop the option,
+    and the symptom is on PyPI rather than in the run: with no tags reachable the version
+    resolves to ``0.1.dev1+g<sha>`` and the build succeeds.
+
+    Asserted for every checkout in the file rather than only the build job, because the
+    version is derived wherever the package is built or installed -- and the next job added
+    to this workflow needs it too.
+    """
+    text = (_ROOT / ".github" / "workflows" / "rhiza_release.yml").read_text(encoding="utf-8")
+    blocks = text.split("uses: actions/checkout@")[1:]
+    assert blocks, "rhiza_release.yml checks out nothing, so this assertion is measuring an empty list"
+    for index, block in enumerate(blocks, start=1):
+        assert "fetch-depth: 0" in block[:400], (
+            f"checkout #{index} in rhiza_release.yml does not pass `fetch-depth: 0`. hatch-vcs "
+            f"derives the version from the tags in the clone, so a shallow one publishes "
+            f"`0.1.dev1+g<sha>` and reports success."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,6 @@ wheels = [
 
 [[package]]
 name = "rhiza-task"
-version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
Closes #160.

## The problem

The version was written in three places — `[project].version`, `src/rhiza_task/__init__.py` and `uv.lock` — and a release had to update all three before it tagged. That is most of what made `/rhiza:release` eleven steps, and it is the shape of a bug this project has already shipped: **v1.0.0 went out with `uv.lock` left behind**, and every gate then failed, because `uv lock --check` is the first thing `install` runs.

## The change

hatch-vcs derives it from the tag:

- `[project]` declares `dynamic = ["version"]`
- `__version__` reads the installed distribution's metadata
- `uv` stops recording a version for the root package at all (confirmed: the `uv.lock` entry loses its `version =` line)

So there is no copy left to disagree with the tag, and no release that can update two of three. Two `[[tool.bumpversion.files]]` entries went with them.

`raw-options.version_scheme = "no-guess-dev"` rather than the default `guess-next-dev`: an untagged commit reports `1.6.0.post1.dev0+g…` rather than claiming `1.7.0` — a version that is unreleased and that `uvx rhiza-task@1.7.0` will later resolve to something else entirely.

## Why one step is the ceiling and not the target

**Three bumpversion entries remain, and no amount of tag-derived versioning removes them.** They rewrite the `rhiza-task@X.Y.Z` pins in `README.md`, `docs/*.md` and `docs/paper/paper.tex`. Those are *documentation* pins: they have to be correct in the commit the tag names, so they cannot be derived from a tag that does not exist yet. Something still has to be committed through a PR before the tag — which `main`'s required-`pull_request` rule would force anyway.

bump-my-version now resolves the current version from the newest reachable tag, since neither `[project].version` nor a `current_version` exists. That used to be a fallback worth warning about (jebel-quant/rhiza#1453, where it meant a release got cut against `git describe` instead of the project's version); with the version *defined* as the tag it is the right answer, and the same answer hatch-vcs gives.

## The new silent failure, and its guard

A derived version fails more quietly than the copies it replaces. A clone with no tags derives `0.1.dev1+g<sha>`, so a distribution built from a shallow checkout is **published at a version nobody asked for** — green build, wrong artifact, no error anywhere. Same shape as jebel-quant/rhiza#1505/#1511/#1516/#1535, reached through a checkout depth.

Every checkout in `rhiza_release.yml` already passes `fetch-depth: 0`. `tests/test_version_source.py` pins that for *every* checkout in the file rather than just the build job — the workflow is template-owned, so a sync is what would drop it — along with the three ways the config could quietly revert: a re-written `version`, a bumpversion entry pointing back at `__init__.py` or `uv.lock`, and a `__version__` literal.

## Verified, not reasoned about

- A build on a `v1.7.0` tag produces `rhiza_task-1.7.0-py3-none-any.whl`.
- `bump-my-version bump minor --dry-run` rewrites the three docs pins and makes **no change** to `pyproject.toml`.
- `rhiza-test` passes against pytest-rhiza with Jebel-Quant/pytest-rhiza#96: 29 passed, 6 skipped — exactly the six assertions about a written version.
- 467 tests pass; `test_rhiza_packaging` skips on the dynamic version, which it already knew how to do.

## Blocked on one release

The `pytest_rhiza` pin is `v0.2.0`, whose `test_pyproject` requires a written `[project].version` — `rhiza-test` fails three assertions on it. Jebel-Quant/pytest-rhiza#96 is merged to `main` but unreleased. Bumping this pin to the release that carries it is verified safe (that is the run above), so this PR needs that tag and a one-line pin change before it can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)