### PR TITLE
fix: verify the built wheel against the tag, not the dynamic version field

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -257,24 +257,6 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
 
-      - name: Verify version matches tag
-        if: hashFiles('pyproject.toml') != ''
-        run: |
-          TAG_VERSION="${{ needs.tag.outputs.tag }}"
-          TAG_VERSION=${TAG_VERSION#v}
-          PROJECT_VERSION=$(uv version --short)
-
-          # Normalize tag version to PEP 440 format for comparison.
-          # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
-          # returns PEP 440 normalized format (e.g., 0.11.1b1).
-          NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
-
-          if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
-            echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
-            exit 1
-          fi
-          echo "Version verified: $PROJECT_VERSION matches tag (normalized: $NORMALIZED_TAG)"
-
       - name: Detect buildable Python package
         id: buildable
         run: |
@@ -289,6 +271,45 @@ jobs:
         run: |
           printf "[INFO] Building package...\n"
           uv build
+
+      # This runs *after* the build, and reads the version out of the wheel rather than
+      # out of pyproject.toml. It used to run before it, on `uv version --short`, which
+      # cannot work on a project whose version is dynamic: since #160 this one derives
+      # its version from the git tag via hatch-vcs and `[project]` carries
+      # `dynamic = ["version"]`, so that command exits 2 with "We cannot get or set
+      # dynamic project versions in: pyproject.toml" and the whole release fails at the
+      # first step. v1.7.0 was tagged before this was noticed -- and nothing here could
+      # have caught it earlier, because every job in this file is green until a release
+      # actually runs.
+      #
+      # Checking the artifact is also the stronger check, and would be worth keeping even
+      # with a static version: it verifies the version that will actually be uploaded to
+      # PyPI, which for a dynamic project is the one thing worth verifying -- that the
+      # build backend resolved the tag it was handed. A static `[project] version` field
+      # agreeing with the tag says nothing about what the backend then produced.
+      - name: Verify version matches tag
+        if: steps.buildable.outputs.buildable == 'true'
+        run: |
+          TAG_VERSION="${{ needs.tag.outputs.tag }}"
+          TAG_VERSION=${TAG_VERSION#v}
+
+          # Normalize tag version to PEP 440 format for comparison.
+          # Tags use semver format (e.g., 0.11.1-beta.1) while a built wheel carries the
+          # PEP 440 normalized format (e.g., 0.11.1b1).
+          NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
+
+          # `{name}-{version}-{python}-{abi}-{platform}.whl`, and PEP 427 escapes any
+          # hyphen in the distribution name to an underscore, so field 2 is the version.
+          # A glob rather than `ls` so shellcheck's SC2012 is satisfied and a surprising
+          # filename cannot be word-split into a passing comparison.
+          WHEELS=(dist/*.whl)
+          BUILT_VERSION=$(basename "${WHEELS[0]}" | cut -d- -f2)
+
+          if [[ "$BUILT_VERSION" != "$NORMALIZED_TAG" ]]; then
+            echo "::error::Version mismatch: built '$BUILT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
+            exit 1
+          fi
+          echo "Version verified: $BUILT_VERSION matches tag (normalized: $NORMALIZED_TAG)"
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''


### PR DESCRIPTION
The v1.7.0 release run [failed at the first step of `Build`](https://github.com/Jebel-Quant/rhiza-task/actions/runs/34093051711). Nothing was published — `Draft GitHub Release`, `Publish to PyPI` and `Finalise Release` all skipped.

## Cause

`Verify version matches tag` ran `uv version --short`, which cannot work on this project since #160 derived the version from the git tag. `[project]` carries `dynamic = ["version"]`, so:

```
error: We cannot get or set dynamic project versions in: pyproject.toml
##[error]Process completed with exit code 2.
```

`uv version --short` is the only static-version read anywhere in `.github/` — everything downstream works off `dist/` — so this is the whole of the breakage.

**Nothing here could have caught it earlier**, which is the point worth keeping: every job in this file is green until a release actually runs. That is exactly the hazard `rhiza_release.yml`'s own header describes for the trusted-publisher filename, and it applies to the job bodies too. #160 changed how the version is declared and passed every gate in the repo.

## Fix

The step now runs **after** the build and reads the version out of the wheel filename:

```bash
WHEELS=(dist/*.whl)
BUILT_VERSION=$(basename "${WHEELS[0]}" | cut -d- -f2)
```

A glob rather than `ls`, so shellcheck's SC2012 is satisfied and a surprising filename cannot be word-split into a passing comparison. The PEP 440 tag normalization is unchanged.

This is also the **stronger** check, and worth keeping even with a static version: it verifies the version that will actually be uploaded to PyPI, which for a dynamic project is the one thing worth verifying — that the build backend resolved the tag it was handed. A `[project] version` field agreeing with the tag says nothing about what the backend then produced.

## Verification

Built from a clean checkout of the `v1.7.0` tag:

```
wheel=rhiza_task-1.7.0-py3-none-any.whl
built=1.7.0  normalized_tag=1.7.0   -> step passes
built=1.7.0  normalized_tag=1.8.0   -> step rejects (exit 1)
```

So it accepts the real tag and still fails on a mismatch. `actionlint` clean; `rhiza-task fmt` green (16 hooks).

## This does not by itself publish v1.7.0

Every job in this workflow checks out the **triggering ref** — there is no `ref:` override — and the triggers are `push: tags: v*` and `workflow_call`, with no `workflow_dispatch`. So a re-run of the failed run, or any replay for `v1.7.0`, uses the workflow file **at the tagged commit**, which does not contain this fix.

Publishing 1.7.0 therefore needs a separate decision (move the tag onto a commit carrying this fix, or burn 1.7.0 and release 1.7.1); it is being made separately and is not part of this PR.

A follow-up worth considering on its own: `workflow_dispatch` plus an explicit `ref:` on each checkout, so a release that fails *after* tagging can be retried at all. Right now it cannot be.
